### PR TITLE
Fixing so that we get Handlebars included in the package

### DIFF
--- a/Source/DotNET/Tools/Roslyn/Roslyn.csproj
+++ b/Source/DotNET/Tools/Roslyn/Roslyn.csproj
@@ -27,15 +27,9 @@
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
 
-    <PropertyGroup>
-        <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
-    </PropertyGroup>
-
-    <Target Name="GetDependencyTargetPaths">
-        <ItemGroup>
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGHandlebars_Net)\lib\netstandard2.0\Handlebars.dll" IncludeRuntimeDependency="false" />
-        </ItemGroup>
-    </Target>
-
+    <ItemGroup>
+        <Content Include="$(PKGHandlebars_Net)\lib\netstandard2.0\Handlebars.dll" PackagePath="analyzers/dotnet/cs" />
+        <Content Include="$(PKGHandlebars_Net)\lib\netstandard2.0\Handlebars.dll" PackagePath="lib/netstandard2.0" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Fixed

- Fixing Roslyn package to include Handlebars in its output.
