### PR TITLE
Fix namespaces for Metrics code generator

### DIFF
--- a/Source/DotNET/Tools/Roslyn/Metrics/MetricTemplateData.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/MetricTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Roslyn.Extensions.Metrics;
+namespace Cratis.Applications.Roslyn.Extensions.Metrics;
 
 /// <summary>
 /// Represents the template for counters.

--- a/Source/DotNET/Tools/Roslyn/Metrics/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/MetricsSourceGenerator.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using Cratis.Applications.Roslyn.Extensions.Templates;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Roslyn.Extensions.Templates;
 
-namespace Roslyn.Extensions.Metrics;
+namespace Cratis.Applications.Roslyn.Extensions.Metrics;
 
 /// <summary>
 /// Represents the source generator for metrics.

--- a/Source/DotNET/Tools/Roslyn/Metrics/MetricsSyntaxReceiver.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/MetricsSyntaxReceiver.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Roslyn.Extensions.Metrics;
+namespace Cratis.Applications.Roslyn.Extensions.Metrics;
 
 /// <summary>
 /// Represents the syntax receiver for metrics.

--- a/Source/DotNET/Tools/Roslyn/Metrics/MetricsTemplateData.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/MetricsTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Roslyn.Extensions.Metrics;
+namespace Cratis.Applications.Roslyn.Extensions.Metrics;
 
 /// <summary>
 /// REpresents the template the for metrics.

--- a/Source/DotNET/Tools/Roslyn/Metrics/TagTemplateData.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/TagTemplateData.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Roslyn.Extensions.Metrics;
+namespace Cratis.Applications.Roslyn.Extensions.Metrics;
 
 /// <summary>
 /// Represents the template for counter tags.

--- a/Source/DotNET/Tools/Roslyn/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Tools/Roslyn/Templates/TemplateTypes.cs
@@ -3,7 +3,7 @@
 
 using HandlebarsDotNet;
 
-namespace Roslyn.Extensions.Templates;
+namespace Cratis.Applications.Roslyn.Extensions.Templates;
 
 /// <summary>
 /// Represents the template types.


### PR DESCRIPTION
### Fixed

- Namespaces for all files within the Roslyn generator was wrong
