### PR TITLE
Adding missing namespace

### DIFF
--- a/Source/DotNET/Tools/Roslyn/Metrics/MetricsSourceGenerator.cs
+++ b/Source/DotNET/Tools/Roslyn/Metrics/MetricsSourceGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using Cratis.Applications.Roslyn.Templates;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 


### PR DESCRIPTION
### Fixed

- Fixing build essentially. A missing using statement in on of the files in the Roslyn extension.
