### PR TITLE
Fixing reference when developing the ProxyGenerator

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <CratisProxyDevAssembly>$(MSBuildThisFileDirectory)../bin/$(Configuration)/net8.0/Cratis.Applications.ProxyGenerator.dll</CratisProxyDevAssembly>
+        <CratisProxyDevAssembly>$(MSBuildThisFileDirectory)../../ProxyGenerator/bin/$(Configuration)/net8.0/Cratis.Applications.ProxyGenerator.dll</CratisProxyDevAssembly>
         <CratisProxyPackedAssembly>$(MSBuildThisFileDirectory)../tasks/net8.0/Cratis.Applications.ProxyGenerator.dll</CratisProxyPackedAssembly>
 
         <CratisProxyGeneratorAssembly Condition="Exists($(CratisProxyPackedAssembly)) == true">$(CratisProxyPackedAssembly)</CratisProxyGeneratorAssembly>


### PR DESCRIPTION
### Fixed

- When doing development on the ProxyGenerator we typically use the sample(s) in the repository, this was broken after changing how we invoke the proxy generator. Fixing this so that local development of the ProxyGenerator is smooth.
