### PR TITLE
Latest Fundamentals and hooking up type discovery using extension method

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="5.2.5" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="5.2.7" />
     <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.9.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.9.5" />

--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -90,16 +90,13 @@ public static class HostBuilderExtensions
         builder.UseDefaultServiceProvider(_ => _.ValidateOnBuild = false);
 
         builder
-            .ConfigureServices(_ =>
-            {
-                _
-                .AddSingleton(Internals.Types)
+            .ConfigureServices(_ => _
+                .AddTypeDiscovery()
                 .AddSingleton<IDerivedTypes>(derivedTypes)
                 .AddIdentityProvider(Internals.Types)
                 .AddControllersFromProjectReferencedAssembles(Internals.Types, derivedTypes)
                 .AddBindingsByConvention()
-                .AddSelfBindings();
-            });
+                .AddSelfBindings());
 
         return builder;
     }


### PR DESCRIPTION
### Fixed

- Latest Fundamentals (5.2.7)
- Using the `AddTypeDiscovery()` extension method from Fundamentals to properly hook up all type discovery.
