### PR TITLE
Fix AcronymFriendlyCamelCaseElementNameConvention

### DIFF
--- a/Source/DotNET/MongoDB/AcronymFriendlyCamelCaseElementNameConvention.cs
+++ b/Source/DotNET/MongoDB/AcronymFriendlyCamelCaseElementNameConvention.cs
@@ -24,10 +24,7 @@ public class AcronymFriendlyCamelCaseElementNameConvention : ConventionBase, IMe
     /// <param name="memberMap">The member map.</param>
     public void Apply(BsonMemberMap memberMap)
     {
-        var name = memberMap.MemberName;
-        name = GetElementName(name);
-        memberMap.SetElementName(name);
+        var name = memberMap.ElementName;
+        memberMap.SetElementName(name.ToCamelCase());
     }
-
-    string GetElementName(string memberName) => memberName.ToCamelCase();
 }

--- a/Specifications/MongoDB/for_AcronymFriendlyCamelCaseElementNameConvention/when_applying_convention_to_all_class_map_members.cs
+++ b/Specifications/MongoDB/for_AcronymFriendlyCamelCaseElementNameConvention/when_applying_convention_to_all_class_map_members.cs
@@ -1,0 +1,32 @@
+using Cratis.Collections;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.MongoDB.for_AcronymFriendlyCamelCaseElementNameConvention;
+
+public class when_applying_convention : Specification
+{
+    class SomeType
+    {
+        public string SomeProperty { get; init; }
+        public string SomeOtherProperty { get; init; }
+    }
+
+    BsonClassMap<SomeType> class_map;
+    AcronymFriendlyCamelCaseElementNameConvention convention;
+
+    void Establish()
+    {
+        class_map = new BsonClassMap<SomeType>();
+        convention = new AcronymFriendlyCamelCaseElementNameConvention();
+        class_map.AutoMap();
+        class_map.MapMember(_ => _.SomeOtherProperty).SetElementName("SomeOtherPropertyName");
+    }
+
+    void Because() => class_map.DeclaredMemberMaps.ForEach(convention.Apply);
+
+    [Fact] void should_have_two_members() => class_map.DeclaredMemberMaps.Count().ShouldEqual(2);
+    [Fact] void should_convert_SomeProperty_to_camelCase() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someProperty")
+        .ShouldContainSingleItem();
+    [Fact] void should_convert_SomeOtherProperty_to_someOtherPropertyName() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someOtherPropertyName")
+        .ShouldContainSingleItem();
+}


### PR DESCRIPTION
## Summary

A bug in the `Cratis.Applications.MongoDB` `AcronymFriendlyCamelCaseElementNameConvention` did not properly convert the `BsonClassMap` element name to camelCase, which made it not respect class map registrations that changes the element name of a member.

### Fixed

- Correctly change the `BsonClassMap` `ElementName` to the camelCase version of the `ElementName`, not `MemberName`
