### PR TITLE
MobxOptions prop optional

### DIFF
--- a/Source/JavaScript/Applications.React.MVVM/MVVMContext.tsx
+++ b/Source/JavaScript/Applications.React.MVVM/MVVMContext.tsx
@@ -8,22 +8,20 @@ import { MobxOptions } from './MobxOptions';
 
 export interface MVVMProps {
     children?: JSX.Element | JSX.Element[];
-    mobx: MobxOptions | undefined
+    mobx?: MobxOptions;
 }
 
 export const MVVMContext = React.createContext({});
 
 export const MVVM = (props: MVVMProps) => {
-
-    const options: MobxOptions = { ...{ enforceActions: 'never' }, ...props.mobx || {} };
-
+    const options: MobxOptions = {
+        ...{ enforceActions: 'never' },
+        ...(props.mobx || {}),
+    };
+    debugger;
     configureMobx(options);
 
     Bindings.initialize();
 
-    return (
-        <MVVMContext.Provider value={{}}>
-            {props.children}
-        </MVVMContext.Provider >
-    );
+    return <MVVMContext.Provider value={{}}>{props.children}</MVVMContext.Provider>;
 };

--- a/Source/JavaScript/Applications.React.MVVM/MVVMContext.tsx
+++ b/Source/JavaScript/Applications.React.MVVM/MVVMContext.tsx
@@ -18,7 +18,7 @@ export const MVVM = (props: MVVMProps) => {
         ...{ enforceActions: 'never' },
         ...(props.mobx || {}),
     };
-    debugger;
+
     configureMobx(options);
 
     Bindings.initialize();


### PR DESCRIPTION
### Fixed

- Make MobxOptions prop optional in MVVM component to avoid getting errors when not specifying them.
