### PR TITLE
Feature/observable-sorting-paging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,6 @@
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.3" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
-    <PackageVersion Include="moq" Version="4.20.70" />
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.10.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>

--- a/Samples/eCommerce/Basic/API/Carts/Cart.cs
+++ b/Samples/eCommerce/Basic/API/Carts/Cart.cs
@@ -54,9 +54,9 @@ public class Cart(IGrainFactory grainFactory, ICartQueries cartQueries) : Contro
     /// </summary>
     /// <returns><see cref="ClientObservable{T}"/> for <see cref="Read.Carts.Cart"/>. </returns>
     [HttpGet("observe")]
-    public async Task<ISubject<Read.Carts.Cart>> ObserveCartForCurrentUser()
+    public ISubject<Read.Carts.Cart> ObserveCartForCurrentUser()
     {
         var cartId = (CartId)(User.Identity?.GetUserIdAsGuid() ?? Guid.Empty);
-        return await cartQueries.Observe(cartId);
+        return cartQueries.Observe(cartId);
     }
 }

--- a/Samples/eCommerce/Basic/API/Products/Catalog.cs
+++ b/Samples/eCommerce/Basic/API/Products/Catalog.cs
@@ -42,7 +42,7 @@ public class Catalog(IGrainFactory grainFactory, ICatalogQueries catalogQueries,
     /// </summary>
     /// <returns>Collection of products.</returns>
     [HttpGet("observe")]
-    public Task<ISubject<IEnumerable<Product>>> ObserveAllProducts() => catalogQueries.ObserveAll();
+    public ISubject<IEnumerable<Product>> ObserveAllProducts() => catalogQueries.ObserveAll();
 
     /// <summary>
     /// Generate some products.

--- a/Samples/eCommerce/Basic/API/Products/Catalog.cs
+++ b/Samples/eCommerce/Basic/API/Products/Catalog.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Subjects;
 using Cratis.Applications;
 using Domain.Products;
 using MongoDB.Driver;
@@ -36,6 +37,17 @@ public class Catalog(IGrainFactory grainFactory, ICatalogQueries catalogQueries,
     [HttpGet]
     public IQueryable<Product> AllProducts() => catalogQueries.All();
 
+    /// <summary>
+    /// Gets all the products in the catalog.
+    /// </summary>
+    /// <returns>Collection of products.</returns>
+    [HttpGet("observe")]
+    public Task<ISubject<IEnumerable<Product>>> ObserveAllProducts() => catalogQueries.ObserveAll();
+
+    /// <summary>
+    /// Generate some products.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
     [HttpGet("generate"), AspNetResult]
     public async Task Generate()
     {

--- a/Samples/eCommerce/Basic/Domain.Interfaces/Carts/ICart.cs
+++ b/Samples/eCommerce/Basic/Domain.Interfaces/Carts/ICart.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Concepts;
+using Concepts.Carts;
 
 namespace Domain.Carts;
 

--- a/Samples/eCommerce/Basic/Domain/Carts/Cart.cs
+++ b/Samples/eCommerce/Basic/Domain/Carts/Cart.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Concepts;
+using Cratis.Applications.Commands;
 using Read.Carts;
 
 namespace Domain.Carts;

--- a/Samples/eCommerce/Basic/Read/Carts/CartQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Carts/CartQueries.cs
@@ -16,5 +16,5 @@ public class CartQueries(IMongoCollection<Cart> collection) : ICartQueries
     public async Task<Cart> Get(CartId cartId) => await collection.FindByIdAsync(cartId) ?? new() { Id = cartId };
 
     /// <inheritdoc/>
-    public Task<ISubject<Cart>> Observe(CartId cartId) => collection.ObserveById(cartId);
+    public ISubject<Cart> Observe(CartId cartId) => collection.ObserveById(cartId);
 }

--- a/Samples/eCommerce/Basic/Read/Carts/ICartQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Carts/ICartQueries.cs
@@ -23,5 +23,5 @@ public interface ICartQueries
     /// </summary>
     /// <param name="cartId">The <see cref="CartId"/> for the cart.</param>
     /// <returns>The subject for <see cref="Cart"/>.</returns>
-    Task<ISubject<Cart>> Observe(CartId cartId);
+    ISubject<Cart> Observe(CartId cartId);
 }

--- a/Samples/eCommerce/Basic/Read/Products/CatalogQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Products/CatalogQueries.cs
@@ -15,5 +15,5 @@ public class CatalogQueries(IMongoCollection<Product> collection) : ICatalogQuer
     public IQueryable<Product> All() => collection.AsQueryable();
 
     /// <inheritdoc/>
-    public Task<ISubject<IEnumerable<Product>>> ObserveAll() => collection.Observe(_ => _.IsRegistered);
+    public ISubject<IEnumerable<Product>> ObserveAll() => collection.Observe(_ => _.IsRegistered);
 }

--- a/Samples/eCommerce/Basic/Read/Products/CatalogQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Products/CatalogQueries.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Subjects;
+
 namespace Read.Products;
 
 /// <summary>
@@ -11,4 +13,7 @@ public class CatalogQueries(IMongoCollection<Product> collection) : ICatalogQuer
 {
     /// <inheritdoc/>
     public IQueryable<Product> All() => collection.AsQueryable();
+
+    /// <inheritdoc/>
+    public Task<ISubject<IEnumerable<Product>>> ObserveAll() => collection.Observe(_ => _.IsRegistered);
 }

--- a/Samples/eCommerce/Basic/Read/Products/ICatalogQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Products/ICatalogQueries.cs
@@ -20,5 +20,5 @@ public interface ICatalogQueries
     /// Observe all products.
     /// </summary>
     /// <returns>Subject of a collection of products.</returns>
-    Task<ISubject<IEnumerable<Product>>> ObserveAll();
+    ISubject<IEnumerable<Product>> ObserveAll();
 }

--- a/Samples/eCommerce/Basic/Read/Products/ICatalogQueries.cs
+++ b/Samples/eCommerce/Basic/Read/Products/ICatalogQueries.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Subjects;
+
 namespace Read.Products;
 
 /// <summary>
@@ -13,4 +15,10 @@ public interface ICatalogQueries
     /// </summary>
     /// <returns>Queryable of products.</returns>
     IQueryable<Product> All();
+
+    /// <summary>
+    /// Observe all products.
+    /// </summary>
+    /// <returns>Subject of a collection of products.</returns>
+    Task<ISubject<IEnumerable<Product>>> ObserveAll();
 }

--- a/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
@@ -26,7 +26,7 @@ export class CartForCurrentUser extends QueryFor<Cart> {
     }
 
 
-    static use(): [QueryResultWithState<Cart>, PerformQuery, SetSorting] {
-        return useQuery<Cart, CartForCurrentUser>(CartForCurrentUser);
+    static use(sorting?: Sorting): [QueryResultWithState<Cart[]>, PerformQuery, SetSorting] {
+        return useQuery<Cart[], CartForCurrentUser>(CartForCurrentUser, undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
@@ -10,6 +10,7 @@ import Handlebars from 'handlebars';
 
 const routeTemplate = Handlebars.compile('/api/carts/observe');
 
+
 export class ObserveCartForCurrentUser extends ObservableQueryFor<Cart> {
     readonly route: string = '/api/carts/observe';
     readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
@@ -24,7 +25,8 @@ export class ObserveCartForCurrentUser extends ObservableQueryFor<Cart> {
         ];
     }
 
-    static use(): [QueryResultWithState<Cart>] {
-        return useObservableQuery<Cart, ObserveCartForCurrentUser>(ObserveCartForCurrentUser);
+
+    static use(sorting?: Sorting): [QueryResultWithState<Cart[]>, SetSorting] {
+        return useObservableQuery<Cart[], ObserveCartForCurrentUser>(ObserveCartForCurrentUser, undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // eslint-disable-next-line header/header
-import { QueryFor, QueryResultWithState, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
+import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
 import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage } from '@cratis/applications.react/queries';
 import { Product } from './Product';
 import Handlebars from 'handlebars';
@@ -48,7 +48,6 @@ class AllProductsSortByWithoutQuery {
     }
 }
 
-
 export class AllProducts extends QueryFor<Product[]> {
     readonly route: string = '/api/products/catalog';
     readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
@@ -74,11 +73,11 @@ export class AllProducts extends QueryFor<Product[]> {
         return this._sortBy;
     }
 
-    static use(): [QueryResultWithState<Product[]>, PerformQuery, SetSorting] {
-        return useQuery<Product[], AllProducts>(AllProducts);
+    static use(sorting?: Sorting): [QueryResultWithState<Product[]>, PerformQuery, SetSorting] {
+        return useQuery<Product[], AllProducts>(AllProducts, undefined, sorting);
     }
 
-    static useWithPaging(pageSize: number): [QueryResultWithState<Product[]>, number, PerformQuery, SetSorting, SetPage] {
-        return useQueryWithPaging<Product[], AllProducts>(AllProducts, new Paging(0, pageSize));
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, number, PerformQuery, SetSorting, SetPage] {
+        return useQueryWithPaging<Product[], AllProducts>(AllProducts, new Paging(0, pageSize), undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line header/header
+import { ObservableQueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForObservableQuery, Paging } from '@cratis/applications/queries';
+import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage } from '@cratis/applications.react/queries';
+import { Product } from './Product';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/products/catalog/observe');
+
+class ObserveAllProductsSortBy {
+    private _id: SortingActionsForObservableQuery<Product[]>;
+    private _name: SortingActionsForObservableQuery<Product[]>;
+    private _isRegistered: SortingActionsForObservableQuery<Product[]>;
+
+    constructor(readonly query: ObserveAllProducts) {
+        this._id = new SortingActionsForObservableQuery<Product[]>('id', query);
+        this._name = new SortingActionsForObservableQuery<Product[]>('name', query);
+        this._isRegistered = new SortingActionsForObservableQuery<Product[]>('isRegistered', query);
+    }
+
+    get id(): SortingActionsForObservableQuery<Product[]> {
+        return this._id;
+    }
+    get name(): SortingActionsForObservableQuery<Product[]> {
+        return this._name;
+    }
+    get isRegistered(): SortingActionsForObservableQuery<Product[]> {
+        return this._isRegistered;
+    }
+}
+
+class ObserveAllProductsSortByWithoutQuery {
+    private _id: SortingActions  = new SortingActions('id');
+    private _name: SortingActions  = new SortingActions('name');
+    private _isRegistered: SortingActions  = new SortingActions('isRegistered');
+
+    get id(): SortingActions {
+        return this._id;
+    }
+    get name(): SortingActions {
+        return this._name;
+    }
+    get isRegistered(): SortingActions {
+        return this._isRegistered;
+    }
+}
+
+export class ObserveAllProducts extends ObservableQueryFor<Product[]> {
+    readonly route: string = '/api/products/catalog/observe';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly defaultValue: Product[] = [];
+    private readonly _sortBy: ObserveAllProductsSortBy;
+    private static readonly _sortBy: ObserveAllProductsSortByWithoutQuery = new ObserveAllProductsSortByWithoutQuery();
+
+    constructor() {
+        super(Product, true);
+        this._sortBy = new ObserveAllProductsSortBy(this);
+    }
+
+    get requestArguments(): string[] {
+        return [
+        ];
+    }
+
+    get sortBy(): ObserveAllProductsSortBy {
+        return this._sortBy;
+    }
+
+    static get sortBy(): ObserveAllProductsSortByWithoutQuery {
+        return this._sortBy;
+    }
+
+    static use(sorting?: Sorting): [QueryResultWithState<Product[]>, SetSorting] {
+        return useObservableQuery<Product[], ObserveAllProducts>(ObserveAllProducts, undefined, sorting);
+    }
+
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, SetSorting, SetPage] {
+        return useObservableQueryWithPaging<Product[], ObserveAllProducts>(ObserveAllProducts, new Paging(0, pageSize), undefined, sorting);
+    }
+}

--- a/Samples/eCommerce/Basic/Web/API/Products/index.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/index.ts
@@ -7,4 +7,5 @@ export * from './Product';
 export * from './SetStockForProduct';
 export * from './SetPrice';
 export * from './AddProduct';
+export * from './ObserveAllProducts';
 export * from './AllProducts';

--- a/Samples/eCommerce/Basic/Web/App.tsx
+++ b/Samples/eCommerce/Basic/Web/App.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
-import { IdentityProvider } from '@cratis/applications.react/identity';
+import React, { useEffect } from 'react';
+import { IdentityProvider, useIdentity } from '@cratis/applications.react/identity';
 import { MVVM } from '@cratis/applications.react.mvvm';
 import { BrowserRouter } from "react-router-dom";
 import { Feature } from './Feature';

--- a/Samples/eCommerce/Basic/Web/Catalog.tsx
+++ b/Samples/eCommerce/Basic/Web/Catalog.tsx
@@ -3,28 +3,41 @@
 
 import { withViewModel } from '@cratis/applications.react.mvvm';
 import { CatalogViewModel } from './CatalogViewModel';
-import { AllProducts } from './API/Products';
+import { AllProducts, ObserveAllProducts } from './API/Products';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { SortDirection, Sorting } from '@cratis/applications/queries';
 
 export const Catalog = withViewModel(CatalogViewModel, ({ viewModel }) => {
-    const [products, currentPage, perform, setSorting, setPage] = AllProducts.useWithPaging(10);
+    const [pageSize, setPageSize] = useState(10);
+    // // const [products, currentPage, perform, setSorting, setPage] = AllProducts.useWithPaging(pageSize);
+    const [observableProducts, setSorting, setPage] = ObserveAllProducts.useWithPaging(10);
     const [descending, setDescending] = useState(false);
+    const [currentPage, setCurrentPage] = useState(0);
 
     return (
         <div>
             <div>Page {currentPage + 1}</div>
-            <DataTable value={products.data}>
+            <DataTable value={observableProducts.data}>
                 <Column field="id" header="SKU" />
                 <Column field="name" header="Name" />
             </DataTable>
 
             <button onClick={() => {
-                const page = currentPage + 1;
-                setPage(page);
+                setCurrentPage(currentPage - 1);
+                setPage(currentPage - 1);
+            }}>Previous page</button>
+
+            <button onClick={() => {
+                setCurrentPage(currentPage + 1);
+                setPage(currentPage + 1);
             }}>Next page</button>
-            <br/>
+            <br />
+
+            <button onClick={() => {
+                setPage(20);
+            }}>More stuff</button>
 
             <button onClick={() => {
                 if (descending) {

--- a/Samples/eCommerce/Basic/Web/Feature.tsx
+++ b/Samples/eCommerce/Basic/Web/Feature.tsx
@@ -7,7 +7,13 @@ import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { useIdentity } from '@cratis/applications.react/identity';
 
-export const Feature = withViewModel(FeatureViewModel, ({ viewModel }) => {
+
+export interface FeatureProps {
+    blah: string;
+}
+
+export const Feature = withViewModel<FeatureViewModel, FeatureProps>(FeatureViewModel, ({ viewModel, props }) => {
+    console.log(props.blah);
 
     const identity = useIdentity();
     return (

--- a/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
+++ b/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
@@ -3,10 +3,11 @@
 
 import { injectable } from 'tsyringe';
 import { Cart, CartForCurrentUser, ObserveCartForCurrentUser } from './API/Carts';
+import { FeatureProps } from './Feature';
 
 @injectable()
 export class FeatureViewModel {
-    constructor(readonly query: ObserveCartForCurrentUser) {
+    constructor(readonly query: ObserveCartForCurrentUser, readonly props: FeatureProps) {
         query.subscribe(result => {
             this.cart = result.data;
         });

--- a/Samples/eCommerce/Basic/Web/index.tsx
+++ b/Samples/eCommerce/Basic/Web/index.tsx
@@ -10,6 +10,10 @@ import './Styles/theme.css';
 import React from 'react';
 import { App } from './App';
 
+const Blah = () => {
+    console.log('Blah');
+    return (<></>);
+};
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/given/a_valid_identity_request.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/given/a_valid_identity_request.cs
@@ -22,9 +22,9 @@ public abstract class a_valid_identity_request : an_identity_provider_endpoint
         headers[MicrosoftIdentityPlatformHeaders.PrincipalHeader] =
             Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(client_principal));
 
-        identity_provider.Setup(_ => _.Provide(IsAny<IdentityProviderContext>())).Returns((IdentityProviderContext context) =>
+        identity_provider.Provide(Arg.Any<IdentityProviderContext>()).Returns((CallInfo x) =>
         {
-            identity_provider_context = context;
+            identity_provider_context = x.Arg<IdentityProviderContext>();
             return Task.FromResult(details_result);
         });
     }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/given/an_identity_provider_endpoint.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/given/an_identity_provider_endpoint.cs
@@ -9,29 +9,29 @@ namespace Cratis.Applications.Identity.for_IdentityProviderEndpoint.given;
 public class an_identity_provider_endpoint : Specification
 {
     protected JsonSerializerOptions serializer_options;
-    protected Mock<IProvideIdentityDetails> identity_provider;
+    protected IProvideIdentityDetails identity_provider;
     protected IdentityProviderEndpoint endpoint;
-    protected Mock<HttpRequest> request;
-    protected Mock<HttpResponse> response;
+    protected HttpRequest request;
+    protected HttpResponse response;
     protected HeaderDictionary headers;
     protected MemoryStream body_stream;
-    protected Mock<HttpContext> http_context;
+    protected HttpContext http_context;
 
     void Establish()
     {
-        http_context = new();
+        http_context = Substitute.For<HttpContext>();
         serializer_options = new JsonSerializerOptions();
-        identity_provider = new();
-        endpoint = new(serializer_options, identity_provider.Object);
+        identity_provider = Substitute.For<IProvideIdentityDetails>();
+        endpoint = new(serializer_options, identity_provider);
 
-        request = new();
-        request.SetupGet(_ => _.HttpContext).Returns(http_context.Object);
+        request = Substitute.For<HttpRequest>();
+        request.HttpContext.Returns(http_context);
         headers = [];
-        request.SetupGet(_ => _.Headers).Returns(headers);
+        request.Headers.Returns(headers);
 
-        response = new();
-        response.SetupGet(_ => _.HttpContext).Returns(http_context.Object);
-        body_stream = new();
-        response.SetupGet(_ => _.Body).Returns(body_stream);
+        response = Substitute.For<HttpResponse>();
+        response.HttpContext.Returns(http_context);
+        body_stream = Substitute.For<MemoryStream>();
+        response.Body.Returns(body_stream);
     }
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_claims_are_missing.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_claims_are_missing.cs
@@ -14,7 +14,7 @@ public class and_claims_are_missing : given.a_valid_identity_request
             Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(client_principal));
     }
 
-    Task Because() => endpoint.Handler(request.Object, response.Object);
+    Task Because() => endpoint.Handler(request, response);
 
-    [Fact] void should_not_invoke_identity_provider() => identity_provider.Verify(_ => _.Provide(IsAny<IdentityProviderContext>()), Never);
+    [Fact] void should_not_invoke_identity_provider() => identity_provider.DidNotReceive().Provide(Arg.Any<IdentityProviderContext>());
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_id_header_is_missing.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_id_header_is_missing.cs
@@ -7,7 +7,7 @@ public class and_identity_id_header_is_missing : given.a_valid_identity_request
 {
     void Establish() => headers.Remove(MicrosoftIdentityPlatformHeaders.IdentityIdHeader);
 
-    Task Because() => endpoint.Handler(request.Object, response.Object);
+    Task Because() => endpoint.Handler(request, response);
 
-    [Fact] void should_not_invoke_identity_provider() => identity_provider.Verify(_ => _.Provide(IsAny<IdentityProviderContext>()), Never);
+    [Fact] void should_not_invoke_identity_provider() => identity_provider.DidNotReceive().Provide(Arg.Any<IdentityProviderContext>());
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_is_valid_with_multiple_roles.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_is_valid_with_multiple_roles.cs
@@ -17,10 +17,10 @@ public class and_identity_is_valid_with_multiple_roles : given.a_valid_identity_
         role_typ = "roles"
     };
 
-    Task Because() => endpoint.Handler(request.Object, response.Object);
+    Task Because() => endpoint.Handler(request, response);
 
-    [Fact] void should_invoke_identity_provider() => identity_provider.Verify(_ => _.Provide(IsAny<IdentityProviderContext>()), Once);
+    [Fact] void should_invoke_identity_provider() => identity_provider.Received(1).Provide(Arg.Any<IdentityProviderContext>());
     [Fact] void should_pass_first_role_to_identity_provider() => identity_provider_context.Claims.ShouldContain(_ => _.Key == "roles" && _.Value == "role1");
     [Fact] void should_pass_second_role_to_identity_provider() => identity_provider_context.Claims.ShouldContain(_ => _.Key == "roles" && _.Value == "role2");
-    [Fact] void should_set_status_code_to_200() => response.VerifySet(_ => _.StatusCode = 200, Once);
+    [Fact] void should_set_status_code_to_200() => response.Received(1).StatusCode = 200;
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_name_header_is_missing.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_identity_name_header_is_missing.cs
@@ -7,7 +7,7 @@ public class and_identity_name_header_is_missing : given.a_valid_identity_reques
 {
     void Establish() => headers.Remove(MicrosoftIdentityPlatformHeaders.IdentityNameHeader);
 
-    Task Because() => endpoint.Handler(request.Object, response.Object);
+    Task Because() => endpoint.Handler(request, response);
 
-    [Fact] void should_not_invoke_identity_provider() => identity_provider.Verify(_ => _.Provide(IsAny<IdentityProviderContext>()), Never);
+    [Fact] void should_not_invoke_identity_provider() => identity_provider.DidNotReceive().Provide(Arg.Any<IdentityProviderContext>());
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_principal_header_is_missing.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpoint/when_handling/and_principal_header_is_missing.cs
@@ -7,7 +7,7 @@ public class and_principal_header_is_missing : given.a_valid_identity_request
 {
     void Establish() => headers.Remove(MicrosoftIdentityPlatformHeaders.PrincipalHeader);
 
-    Task Because() => endpoint.Handler(request.Object, response.Object);
+    Task Because() => endpoint.Handler(request, response);
 
-    [Fact] void should_not_invoke_identity_provider() => identity_provider.Verify(_ => _.Provide(IsAny<IdentityProviderContext>()), Never);
+    [Fact] void should_not_invoke_identity_provider() => identity_provider.DidNotReceive().Provide(Arg.Any<IdentityProviderContext>());
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_multiple_providers.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_multiple_providers.cs
@@ -8,19 +8,19 @@ namespace Cratis.Applications.Identity.for_IdentityProviderEndpointExtensions.wh
 
 public class and_there_are_multiple_providers : Specification
 {
-    Mock<IServiceCollection> services;
-    Mock<ITypes> types;
+    IServiceCollection services;
+    ITypes types;
     Exception exception;
 
     void Establish()
     {
-        services = new();
-        types = new();
-        types.Setup(_ => _.FindMultiple<IProvideIdentityDetails>()).Returns([typeof(object), typeof(object)]);
+        services = Substitute.For<IServiceCollection>();
+        types = Substitute.For<ITypes>();
+        types.FindMultiple<IProvideIdentityDetails>().Returns([typeof(object), typeof(object)]);
     }
 
-    void Because() => exception = Catch.Exception(() => services.Object.AddIdentityProvider(types.Object));
+    void Because() => exception = Catch.Exception(() => services.AddIdentityProvider(types));
 
     [Fact] void should_throw_multiple_identity_details_providers_found() => exception.ShouldBeOfExactType<MultipleIdentityDetailsProvidersFound>();
-    [Fact] void should_not_add_service_registration() => services.Verify(_ => _.Add(IsAny<ServiceDescriptor>()), Never);
+    [Fact] void should_not_add_service_registration() => services.DidNotReceive().Add(Arg.Any<ServiceDescriptor>());
 }

--- a/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_no_providers.cs
+++ b/Source/DotNET/Applications.Specs/Identity/for_IdentityProviderEndpointExtensions/when_adding_identity_provider/and_there_are_no_providers.cs
@@ -8,19 +8,21 @@ namespace Cratis.Applications.Identity.for_IdentityProviderEndpointExtensions.wh
 
 public class and_there_are_no_providers : Specification
 {
-    Mock<IServiceCollection> services;
-    Mock<ITypes> types;
+    IServiceCollection services;
+    ITypes types;
     ServiceDescriptor service_descriptor;
 
     void Establish()
     {
-        services = new();
-        types = new();
-        services.Setup(_ => _.Add(IsAny<ServiceDescriptor>())).Callback((ServiceDescriptor _) => service_descriptor = _);
+        services = Substitute.For<IServiceCollection>();
+        types = Substitute.For<ITypes>();
+        services
+            .When(_ => _.Add(Arg.Any<ServiceDescriptor>()))
+            .Do(_ => service_descriptor = _.Arg<ServiceDescriptor>());
     }
 
-    void Because() => services.Object.AddIdentityProvider(types.Object);
+    void Because() => services.AddIdentityProvider(types);
 
-    [Fact] void should_add_one_service_registration() => services.Verify(_ => _.Add(IsAny<ServiceDescriptor>()), Once);
+    [Fact] void should_add_one_service_registration() => services.Received(1).Add(Arg.Any<ServiceDescriptor>());
     [Fact] void should_add_default_identity_details_provider() => service_descriptor.ImplementationType.ShouldEqual(typeof(DefaultIdentityDetailsProvider));
 }

--- a/Source/DotNET/Applications/Commands/CommandActionFilter.cs
+++ b/Source/DotNET/Applications/Commands/CommandActionFilter.cs
@@ -61,11 +61,11 @@ public class CommandActionFilter : IAsyncActionFilter
 
             if (!commandResult.IsAuthorized)
             {
-                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;            // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;            // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden
             }
             else if (!commandResult.IsValid)
             {
-                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;             // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;           // Bad request: https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request
             }
             else if (commandResult.HasExceptions)
             {

--- a/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
@@ -26,14 +26,9 @@ public static class IdentityProviderServiceCollectionExtensions
             throw new MultipleIdentityDetailsProvidersFound(providerTypes);
         }
 
-        if (providerTypes.Length == 1)
-        {
-            services.AddSingleton(typeof(IProvideIdentityDetails), providerTypes[0]);
-        }
-        else
-        {
-            services.AddSingleton<IProvideIdentityDetails, DefaultIdentityDetailsProvider>();
-        }
+        services.AddSingleton(
+            typeof(IProvideIdentityDetails),
+            providerTypes.Length == 1 ? providerTypes[0] : typeof(DefaultIdentityDetailsProvider));
 
         return services;
     }

--- a/Source/DotNET/Applications/Queries/Paging.cs
+++ b/Source/DotNET/Applications/Queries/Paging.cs
@@ -51,4 +51,9 @@ public record Paging
     /// Whether or not paging is to be used.
     /// </summary>
     public bool IsPaged { get; }
+
+    /// <summary>
+    /// Gets the number of items to skip.
+    /// </summary>
+    public int Skip => Page * Size;
 }

--- a/Source/DotNET/Applications/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/Applications/Queries/QueryActionFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using System.Reactive.Subjects;
 using Cratis.Applications.Validation;
 using Cratis.Reflection;
@@ -122,15 +123,15 @@ public class QueryActionFilter(
 
                 if (!queryResult.IsAuthorized)
                 {
-                    context.HttpContext.Response.StatusCode = 401;   // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized
+                    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;         // Forbidden: https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden
                 }
                 else if (!queryResult.IsValid)
                 {
-                    context.HttpContext.Response.StatusCode = 409;   // Conflict: https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict
+                    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;           // Bad request: https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request
                 }
                 else if (queryResult.HasExceptions)
                 {
-                    context.HttpContext.Response.StatusCode = 500;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
+                    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;  // Internal Server error: https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error
                 }
 
                 var actualResult = new ObjectResult(queryResult);

--- a/Source/DotNET/Applications/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/Applications/Queries/QueryActionFilter.cs
@@ -30,10 +30,25 @@ public class QueryActionFilter(
     IQueryProviders queryProviders,
     ILogger<QueryActionFilter> logger) : IAsyncActionFilter
 {
-    const string SortByQueryStringKey = "sortby";
-    const string SortDirectionQueryStringKey = "sortDirection";
-    const string PageQueryStringKey = "page";
-    const string PageSizeQueryStringKey = "pageSize";
+    /// <summary>
+    /// Gets the key for the sort by query string.
+    /// </summary>
+    public const string SortByQueryStringKey = "sortby";
+
+    /// <summary>
+    /// Gets the key for the sort direction query string.
+    /// </summary>
+    public const string SortDirectionQueryStringKey = "sortDirection";
+
+    /// <summary>
+    /// Gets the key for the page query string.
+    /// </summary>
+    public const string PageQueryStringKey = "page";
+
+    /// <summary>
+    /// Gets the key for the page size query string.
+    /// </summary>
+    public const string PageSizeQueryStringKey = "pageSize";
 
     readonly JsonOptions _options = options.Value;
 

--- a/Source/DotNET/Applications/Queries/QueryableQueryProvider.cs
+++ b/Source/DotNET/Applications/Queries/QueryableQueryProvider.cs
@@ -23,7 +23,7 @@ public class QueryableQueryProvider : IQueryProviderFor<IQueryable>
 
         if (queryContext.Paging.IsPaged)
         {
-            query = query.Skip(queryContext.Paging.Page * queryContext.Paging.Size)
+            query = query.Skip(queryContext.Paging.Skip)
                          .Take(queryContext.Paging.Size);
         }
 

--- a/Source/DotNET/Directory.Build.props
+++ b/Source/DotNET/Directory.Build.props
@@ -57,7 +57,6 @@
     <ItemGroup Condition="'$(IsTestProject)'=='true'">
         <PackageReference Include="Cratis.Specifications.XUnit" />
         <PackageReference Include="NSubstitute" />
-        <PackageReference Include="moq" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/Source/DotNET/GlobalUsings.Specs.cs
+++ b/Source/DotNET/GlobalUsings.Specs.cs
@@ -5,7 +5,6 @@
 
 global using Cratis.Specifications;
 global using Cratis.Types;
-global using Moq;
+global using NSubstitute;
+global using NSubstitute.Core;
 global using Xunit;
-global using static Moq.It;
-global using static Moq.Times;

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/InvocationTarget.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/InvocationTarget.cs
@@ -7,16 +7,11 @@ public class InvocationTarget
 {
     public const string ErrorMessage = "Something went wrong";
 
-    public Task<string> SuccessfulMethod() => Task.FromResult("Hello");
-    public Task<string> CancelledMethod() => Task.FromCanceled<string>(new CancellationToken(true));
-    public Task<string> FaultedMethod() => Task.Run<string>(() =>
-    {
-        #pragma warning disable AS0008, CA2201
-        throw new(ErrorMessage);
-#pragma warning disable CS0162 // Unreachable code detected
-        return "Hello";
-#pragma warning restore CS0162 // Unreachable code detected
-    });
+    public Task SuccessfulMethod() => Task.CompletedTask;
+    public Task CancelledMethod() => Task.FromCanceled(new CancellationToken(true));
 
-    public Task<string> FaultedMethodWithoutTask() => throw new(ErrorMessage);
+#pragma warning disable AS0008, CA2201
+    public Task FaultedMethod() => Task.Run(() => throw new(ErrorMessage));
+
+    public Task FaultedMethodWithoutTask() => throw new(ErrorMessage);
 }

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/given/an_interceptor.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/given/an_interceptor.cs
@@ -12,7 +12,7 @@ public abstract class an_interceptor : Specification
     protected ResiliencePipeline resilience_pipeline;
     protected MongoClientSettings settings;
     protected MongoCollectionInterceptor interceptor;
-    protected Mock<Castle.DynamicProxy.IInvocation> invocation;
+    protected Castle.DynamicProxy.IInvocation invocation;
     protected Task return_value;
     protected for_MongoCollectionInterceptorForReturnValue.InvocationTarget target;
     protected SemaphoreSlim semaphore;
@@ -27,10 +27,10 @@ public abstract class an_interceptor : Specification
 
         interceptor = new(resilience_pipeline, semaphore);
 
-        invocation = new();
-        invocation.SetupGet(_ => _.Method).Returns(typeof(for_MongoCollectionInterceptorForReturnValue.InvocationTarget).GetMethod(GetInvocationTargetMethod())!);
+        invocation = Substitute.For<Castle.DynamicProxy.IInvocation>();
+        invocation.Method.Returns(typeof(for_MongoCollectionInterceptorForReturnValue.InvocationTarget).GetMethod(GetInvocationTargetMethod())!);
         target = new();
-        invocation.SetupGet(_ => _.InvocationTarget).Returns(target);
-        invocation.SetupSet(_ => _.ReturnValue = It.IsAny<Task>()).Callback((object? value) => return_value = value as Task);
+        invocation.InvocationTarget.Returns(target);
+        invocation.When(_ => _.ReturnValue = Arg.Any<Task>()).Do((CallInfo? _) => return_value = _.Arg<Task>());
     }
 }

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/cancelled_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/cancelled_method.cs
@@ -10,7 +10,7 @@ public class cancelled_method : given.an_interceptor
 
     async Task Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = await Catch.Exception(async () => await return_value);
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method.cs
@@ -11,7 +11,7 @@ public class faulted_method : given.an_interceptor
 
     async Task Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = await Catch.Exception(async () => await return_value);
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method_without_task.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method_without_task.cs
@@ -11,7 +11,7 @@ public class faulted_method_without_task : given.an_interceptor
 
     void Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = return_value.Exception.InnerExceptions.Single().InnerException;
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/successful_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptor/when_intercepting/successful_method.cs
@@ -7,7 +7,7 @@ public class successful_method : given.an_interceptor
 {
     protected override string GetInvocationTargetMethod() => nameof(for_MongoCollectionInterceptorForReturnValue.InvocationTarget.SuccessfulMethod);
 
-    void Because() => interceptor.Intercept(invocation.Object);
+    void Because() => interceptor.Intercept(invocation);
 
     [Fact] void should_return_successful_task() => return_value.IsCompletedSuccessfully.ShouldBeTrue();
     [Fact] void should_have_freed_up_semaphore() => semaphore.CurrentCount.ShouldEqual(pool_size);

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/InvocationTarget.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/InvocationTarget.cs
@@ -7,11 +7,16 @@ public class InvocationTarget
 {
     public const string ErrorMessage = "Something went wrong";
 
-    public Task SuccessfulMethod() => Task.CompletedTask;
-    public Task CancelledMethod() => Task.FromCanceled(new CancellationToken(true));
-
-#pragma warning disable AS0008, CA2201
-    public Task FaultedMethod() => Task.Run(() => throw new(ErrorMessage));
+    public Task<string> SuccessfulMethod() => Task.FromResult("Hello");
+    public Task<string> CancelledMethod() => Task.FromCanceled<string>(new CancellationToken(true));
+    public Task<string> FaultedMethod() => Task.Run(() =>
+    {
+        #pragma warning disable AS0008, CA2201
+        throw new(ErrorMessage);
+#pragma warning disable CS0162 // Unreachable code detected
+        return "Hello";
+#pragma warning restore CS0162 // Unreachable code detected
+    });
 
     public Task<string> FaultedMethodWithoutTask() => throw new(ErrorMessage);
 }

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/given/an_interceptor.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/given/an_interceptor.cs
@@ -12,9 +12,9 @@ public abstract class an_interceptor : Specification
     protected ResiliencePipeline resilience_pipeline;
     protected MongoClientSettings settings;
     protected MongoCollectionInterceptorForReturnValues interceptor;
-    protected Mock<Castle.DynamicProxy.IInvocation> invocation;
+    protected Castle.DynamicProxy.IInvocation invocation;
     protected Task<string> return_value;
-    protected for_MongoCollectionInterceptor.InvocationTarget target;
+    protected InvocationTarget target;
     protected SemaphoreSlim semaphore;
 
     protected abstract string GetInvocationTargetMethod();
@@ -26,10 +26,10 @@ public abstract class an_interceptor : Specification
 
         interceptor = new(resilience_pipeline, semaphore);
 
-        invocation = new();
-        invocation.SetupGet(_ => _.Method).Returns(typeof(for_MongoCollectionInterceptor.InvocationTarget).GetMethod(GetInvocationTargetMethod())!);
+        invocation = Substitute.For<Castle.DynamicProxy.IInvocation>();
+        invocation.Method.Returns(typeof(InvocationTarget).GetMethod(GetInvocationTargetMethod())!);
         target = new();
-        invocation.SetupGet(_ => _.InvocationTarget).Returns(target);
-        invocation.SetupSet(_ => _.ReturnValue = It.IsAny<Task<string>>()).Callback((object? value) => return_value = value as Task<string>);
+        invocation.InvocationTarget.Returns(target);
+        invocation.When(_ => _.ReturnValue = Arg.Any<Task<string>>()).Do((CallInfo? _) => return_value = _.Arg<Task<string>>());
     }
 }

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/cancelled_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/cancelled_method.cs
@@ -10,7 +10,7 @@ public class cancelled_method : given.an_interceptor
 
     async Task Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = await Catch.Exception(async () => await return_value);
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method.cs
@@ -11,7 +11,7 @@ public class faulted_method : given.an_interceptor
 
     async Task Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = await Catch.Exception(async () => await return_value);
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method_without_task.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method_without_task.cs
@@ -7,11 +7,11 @@ public class faulted_method_without_task : given.an_interceptor
 {
     Exception exception;
 
-    protected override string GetInvocationTargetMethod() => nameof(for_MongoCollectionInterceptor.InvocationTarget.FaultedMethodWithoutTask);
+    protected override string GetInvocationTargetMethod() => nameof(InvocationTarget.FaultedMethodWithoutTask);
 
     void Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         exception = return_value.Exception.InnerExceptions.Single().InnerException;
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/successful_method.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/successful_method.cs
@@ -10,7 +10,7 @@ public class successful_method : given.an_interceptor
 
     async Task Because()
     {
-        interceptor.Intercept(invocation.Object);
+        interceptor.Intercept(invocation);
         result = await return_value;
     }
 

--- a/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorSelector/given/an_interceptor_selector.cs
+++ b/Source/DotNET/MongoDB.Specs/Resilience/for_MongoCollectionInterceptorSelector/given/an_interceptor_selector.cs
@@ -10,15 +10,15 @@ public class an_interceptor_selector : Specification
 {
     protected MongoCollectionInterceptorSelector selector;
     protected ResiliencePipeline resilience_pipeline;
-    protected Mock<IMongoClient> mongo_client;
+    protected IMongoClient mongo_client;
     protected MongoClientSettings settings;
 
     void Establish()
     {
         resilience_pipeline = new ResiliencePipelineBuilder().Build();
-        mongo_client = new();
+        mongo_client = Substitute.For<IMongoClient>();
         settings = new MongoClientSettings();
-        mongo_client.SetupGet(_ => _.Settings).Returns(settings);
-        selector = new MongoCollectionInterceptorSelector(resilience_pipeline, mongo_client.Object);
+        mongo_client.Settings.Returns(settings);
+        selector = new MongoCollectionInterceptorSelector(resilience_pipeline, mongo_client);
     }
 }

--- a/Source/DotNET/MongoDB.Specs/for_AcronymFriendlyCamelCaseElementNameConvention/when_applying_convention_to_all_class_map_members.cs
+++ b/Source/DotNET/MongoDB.Specs/for_AcronymFriendlyCamelCaseElementNameConvention/when_applying_convention_to_all_class_map_members.cs
@@ -25,8 +25,6 @@ public class when_applying_convention_to_all_class_map_members : Specification
     void Because() => class_map.DeclaredMemberMaps.ForEach(convention.Apply);
 
     [Fact] void should_have_two_members() => class_map.DeclaredMemberMaps.Count().ShouldEqual(2);
-    [Fact] void should_convert_SomeProperty_to_camelCase() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someProperty")
-        .ShouldContainSingleItem();
-    [Fact] void should_convert_SomeOtherProperty_to_someOtherPropertyName() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someOtherPropertyName")
-        .ShouldContainSingleItem();
+    [Fact] void should_convert_SomeProperty_to_camelCase() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someProperty").ShouldContainSingleItem();
+    [Fact] void should_convert_SomeOtherProperty_to_someOtherPropertyName() => class_map.DeclaredMemberMaps.Where(_ => _.ElementName == "someOtherPropertyName").ShouldContainSingleItem();
 }

--- a/Source/DotNET/MongoDB.Specs/for_BsonClassMapExtensions/when_applying_conventions.cs
+++ b/Source/DotNET/MongoDB.Specs/for_BsonClassMapExtensions/when_applying_conventions.cs
@@ -12,19 +12,19 @@ public class when_applying_conventions : Specification
     }
 
     BsonClassMap<SomeType> class_map;
-    Mock<IMemberMapConvention> convention;
+    IMemberMapConvention convention;
 
     void Establish()
     {
         class_map = new BsonClassMap<SomeType>();
         class_map.AutoMap();
-        convention = new Mock<IMemberMapConvention>();
-        ConventionRegistry.Register(Guid.NewGuid().ToString(), new ConventionPack { convention.Object }, type => type == typeof(SomeType));
+        convention = Substitute.For<IMemberMapConvention>();
+        ConventionRegistry.Register(Guid.NewGuid().ToString(), new ConventionPack { convention }, type => type == typeof(SomeType));
     }
 
     void Because() => class_map.ApplyConventions();
 
     [Fact] void should_have_two_members() => class_map.DeclaredMemberMaps.Count().ShouldEqual(2);
-    [Fact] void should_call_convention_for_first_property() => convention.Verify(_ => _.Apply(class_map.DeclaredMemberMaps.First()), Once);
-    [Fact] void should_call_convention_for_second_property() => convention.Verify(_ => _.Apply(class_map.DeclaredMemberMaps.ToArray()[1]), Once);
+    [Fact] void should_call_convention_for_first_property() => convention.Received(1).Apply(class_map.DeclaredMemberMaps.First());
+    [Fact] void should_call_convention_for_second_property() => convention.Received(1).Apply(class_map.DeclaredMemberMaps.ToArray()[1]);
 }

--- a/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_convention_pack_other_than_specified_in_ignore_attribute_on_type.cs
+++ b/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_convention_pack_other_than_specified_in_ignore_attribute_on_type.cs
@@ -16,7 +16,7 @@ public class when_asking_should_include_for_convention_pack_other_than_specified
 
     void Establish() => filter = new();
 
-    void Because() => result = filter.ShouldInclude("SomePack", Mock.Of<IConventionPack>(), typeof(TheType));
+    void Because() => result = filter.ShouldInclude("SomePack", Substitute.For<IConventionPack>(), typeof(TheType));
 
     [Fact] void should_include_it() => result.ShouldBeTrue();
 }

--- a/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_convention_same_as_specified_in_ignore_attribute_on_type.cs
+++ b/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_convention_same_as_specified_in_ignore_attribute_on_type.cs
@@ -16,7 +16,7 @@ public class when_asking_should_include_for_convention_same_as_specified_in_igno
 
     void Establish() => filter = new();
 
-    void Because() => result = filter.ShouldInclude("SomePack", Mock.Of<IConventionPack>(), typeof(TheType));
+    void Because() => result = filter.ShouldInclude("SomePack", Substitute.For<IConventionPack>(), typeof(TheType));
 
     [Fact] void should_not_include_it() => result.ShouldBeFalse();
 }

--- a/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_type_with_ignore_attribute_ignoring_all.cs
+++ b/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_type_with_ignore_attribute_ignoring_all.cs
@@ -16,7 +16,7 @@ public class when_asking_should_include_for_type_with_ignore_attribute_ignoring_
 
     void Establish() => filter = new();
 
-    void Because() => result = filter.ShouldInclude("SomePack", Mock.Of<IConventionPack>(), typeof(TheType));
+    void Because() => result = filter.ShouldInclude("SomePack", Substitute.For<IConventionPack>(), typeof(TheType));
 
     [Fact] void should_not_include_it() => result.ShouldBeFalse();
 }

--- a/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_type_without_ignore_attribute.cs
+++ b/Source/DotNET/MongoDB.Specs/for_IgnoreConventionsAttributeFilter/when_asking_should_include_for_type_without_ignore_attribute.cs
@@ -15,7 +15,7 @@ public class when_asking_should_include_for_type_without_ignore_attribute : Spec
 
     void Establish() => filter = new();
 
-    void Because() => result = filter.ShouldInclude("SomePack", Mock.Of<IConventionPack>(), typeof(TheType));
+    void Because() => result = filter.ShouldInclude("SomePack", Substitute.For<IConventionPack>(), typeof(TheType));
 
     [Fact] void should_include_it() => result.ShouldBeTrue();
 }

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace MongoDB.Driver;
 /// <summary>
 /// Extension methods for <see cref="IMongoCollection{TDocument}"/>.
 /// </summary>
-public static class MongoDBCollectionExtensions
+public static class MongoCollectionExtensions
 {
     /// <summary>
     /// Find a single document based on Id.

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.Driver;
+
+#pragma warning disable MA0048 // File name must match type name
+
+internal static partial class MongoCollectionExtensionsLogMessages
+{
+    [LoggerMessage(LogLevel.Trace, "Cursor '{Name}' disposed")]
+    internal static partial void CursorDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger, string name);
+}

--- a/Source/DotNET/Swagger/CommandResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/CommandResultOperationFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using Cratis.Applications.Commands;
 using Cratis.Concepts;
 using Cratis.Reflection;
@@ -46,5 +47,23 @@ public class CommandResultOperationFilter(ISchemaGenerator schemaGenerator) : IO
         {
             response.Content.Add(new("application/json", new() { Schema = schema }));
         }
+
+        operation.Responses.Add(((int)HttpStatusCode.Forbidden).ToString(), new OpenApiResponse()
+        {
+            Description = "Forbidden",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                { "application/json", new OpenApiMediaType() { Schema = schema } }
+            }
+        });
+
+        operation.Responses.Add(((int)HttpStatusCode.BadRequest).ToString(), new OpenApiResponse()
+        {
+            Description = "Bad Request - typically a validation error",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                { "application/json", new OpenApiMediaType() { Schema = schema } }
+            }
+        });
     }
 }

--- a/Source/DotNET/Swagger/EnumSchemaFilter.cs
+++ b/Source/DotNET/Swagger/EnumSchemaFilter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Cratis.Applications.Swagger;
+
+/// <summary>
+/// Represents an implementation of <see cref="ISchemaFilter"/> that correctly provides the schema for enums as names instead of integers.
+/// </summary>
+public class EnumSchemaFilter : ISchemaFilter
+{
+    /// <inheritdoc/>
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type.IsEnum)
+        {
+            schema.Enum.Clear();
+            Enum.GetNames(context.Type)
+                .ToList()
+                .ForEach(name => schema.Enum.Add(new OpenApiString(name)));
+        }
+    }
+}

--- a/Source/DotNET/Swagger/Extensions.cs
+++ b/Source/DotNET/Swagger/Extensions.cs
@@ -18,6 +18,7 @@ public static class Extensions
     public static void AddConcepts(this SwaggerGenOptions options)
     {
         options.SchemaFilter<ConceptSchemaFilter>();
+        options.SchemaFilter<EnumSchemaFilter>();
         options.OperationFilter<CommandResultOperationFilter>();
         options.OperationFilter<QueryResultOperationFilter>();
     }

--- a/Source/DotNET/Swagger/QueryResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/QueryResultOperationFilter.cs
@@ -4,6 +4,7 @@
 using Cratis.Applications.Queries;
 using Cratis.Concepts;
 using Cratis.Reflection;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -21,13 +22,55 @@ public class QueryResultOperationFilter(ISchemaGenerator schemaGenerator) : IOpe
         if (!context.MethodInfo.IsQuery()) return;
 
         var returnType = context.MethodInfo.GetActualReturnType();
-
         if (returnType.IsConcept())
         {
             returnType = returnType.GetConceptValueType();
         }
 
         var queryResultType = typeof(QueryResult<>).MakeGenericType(returnType);
+
+        if (context.MethodInfo.ReturnType.IsEnumerable())
+        {
+            operation.Parameters.Add(new()
+            {
+                Name = QueryActionFilter.SortByQueryStringKey,
+                In = ParameterLocation.Query,
+                Description = "Sort by field name",
+                Required = false,
+                Schema = new() { Type = "string" }
+            });
+
+            operation.Parameters.Add(new()
+            {
+                Name = QueryActionFilter.SortDirectionQueryStringKey,
+                In = ParameterLocation.Query,
+                Required = false,
+                Description = "Sort direction",
+                Schema = new()
+                {
+                    Type = "string",
+                    Enum = [new OpenApiString("asc"), new OpenApiString("desc")]
+                }
+            });
+
+            operation.Parameters.Add(new()
+            {
+                Name = QueryActionFilter.PageSizeQueryStringKey,
+                In = ParameterLocation.Query,
+                Description = "Number of items to limit a page to",
+                Required = false,
+                Schema = new() { Type = "integer", Format = "int32" }
+            });
+
+            operation.Parameters.Add(new()
+            {
+                Name = QueryActionFilter.PageQueryStringKey,
+                In = ParameterLocation.Query,
+                Description = "Page number to show",
+                Required = false,
+                Schema = new() { Type = "integer", Format = "int32" }
+            });
+        }
 
         var schema = schemaGenerator.GenerateSchema(queryResultType, context.SchemaRepository);
         var response = operation.Responses.First().Value;

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -3,14 +3,51 @@
  *--------------------------------------------------------------------------------------------*/
 
 // eslint-disable-next-line header/header
+{{#if IsEnumerable}}
+import { ObservableQueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForObservableQuery, Paging } from '@cratis/applications/queries';
+import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage } from '@cratis/applications.react/queries';
+{{else}}
 import { ObservableQueryFor, QueryResultWithState } from '@cratis/applications/queries';
 import { useObservableQuery } from '@cratis/applications.react/queries';
+{{/if}}
 {{#Imports}}
 import { {{Type}} } from '{{Module}}';
 {{/Imports}}
 import Handlebars from 'handlebars';
 
 const routeTemplate = Handlebars.compile('{{{Route}}}');
+
+{{#if IsEnumerable}}
+class {{Name}}SortBy {
+{{#Properties}}
+    private _{{camelCase Name}}: SortingActionsForObservableQuery<{{../Model}}[]>;
+{{/Properties}}
+
+    constructor(readonly query: {{Name}}) {
+{{#Properties}}
+        this._{{camelCase Name}} = new SortingActionsForObservableQuery<{{../Model}}[]>('{{camelCase Name}}', query);
+{{/Properties}}
+    }
+
+{{#Properties}}
+    get {{camelCase Name}}(): SortingActionsForObservableQuery<{{../Model}}[]> {
+        return this._{{camelCase Name}};
+    }
+{{/Properties}}
+}
+
+class {{Name}}SortByWithoutQuery {
+{{#Properties}}
+    private _{{camelCase Name}}: SortingActions  = new SortingActions('{{camelCase Name}}');
+{{/Properties}}
+
+{{#Properties}}
+    get {{camelCase Name}}(): SortingActions {
+        return this._{{camelCase Name}};
+    }
+{{/Properties}}
+}
+{{/if}}
 
 {{#if Arguments.[0]}}
 export interface {{Name}}Arguments {
@@ -38,12 +75,17 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
     readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
 {{#if IsEnumerable}}
     readonly defaultValue: {{Model}}[] = [];
+    private readonly _sortBy: {{Name}}SortBy;
+    private static readonly _sortBy: {{Name}}SortByWithoutQuery = new {{Name}}SortByWithoutQuery();
 {{else}}
     readonly defaultValue: {{Model}} = {} as any;
 {{/if}}
 
     constructor() {
         super({{Model}}, {{lowercase IsEnumerable}});
+{{#if IsEnumerable}}        
+        this._sortBy = new {{Name}}SortBy(this);
+{{/if}}
     }
 
     get requestArguments(): string[] {
@@ -54,24 +96,34 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
         ];
     }
 
-{{#if Arguments.[0]}}
 {{#if IsEnumerable}}
-    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}[]>] {
-        return useObservableQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args);
+    get sortBy(): {{Name}}SortBy {
+        return this._sortBy;
     }
-{{else}}
-    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}>] {
-        return useObservableQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
+
+    static get sortBy(): {{Name}}SortByWithoutQuery {
+        return this._sortBy;
     }
 {{/if}}
-{{else}}
-{{#if IsEnumerable}}
-    static use(): [QueryResultWithState<{{Model}}[]>] {
-        return useObservableQuery<{{Model}}[], {{Name}}>({{Name}});
+
+{{#if Arguments.[0]}}
+    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>] {
+        return useObservableQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args, sorting);
     }
+{{#if IsEnumerable}}
+
+    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage] {
+        return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
+    }
+{{/if}}    
 {{else}}
-    static use(): [QueryResultWithState<{{Model}}>] {
-        return useObservableQuery<{{Model}}, {{Name}}>({{Name}});
+    static use(sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting] {
+        return useObservableQuery<{{Model}}[], {{Name}}>({{Name}}, undefined, sorting);
+    }
+{{#if IsEnumerable}}
+
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage] {
+        return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
     }
 {{/if}}
 {{/if}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line header/header
 {{#if IsEnumerable}}
-import { QueryFor, QueryResultWithState, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
+import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
 import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage } from '@cratis/applications.react/queries';
 {{else}}
 import { QueryFor, QueryResultWithState } from '@cratis/applications/queries';
@@ -47,7 +47,6 @@ class {{Name}}SortByWithoutQuery {
     }
 {{/Properties}}
 }
-
 {{/if}}
 
 {{#if Arguments.[0]}}
@@ -109,31 +108,23 @@ export class {{Name}} extends QueryFor<{{Model}}> {
 {{/if}}
 
 {{#if Arguments.[0]}}
+    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery<{{Name}}Arguments>] {
+        return useQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args, sorting);
+    }
 {{#if IsEnumerable}}
-    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}[]>, PerformQuery<{{Name}}Arguments>] {
-        return useQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args);
-    }
 
-    static useWithPaging(pageSize: number, args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
-        return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args);
-    }
-{{else}}
-    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}>, PerformQuery<{{Name}}Arguments>] {
-        return useQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
+    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
+        return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
     }
 {{/if}}
 {{else}}
+    static use(sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery, SetSorting] {
+        return useQuery<{{Model}}[], {{Name}}>({{Name}}, undefined, sorting);
+    }
 {{#if IsEnumerable}}
-    static use(): [QueryResultWithState<{{Model}}[]>, PerformQuery, SetSorting] {
-        return useQuery<{{Model}}[], {{Name}}>({{Name}});
-    }
 
-    static useWithPaging(pageSize: number): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
-        return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize));
-    }
-{{else}}
-    static use(): [QueryResultWithState<{{Model}}>, PerformQuery, SetSorting] {
-        return useQuery<{{Model}}, {{Name}}>({{Name}});
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
+        return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
     }
 {{/if}}
 {{/if}}

--- a/Source/JavaScript/Applications.React/queries/SetPage.ts
+++ b/Source/JavaScript/Applications.React/queries/SetPage.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Delegate type for setting the page in the context of the {@link useQueryWithPaging} or {@link useObservableQueryWithPaging} hooks.
+ */
+export type SetPage = (page: number) => Promise<void>;

--- a/Source/JavaScript/Applications.React/queries/SetSorting.ts
+++ b/Source/JavaScript/Applications.React/queries/SetSorting.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Sorting } from '@cratis/applications/queries';
+
+/**
+ * Delegate type for setting the sorting in the context of the {@link useQuery}, {@link useQueryWithPaging}, {@link useObservableQuery} or {@link useObservableQueryWithPaging} hooks.
+ */
+export type SetSorting = (sorting: Sorting) => Promise<void>;

--- a/Source/JavaScript/Applications.React/queries/index.ts
+++ b/Source/JavaScript/Applications.React/queries/index.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './SetPage';
+export * from './SetSorting';
 export * from './useObservableQuery';
 export * from './useQuery';

--- a/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
@@ -1,20 +1,21 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { QueryResultWithState, IObservableQueryFor, QueryResult } from '@cratis/applications/queries';
+import { QueryResultWithState, IObservableQueryFor, QueryResult, Sorting, Paging, ObservableQuerySubscription } from '@cratis/applications/queries';
 import { Constructor } from '@cratis/fundamentals';
 import { useState, useEffect } from 'react';
+import { SetSorting } from './SetSorting';
+import { SetPage } from './SetPage';
 
-/**
- * React hook for working with {@link IObservableQueryFor} within the state management of React.
- * @template TDataType Type of model the query is for.
- * @template TQuery Type of observable query to use.
- * @template TArguments Optional: Arguments for the query, if any
- * @param query Query type constructor.
- * @returns Tuple of {@link QueryResult} and a {@link PerformQuery} delegate.
- */
-export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments): [QueryResultWithState<TDataType>] {
+
+function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, sorting?: Sorting, paging?: Paging, args?: TArguments):
+    [QueryResultWithState<TDataType>, SetSorting, SetPage] {
+    const [currentPaging, setCurrentPaging] = useState<Paging>(paging ?? Paging.noPaging);
+    const [currentSorting, setCurrentSorting] = useState<Sorting>(sorting ?? Sorting.none);
     const queryInstance = new query() as TQuery;
+    queryInstance.paging = currentPaging;
+    queryInstance.sorting = currentSorting;
+
     const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.empty(queryInstance.defaultValue));
     const argumentsDependency = queryInstance.requestArguments.map(_ => args?.[_]);
 
@@ -23,8 +24,47 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
             setResult(QueryResultWithState.fromQueryResult(response, false));
         }, args as any);
 
-        return () => subscription.unsubscribe();
-    }, argumentsDependency);
+        return () => {
+            subscription.unsubscribe();
+        };
+    }, [...argumentsDependency, ...[currentPaging, currentSorting]]);
 
-    return [result];
+    return [
+        result,
+        async (sorting: Sorting) => {
+            setCurrentSorting(sorting);
+        },
+        async (page: number) => {
+            setCurrentPaging({ page, pageSize: currentPaging.pageSize });
+        }];
+}
+
+/**
+ * React hook for working with {@link IObservableQueryFor} within the state management of React.
+ * @template TDataType Type of model the query is for.
+ * @template TQuery Type of observable query to use.
+ * @template TArguments Optional: Arguments for the query, if any
+ * @param query Query type constructor.
+ * @param args Optional: Arguments for the query, if any
+ * @returns Tuple of {@link QueryResult} and a {@link PerformQuery} delegate.
+ */
+export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting):
+    [QueryResultWithState<TDataType>, SetSorting] {
+    const [result, setSorting, _] = useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, Paging.noPaging, args);
+    return [result, setSorting];
+}
+
+/**
+ * React hook for working with {@link IObservableQueryFor} within the state management of React for queries with paging.
+ * @template TDataType Type of model the query is for.
+ * @template TQuery Type of observable query to use.
+ * @template TArguments Optional: Arguments for the query, if any
+ * @param query Query type constructor.
+ * @param args Optional: Arguments for the query, if any
+ * @param paging Paging information.
+ * @returns Tuple of {@link QueryResult} and a {@link PerformQuery} delegate.
+ */
+export function useObservableQueryWithPaging<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting):
+    [QueryResultWithState<TDataType>, SetSorting, SetPage] {
+    return useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, paging, args);
 }

--- a/Source/JavaScript/Applications/queries/IObservableQueryConnection.ts
+++ b/Source/JavaScript/Applications/queries/IObservableQueryConnection.ts
@@ -10,8 +10,9 @@ export interface IObservableQueryConnection<TDataType> {
     /**
      * Connect to a specific route.
      * @param {DataReceived<TDataType> dataReceived Callback that will receive the data.
+     * @param queryArguments Optional query arguments to pass along.
      */
-    connect(dataReceived: DataReceived<TDataType>);
+    connect(dataReceived: DataReceived<TDataType>, queryArguments?: any): void;
 
     /**
      * Disconnect the connection.

--- a/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
@@ -4,6 +4,8 @@
 import Handlebars from 'handlebars';
 import { ObservableQuerySubscription } from './ObservableQuerySubscription';
 import { QueryResult } from './QueryResult';
+import { Paging } from './Paging';
+import { Sorting } from './Sorting';
 
 /**
  * The delegate type representing the callback of result from the server.
@@ -20,6 +22,26 @@ export interface IObservableQueryFor<TDataType, TArguments = {}> {
     readonly routeTemplate: Handlebars.TemplateDelegate;
     readonly requestArguments: string[];
     readonly defaultValue: TDataType;
+
+    /**
+     * Gets the sorting for the query.
+     */
+    get sorting(): Sorting;
+
+    /**
+     * Sets the sorting for the query.
+     */
+    set sorting(value: Sorting);
+
+    /**
+     * Gets the paging for the query.
+     */
+    get paging(): Paging | undefined;
+
+    /**
+     * Sets the paging for the query.
+     */ 
+    set paging(value: Paging);
 
     /**
      * Subscribe to the query. This will create a subscription onto the server.

--- a/Source/JavaScript/Applications/queries/Paging.ts
+++ b/Source/JavaScript/Applications/queries/Paging.ts
@@ -7,6 +7,11 @@
 export class Paging {
 
     /**
+     * No paging.
+     */
+    static noPaging: Paging = new Paging(0, 0);
+
+    /**
      * Initializes a new instance of {@link Paging}.
      */
     constructor(page?: number, pageSize?: number) {

--- a/Source/JavaScript/Applications/queries/SortingActionsForObservableQuery.ts
+++ b/Source/JavaScript/Applications/queries/SortingActionsForObservableQuery.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IObservableQueryFor } from './IObservableQueryFor';
+import { SortDirection } from './SortDirection';
+import { Sorting } from './Sorting';
+
+/**
+ * Represents sorting for an observable query.
+ */
+export class SortingActionsForObservableQuery<TDataType, TArguments = {}> {
+
+    /**
+     * Initializes a new instance of {@link SortingActionsForQuery}.
+     * @param {string} field The field that the sorting represents.
+     * @param {IQueryFor<TDataType, TArguments>} query The query that holds the field.
+     */
+    constructor(readonly field: string, readonly query: IObservableQueryFor<TDataType, TArguments>) {
+    }
+
+    /**
+      * Instructs query to sort ascending for the field.
+      */
+    ascending(): Sorting {
+        this.query.sorting = new Sorting(this.field, SortDirection.ascending);
+        return this.query.sorting;
+    }
+
+    /**
+      * Instructs query to sort ascending for the field.
+      */
+    descending(): Sorting {
+        this.query.sorting = new Sorting(this.field, SortDirection.descending);
+        return this.query.sorting;
+    }
+}

--- a/Source/JavaScript/Applications/queries/index.ts
+++ b/Source/JavaScript/Applications/queries/index.ts
@@ -7,6 +7,7 @@ export * from './Sorting';
 export * from './SortDirection';
 export * from './SortingActions';
 export * from './SortingActionsForQuery';
+export * from './SortingActionsForObservableQuery';
 export * from './QueryFor';
 export * from './QueryResult';
 export * from './QueryResultWithState';


### PR DESCRIPTION
### Added

- Support for paging and sorting as a frontend concern for observable queries. This includes all the way from the proxy generators and down into the backend implementation for MongoDB.
- Added visibility of query parameters related to sorting and paging, seeing that they're automatically handled as a separate concern.
- Adding error codes to Swagger definitions for Commands and Queries.

### Changed

- `MongoCollectionExtensions` convenience methods for observing mongo collections are now returning `ISubject<>` instead of `Task<ISubject<>>`. The reason for this is that `ISubject<>` as a construct can be created synchronously and we now instead run the actual query and the Mongo Watch in a separate task that calls `OnNext()` on the subject.
- Swagger schema filter added that will now show enums as string names, rather than integer values. The JSON serializer should support deserializing enums as strings.

### Fixed

- Migrated from Moq to NSubstitute