### PR TITLE
Feature/state-extensions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.1" />
-    <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="1.0.0" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.9.5" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.9.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,14 +29,14 @@
     <PackageVersion Include="polly.core" Version="8.3.1" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <!-- Orleans -->
-    <PackageVersion Include="Microsoft.Orleans.SDK" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="8.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="8.1.0" />
-    <PackageVersion Include="OrleansTestKit" Version="8.1.0" />
-    <PackageVersion Include="OrleansDashboard" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Orleans.SDK" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Runtime" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Serialization" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="8.2.0" />
+    <PackageVersion Include="OrleansTestKit" Version="8.2.0" />
+    <PackageVersion Include="OrleansDashboard" Version="8.2.0" />
     <!-- Roslyn-->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,10 +38,10 @@
     <PackageVersion Include="OrleansTestKit" Version="8.2.0" />
     <PackageVersion Include="OrleansDashboard" Version="8.2.0" />
     <!-- Roslyn-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
     <!-- Analysis -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.10.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.2" />

--- a/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line header/header
 import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
-import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage } from '@cratis/applications.react/queries';
+import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 import { Product } from './Product';
 import Handlebars from 'handlebars';
 
@@ -77,7 +77,7 @@ export class AllProducts extends QueryFor<Product[]> {
         return useQuery<Product[], AllProducts>(AllProducts, undefined, sorting);
     }
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, number, PerformQuery, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<Product[], AllProducts>(AllProducts, new Paging(0, pageSize), undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line header/header
 import { ObservableQueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForObservableQuery, Paging } from '@cratis/applications/queries';
-import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage } from '@cratis/applications.react/queries';
+import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 import { Product } from './Product';
 import Handlebars from 'handlebars';
 
@@ -77,7 +77,7 @@ export class ObserveAllProducts extends ObservableQueryFor<Product[]> {
         return useObservableQuery<Product[], ObserveAllProducts>(ObserveAllProducts, undefined, sorting);
     }
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, SetSorting, SetPage, SetPageSize] {
         return useObservableQueryWithPaging<Product[], ObserveAllProducts>(ObserveAllProducts, new Paging(0, pageSize), undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/Catalog.tsx
+++ b/Samples/eCommerce/Basic/Web/Catalog.tsx
@@ -10,24 +10,28 @@ import { useEffect, useState } from 'react';
 import { SortDirection, Sorting } from '@cratis/applications/queries';
 
 export const Catalog = withViewModel(CatalogViewModel, ({ viewModel }) => {
-    const [pageSize, setPageSize] = useState(10);
-    // // const [products, currentPage, perform, setSorting, setPage] = AllProducts.useWithPaging(pageSize);
-    const [observableProducts, setSorting, setPage] = ObserveAllProducts.useWithPaging(10);
+    // // const [products, perform, setSorting, setPage] = AllProducts.useWithPaging(pageSize);
+    const [observableProducts, setSorting, setPage, setPageSize] = ObserveAllProducts.useWithPaging(10);
     const [descending, setDescending] = useState(false);
     const [currentPage, setCurrentPage] = useState(0);
 
     return (
         <div>
-            <div>Page {currentPage + 1}</div>
+            <div>Page {currentPage + 1} of {observableProducts.paging.totalPages}</div>
             <DataTable value={observableProducts.data}>
                 <Column field="id" header="SKU" />
                 <Column field="name" header="Name" />
             </DataTable>
+            Total items: {observableProducts.paging.totalItems}
+            <br />
 
             <button onClick={() => {
                 setCurrentPage(currentPage - 1);
                 setPage(currentPage - 1);
             }}>Previous page</button>
+
+            &nbsp;
+            &nbsp;
 
             <button onClick={() => {
                 setCurrentPage(currentPage + 1);
@@ -36,8 +40,10 @@ export const Catalog = withViewModel(CatalogViewModel, ({ viewModel }) => {
             <br />
 
             <button onClick={() => {
-                setPage(20);
+                setPageSize(20);
             }}>More stuff</button>
+
+            &nbsp;
 
             <button onClick={() => {
                 if (descending) {

--- a/Source/DotNET/Applications/Queries/ClientObservable.cs
+++ b/Source/DotNET/Applications/Queries/ClientObservable.cs
@@ -16,9 +16,13 @@ namespace Cratis.Applications.Queries;
 /// <remarks>
 /// Initializes a new instance of the <see cref="ClientObservable{T}"/> class.
 /// </remarks>
+/// <param name="queryContext">The <see cref="QueryContext"/> the observable is for.</param>
 /// <param name="subject">The <see cref="ISubject{T}"/> the observable wraps.</param>
 /// <param name="jsonOptions">The <see cref="JsonOptions"/>.</param>
-public class ClientObservable<T>(ISubject<T> subject, JsonOptions jsonOptions) : IClientObservable, IAsyncEnumerable<T>
+public class ClientObservable<T>(
+    QueryContext queryContext,
+    ISubject<T> subject,
+    JsonOptions jsonOptions) : IClientObservable, IAsyncEnumerable<T>
 {
     /// <summary>
     /// Notifies all subscribed and future observers about the arrival of the specified element in the sequence.
@@ -37,6 +41,11 @@ public class ClientObservable<T>(ISubject<T> subject, JsonOptions jsonOptions) :
 #pragma warning disable MA0147 // Avoid async void method for delegate
         subscription = subject.Subscribe(async _ =>
         {
+            queryResult.Paging = new(
+                queryContext.Paging.Page,
+                queryContext.Paging.Size,
+                queryContext.TotalItems);
+
             queryResult.Data = _!;
 
             try

--- a/Source/DotNET/Applications/Queries/Paging.cs
+++ b/Source/DotNET/Applications/Queries/Paging.cs
@@ -23,14 +23,7 @@ public record Paging
     {
         if (isPaged)
         {
-            if (page < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(page), "Page number must be greater or equal to 0");
-            }
-            if (size <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(size), "Page size must be greater than 0");
-            }
+            Validate(page, size);
         }
         Page = page;
         Size = size;
@@ -56,4 +49,16 @@ public record Paging
     /// Gets the number of items to skip.
     /// </summary>
     public int Skip => Page * Size;
+
+    void Validate(int page, int size)
+    {
+        if (page < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(page), "Page number must be greater or equal to 0");
+        }
+        if (size <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), "Page size must be greater than 0");
+        }
+    }
 }

--- a/Source/DotNET/Applications/Queries/PagingInfo.cs
+++ b/Source/DotNET/Applications/Queries/PagingInfo.cs
@@ -9,11 +9,15 @@ namespace Cratis.Applications.Queries;
 /// <param name="Page">The page number.</param>
 /// <param name="Size">The size of the page.</param>
 /// <param name="TotalItems">The total number of items.</param>
-/// <param name="TotalPages">The total number of pages.</param>
-public record PagingInfo(int Page, int Size, int TotalItems, int TotalPages)
+public record PagingInfo(int Page, int Size, long TotalItems)
 {
     /// <summary>
     /// Represents a not paged result.
     /// </summary>
-    public static readonly PagingInfo NotPaged = new(0, 0, 0, 0);
+    public static readonly PagingInfo NotPaged = new(0, 0, 0);
+
+    /// <summary>
+    /// Gets the total number of pages.
+    /// </summary>
+    public int TotalPages => Size == 0 ? 0 : (int)Math.Ceiling((double)TotalItems / Size);
 }

--- a/Source/DotNET/Applications/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/Applications/Queries/QueryActionFilter.cs
@@ -112,8 +112,7 @@ public class QueryActionFilter(
                     Paging = queryContext.Paging == Paging.NotPaged ? PagingInfo.NotPaged : new PagingInfo(
                         queryContext.Paging.Page,
                         queryContext.Paging.Size,
-                        response.TotalItems,
-                        response.TotalItems / queryContext.Paging.Size),
+                        response.TotalItems),
                     CorrelationId = context.HttpContext.GetCorrelationId(),
                     ValidationResults = context.ModelState.SelectMany(_ => _.Value!.Errors.Select(p => p.ToValidationResult(_.Key.ToCamelCase()))),
                     ExceptionMessages = callResult.ExceptionMessages,
@@ -188,7 +187,7 @@ public class QueryActionFilter(
         var type = objectResult.Value!.GetType();
         var subjectType = type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(ISubject<>));
         var clientObservableType = typeof(ClientObservable<>).MakeGenericType(subjectType.GetGenericArguments()[0]);
-        return (Activator.CreateInstance(clientObservableType, objectResult.Value, _options) as IClientObservable)!;
+        return (Activator.CreateInstance(clientObservableType, queryContextManager.Current, objectResult.Value, _options) as IClientObservable)!;
     }
 
     bool IsStreamingResult(ObjectResult objectResult) => IsAsyncEnumerableResult(objectResult) || IsSubjectResult(objectResult);

--- a/Source/DotNET/Applications/Queries/QueryContext.cs
+++ b/Source/DotNET/Applications/Queries/QueryContext.cs
@@ -11,4 +11,10 @@ namespace Cratis.Applications.Queries;
 /// <param name="CorrelationId">The <see cref="CorrelationId"/> for the query.</param>
 /// <param name="Paging">The <see cref="Paging"/> information.</param>
 /// <param name="Sorting">The <see cref="Sorting"/> information.</param>
-public record QueryContext(CorrelationId CorrelationId, Paging Paging, Sorting Sorting);
+public record QueryContext(CorrelationId CorrelationId, Paging Paging, Sorting Sorting)
+{
+    /// <summary>
+    /// Gets the total number of items in the query.
+    /// </summary>
+    public long TotalItems { get; set; }
+}

--- a/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
@@ -27,7 +27,7 @@ public class MongoClientInterceptorSelector(
     {
         if (method.Name == nameof(IMongoClient.GetDatabase))
         {
-            return new[] { new MongoClientInterceptor(proxyGenerator, resiliencePipeline, mongoClient) };
+            return [new MongoClientInterceptor(proxyGenerator, resiliencePipeline, mongoClient)];
         }
         return [];
     }

--- a/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorForReturnValues.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorForReturnValues.cs
@@ -69,7 +69,7 @@ public class MongoCollectionInterceptorForReturnValues(
             catch (Exception ex)
             {
                 openConnectionSemaphore.Release(1);
-                setExceptionMethod.Invoke(tcs, new[] { ex });
+                setExceptionMethod.Invoke(tcs, [ex]);
             }
 
             return ValueTask.CompletedTask;

--- a/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorSelector.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorSelector.cs
@@ -30,10 +30,10 @@ public class MongoCollectionInterceptorSelector(
         {
             if (method.ReturnType.IsGenericType)
             {
-                return new[] { new MongoCollectionInterceptorForReturnValues(resiliencePipeline, semaphore) };
+                return [new MongoCollectionInterceptorForReturnValues(resiliencePipeline, semaphore)];
             }
 
-            return new[] { new MongoCollectionInterceptor(resiliencePipeline, semaphore) };
+            return [new MongoCollectionInterceptor(resiliencePipeline, semaphore)];
         }
         return [];
     }

--- a/Source/DotNET/MongoDB/Resilience/MongoDatabaseInterceptorSelector.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoDatabaseInterceptorSelector.cs
@@ -27,7 +27,7 @@ public class MongoDatabaseInterceptorSelector(
     {
         if (method.Name == nameof(IMongoDatabase.GetCollection))
         {
-            return new[] { new MongoDatabaseInterceptor(proxyGenerator, resiliencePipeline, mongoClient) };
+            return [new MongoDatabaseInterceptor(proxyGenerator, resiliencePipeline, mongoClient)];
         }
         return [];
     }

--- a/Source/DotNET/Orleans.MongoDB/MongoDBGrainStorage.cs
+++ b/Source/DotNET/Orleans.MongoDB/MongoDBGrainStorage.cs
@@ -4,7 +4,6 @@
 using Cratis.Applications.MongoDB;
 using Cratis.Concepts;
 using MongoDB.Driver;
-using Orleans.Runtime;
 using Orleans.Storage;
 
 namespace Cratis.Applications.Orleans.MongoDB;

--- a/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_activating/with_unknown_current_state.cs
+++ b/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_activating/with_unknown_current_state.cs
@@ -7,7 +7,7 @@ public class with_unknown_current_state : given.a_state_machine
 {
     Exception exception;
 
-    protected override IEnumerable<IState<StateMachineStateForTesting>> CreateStates() => new[] { new StateThatSupportsTransitioningFrom() };
+    protected override IEnumerable<IState<StateMachineStateForTesting>> CreateStates() => [new StateThatSupportsTransitioningFrom()];
 
     void Establish()
     {

--- a/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_activating/with_valid_initial_state_type.cs
+++ b/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_activating/with_valid_initial_state_type.cs
@@ -8,7 +8,7 @@ public class with_valid_initial_state_type : given.a_state_machine
     Exception exception;
 
     protected override Type initial_state => typeof(StateThatSupportsTransitioningFrom);
-    protected override IEnumerable<IState<StateMachineStateForTesting>> CreateStates() => new[] { new StateThatSupportsTransitioningFrom() };
+    protected override IEnumerable<IState<StateMachineStateForTesting>> CreateStates() => [new StateThatSupportsTransitioningFrom()];
 
     async Task Because() => exception = await Catch.Exception(async () => await state_machine.OnActivateAsync(CancellationToken.None));
 

--- a/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_transitioning/and_state_can_be_transitioned_to.cs
+++ b/Source/DotNET/Orleans.Specs/StateMachines/for_StateMachine/when_transitioning/and_state_can_be_transitioned_to.cs
@@ -33,8 +33,8 @@ public class and_state_can_be_transitioned_to : given.a_state_machine_with_well_
     [Fact] void should_write_state_once() => silo.StorageStats<StateMachineForTesting, StateMachineStateForTesting>().Writes.ShouldEqual(1);
     [Fact] void should_write_current_state() => state_storage.State.CurrentState.ShouldEqual(typeof(StateThatDoesNotSupportTransitioningFrom).FullName);
     [Fact] void should_write_state_coming_from_on_enter() => state_storage.State.ShouldEqual(state_that_does_not_support_transitioning.StateToReturnOnEnter);
-    [Fact] void should_call_on_before_entering_state_for_state_entered() => state_machine.OnBeforeEnteringStates.ShouldContainOnly(new[] { state_that_does_not_support_transitioning });
-    [Fact] void should_call_on_after_entering_state_for_state_entered() => state_machine.OnAfterEnteringStates.ShouldContainOnly(new[] { state_that_does_not_support_transitioning });
-    [Fact] void should_call_on_before_leaving_state_for_state_entered() => state_machine.OnBeforeLeavingStates.ShouldContainOnly(new[] { state_that_supports_transitioning });
-    [Fact] void should_call_on_after_leaving_state_for_state_entered() => state_machine.OnAfterLeavingStates.ShouldContainOnly(new[] { state_that_supports_transitioning });
+    [Fact] void should_call_on_before_entering_state_for_state_entered() => state_machine.OnBeforeEnteringStates.ShouldContainOnly([state_that_does_not_support_transitioning]);
+    [Fact] void should_call_on_after_entering_state_for_state_entered() => state_machine.OnAfterEnteringStates.ShouldContainOnly([state_that_does_not_support_transitioning]);
+    [Fact] void should_call_on_before_leaving_state_for_state_entered() => state_machine.OnBeforeLeavingStates.ShouldContainOnly([state_that_supports_transitioning]);
+    [Fact] void should_call_on_after_leaving_state_for_state_entered() => state_machine.OnAfterLeavingStates.ShouldContainOnly([state_that_supports_transitioning]);
 }

--- a/Source/DotNET/Orleans/StateMachines/StateExtensions.cs
+++ b/Source/DotNET/Orleans/StateMachines/StateExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.Orleans.StateMachines;
+
+/// <summary>
+/// Extension methods for working with states in the context of testing.
+/// </summary>
+public static class StateExtensions
+{
+    /// <summary>
+    /// Set the state machine for a state.
+    /// </summary>
+    /// <param name="state">State to set it for.</param>
+    /// <param name="stateMachine">The state machine to set.</param>
+    /// <typeparam name="TStoredState">Type of stored state.</typeparam>
+    /// <exception cref="NotImplementedException">Thrown when this method is called.</exception>
+    public static void SetStateMachine<TStoredState>(this State<TStoredState> state, IStateMachine<TStoredState> stateMachine)
+        where TStoredState : class
+    {
+        state._stateMachine = stateMachine;
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -5,7 +5,7 @@
 // eslint-disable-next-line header/header
 {{#if IsEnumerable}}
 import { ObservableQueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForObservableQuery, Paging } from '@cratis/applications/queries';
-import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage } from '@cratis/applications.react/queries';
+import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 {{else}}
 import { ObservableQueryFor, QueryResultWithState } from '@cratis/applications/queries';
 import { useObservableQuery } from '@cratis/applications.react/queries';
@@ -112,7 +112,7 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
     }
 {{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage, SetPageSize] {
         return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
     }
 {{/if}}    
@@ -122,7 +122,7 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
     }
 {{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage, SetPageSize] {
         return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
     }
 {{/if}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -5,7 +5,7 @@
 // eslint-disable-next-line header/header
 {{#if IsEnumerable}}
 import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
-import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage } from '@cratis/applications.react/queries';
+import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 {{else}}
 import { QueryFor, QueryResultWithState } from '@cratis/applications/queries';
 import { useQuery, PerformQuery, SetSorting} from '@cratis/applications.react/queries';
@@ -113,7 +113,7 @@ export class {{Name}} extends QueryFor<{{Model}}> {
     }
 {{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
     }
 {{/if}}
@@ -123,7 +123,7 @@ export class {{Name}} extends QueryFor<{{Model}}> {
     }
 {{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
     }
 {{/if}}

--- a/Source/JavaScript/Applications.React/queries/SetPageSize.ts
+++ b/Source/JavaScript/Applications.React/queries/SetPageSize.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Delegate type for setting the page size in the context of the {@link useQueryWithPaging} or {@link useObservableQueryWithPaging} hooks.
+ */
+export type SetPageSize = (pageSize: number) => Promise<void>;

--- a/Source/JavaScript/Applications.React/queries/index.ts
+++ b/Source/JavaScript/Applications.React/queries/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './SetPage';
+export * from './SetPageSize';
 export * from './SetSorting';
 export * from './useObservableQuery';
 export * from './useQuery';

--- a/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
@@ -6,10 +6,10 @@ import { Constructor } from '@cratis/fundamentals';
 import { useState, useEffect } from 'react';
 import { SetSorting } from './SetSorting';
 import { SetPage } from './SetPage';
-
+import { SetPageSize } from './SetPageSize';
 
 function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, sorting?: Sorting, paging?: Paging, args?: TArguments):
-    [QueryResultWithState<TDataType>, SetSorting, SetPage] {
+    [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize] {
     const [currentPaging, setCurrentPaging] = useState<Paging>(paging ?? Paging.noPaging);
     const [currentSorting, setCurrentSorting] = useState<Sorting>(sorting ?? Sorting.none);
     const queryInstance = new query() as TQuery;
@@ -36,6 +36,9 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         },
         async (page: number) => {
             setCurrentPaging({ page, pageSize: currentPaging.pageSize });
+        },
+        async (pageSize: number) => {
+            setCurrentPaging({ page: currentPaging.page, pageSize });
         }];
 }
 
@@ -65,6 +68,6 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
  * @returns Tuple of {@link QueryResult} and a {@link PerformQuery} delegate.
  */
 export function useObservableQueryWithPaging<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = {}>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting):
-    [QueryResultWithState<TDataType>, SetSorting, SetPage] {
+    [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize] {
     return useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, paging, args);
 }


### PR DESCRIPTION
### Added

- Extension method for setting `StateMachine` on a `State` in Orleans. This is primarily to support automated test scenarios.
- Adding `SetPageSize` as a return value from `useWithPaging()` hooks.

## Changes

- With version 12.0.0 there was supposed to be a breaking change for `useWithPaging()` on regular queries - since its just a few hours since release, decided not to do a major release for this change. `useWithPaging()` will not return explicitly `page` in the tupple. This value is already on the result itself in the `paging` property. This contains all the information about the current state of paging.

### Fixed

- Upgraded all Orleans packages to version 8.2.0.
- Fixing so that we have correct `totalItems` on paging info for observable queries.
