### PR TITLE
Fixing total items properly by creating a unique base query for counting

### DIFF
--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -207,9 +207,9 @@ public static class MongoCollectionExtensions
         {
             try
             {
+                var baseQuery = findCall();
                 var query = findCall();
                 await UpdateTotalItems(queryContext, query);
-                var baseQuery = query;
 
                 query = AddSorting(queryContext, query);
                 query = AddPaging(queryContext, query);


### PR DESCRIPTION
### Fixed

- Fixing and verifying that the `totalItems` count now is accurate for the `MongoCollectionExtensions`. It was reusing the query with paging still and ended up showing wrong on subsequent changes for typically `insert`, `delete` change stream operation types.
