### PR TITLE
Fixing so we load assemblies once

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/FileNameComparer.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/FileNameComparer.cs
@@ -3,13 +3,15 @@
 
 namespace Cratis.Applications.ProxyGenerator;
 
+#pragma warning disable RCS1241 // Implement IEqualityComparer when implementing IEqualityComparer<T>
+
 /// <summary>
 /// Represents a comparer for file names.
 /// </summary>
 public class FileNameComparer : IEqualityComparer<string>
 {
     /// <inheritdoc/>
-    public bool Equals(string x, string y)
+    public bool Equals(string? x, string? y)
     {
         if (x == null || y == null)
             return false;

--- a/Source/DotNET/Tools/ProxyGenerator/FileNameComparer.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/FileNameComparer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.ProxyGenerator;
+
+/// <summary>
+/// Represents a comparer for file names.
+/// </summary>
+public class FileNameComparer : IEqualityComparer<string>
+{
+    /// <inheritdoc/>
+    public bool Equals(string x, string y)
+    {
+        if (x == null || y == null)
+            return false;
+
+        return StringComparer.OrdinalIgnoreCase.Equals(Path.GetFileName(x), Path.GetFileName(y));
+    }
+
+    /// <inheritdoc/>
+    public int GetHashCode(string obj)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(Path.GetFileName(obj));
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -71,7 +71,7 @@ public static class TypeExtensions
 
     static readonly Dictionary<string, Assembly> _assembliesByName = [];
 
-    static PathAssemblyResolver? _assemblyResolver;
+    static MetadataAssemblyResolver? _assemblyResolver;
     static MetadataLoadContext? _metadataLoadContext;
 
     /// <summary>
@@ -114,7 +114,9 @@ public static class TypeExtensions
         var appAssemblies = Directory.GetFiles(assemblyFolder, "*.dll");
         string[] paths = [.. runtimeAssemblies, .. aspNetCoreAssemblies, .. appAssemblies];
 
-        _assemblyResolver = new PathAssemblyResolver(paths);
+        var filtered = paths.Distinct(new FileNameComparer()).ToArray();
+
+        _assemblyResolver = new PathAssemblyResolver(filtered);
 #pragma warning disable CA2000 // Dispose objects before losing scope
         _metadataLoadContext = new MetadataLoadContext(_assemblyResolver);
 #pragma warning restore CA2000 // Dispose objects before losing scope


### PR DESCRIPTION
### Fixed

- Fixes the ProxyGenerator to not fall over if the same assembly exists from the paths it uses during startup.
