### PR TITLE
Fix/minor-proxy-generator-bugs

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -94,6 +94,7 @@ dotnet_diagnostic.SA1501.severity = none
 dotnet_diagnostic.SA1503.severity = none
 dotnet_diagnostic.SA1513.severity = none
 dotnet_diagnostic.SA1516.severity = none
+dotnet_diagnostic.SA1518.severity = none
 dotnet_diagnostic.SA1601.severity = none
 dotnet_diagnostic.SA1623.severity = none
 dotnet_diagnostic.SA1633.severity = none

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,9 +25,11 @@
             "cwd": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator",
             "program": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator/bin/Debug/net8.0/Cratis.Applications.ProxyGenerator.dll",
             "args": [
-                "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
-                "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
-                "1"
+                "/Volumes/Code/Cratis/Chronicle/Source/Api/bin/Debug/net8.0/Cratis.Chronicle.Api.dll",
+                "/Volumes/Code/Cratis/Chronicle/Source/Workbench/Api",
+                // "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
+                // "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
+                "2"
             ],
             "stopAtEntry": false,
             "env": {

--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -64,6 +64,8 @@ public static class CommandExtensions
             property.CollectTypesInvolved(additionalTypesInvolved);
         }
 
+        imports = imports.Distinct().ToList();
+
         return new(
             method.DeclaringType!,
             method,

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -107,23 +107,33 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
 {{/if}}
 
 {{#if Arguments.[0]}}
-    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>] {
+{{#if IsEnumerable}}
+    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting] {
         return useObservableQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args, sorting);
     }
-{{#if IsEnumerable}}
 
     static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage, SetPageSize] {
         return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
     }
+{{else}}
+    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}>] {
+        const [result] = useObservableQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
+        return result;
+    }
 {{/if}}    
 {{else}}
+{{#if IsEnumerable}}
     static use(sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting] {
         return useObservableQuery<{{Model}}[], {{Name}}>({{Name}}, undefined, sorting);
     }
-{{#if IsEnumerable}}
 
     static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, SetSorting, SetPage, SetPageSize] {
         return useObservableQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
+    }
+{{else}}
+    static use(): [QueryResultWithState<{{Model}}>] {
+        const [result] = useObservableQuery<{{Model}}, {{Name}}>({{Name}});
+        return result;
     }
 {{/if}}
 {{/if}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -8,7 +8,7 @@ import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActions
 import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 {{else}}
 import { QueryFor, QueryResultWithState } from '@cratis/applications/queries';
-import { useQuery, PerformQuery, SetSorting} from '@cratis/applications.react/queries';
+import { useQuery, PerformQuery } from '@cratis/applications.react/queries';
 {{/if}}
 {{#Imports}}
 import { {{Type}} } from '{{Module}}';
@@ -108,23 +108,33 @@ export class {{Name}} extends QueryFor<{{Model}}> {
 {{/if}}
 
 {{#if Arguments.[0]}}
-    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery<{{Name}}Arguments>] {
+{{#if IsEnumerable}}
+    static use(args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery<{{Name}}Arguments>, SetSorting] {
         return useQuery<{{Model}}[], {{Name}}, {{Name}}Arguments>({{Name}}, args, sorting);
     }
-{{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
+    static useWithPaging(pageSize: number, args?: {{Name}}Arguments, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), args, sorting);
+    }
+{{else}}
+    static use(args?: {{Name}}Arguments): [QueryResultWithState<{{Model}}>, PerformQuery<{{Name}}Arguments>] {
+        const [result, perform] = useQuery<{{Model}}, {{Name}}, {{Name}}Arguments>({{Name}}, args);
+        return [result, perform];
     }
 {{/if}}
 {{else}}
+{{#if IsEnumerable}}
     static use(sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery, SetSorting] {
         return useQuery<{{Model}}[], {{Name}}>({{Name}}, undefined, sorting);
     }
-{{#if IsEnumerable}}
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<{{Model}}[]>, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<{{Model}}[], {{Name}}>({{Name}}, new Paging(0, pageSize), undefined, sorting);
+    }
+{{else}}
+    static use(): [QueryResultWithState<{{Model}}>, PerformQuery] {
+        const [result, perform] = useQuery<{{Model}}, {{Name}}>({{Name}});
+        return [result, perform];
     }
 {{/if}}
 {{/if}}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -40,33 +40,38 @@ public static class TypeExtensions
     internal static Type _voidType = typeof(void);
 #pragma warning restore SA1600 // Elements should be documented
 
+    static readonly TargetType _numberTargetType = new("number", "Number");
+    static readonly TargetType _dateTargetType = new("Date", "Date");
+    static readonly TargetType _stringTargetType = new("string", "String");
+    static readonly TargetType _booleanTargetType = new("boolean", "Boolean");
+
     static readonly Dictionary<string, TargetType> _primitiveTypeMap = new()
     {
         { typeof(object).FullName!, AnyTypeFinal },
-        { typeof(char).FullName!, new("string", "String") },
-        { typeof(byte).FullName!, new("number", "Number") },
-        { typeof(sbyte).FullName!, new("number", "Number") },
-        { typeof(bool).FullName!, new("boolean", "Boolean") },
-        { typeof(string).FullName!, new("string", "String") },
-        { typeof(short).FullName!, new("number", "Number") },
-        { typeof(int).FullName!, new("number", "Number") },
-        { typeof(long).FullName!, new("number", "Number") },
-        { typeof(ushort).FullName!, new("number", "Number") },
-        { typeof(uint).FullName!, new("number", "Number") },
-        { typeof(ulong).FullName!, new("number", "Number") },
-        { typeof(float).FullName!, new("number", "Number") },
-        { typeof(double).FullName!, new("number", "Number") },
-        { typeof(decimal).FullName!, new("number", "Number") },
-        { typeof(DateTime).FullName!, new("Date",  "Date") },
-        { typeof(DateTimeOffset).FullName!, new("Date", "Date") },
+        { typeof(char).FullName!, _stringTargetType },
+        { typeof(byte).FullName!, _numberTargetType },
+        { typeof(sbyte).FullName!, _numberTargetType },
+        { typeof(bool).FullName!, _booleanTargetType },
+        { typeof(string).FullName!, _stringTargetType },
+        { typeof(short).FullName!, _numberTargetType },
+        { typeof(int).FullName!, _numberTargetType },
+        { typeof(long).FullName!, _numberTargetType },
+        { typeof(ushort).FullName!, _numberTargetType },
+        { typeof(uint).FullName!, _numberTargetType },
+        { typeof(ulong).FullName!, _numberTargetType },
+        { typeof(float).FullName!, _numberTargetType },
+        { typeof(double).FullName!, _numberTargetType },
+        { typeof(decimal).FullName!, _numberTargetType },
+        { typeof(DateTime).FullName!, _dateTargetType },
+        { typeof(DateTimeOffset).FullName!, _dateTargetType },
         { typeof(Guid).FullName!, new("Guid", "Guid", "@cratis/fundamentals") },
-        { typeof(DateOnly).FullName!, new("Date", "Date") },
-        { typeof(TimeOnly).FullName!, new("Date", "Date") },
+        { typeof(DateOnly).FullName!, _dateTargetType },
+        { typeof(TimeOnly).FullName!, _dateTargetType },
         { typeof(System.Text.Json.Nodes.JsonNode).FullName!, AnyTypeFinal },
         { typeof(System.Text.Json.Nodes.JsonObject).FullName!, AnyTypeFinal },
         { typeof(System.Text.Json.Nodes.JsonArray).FullName!, AnyTypeFinal },
         { typeof(System.Text.Json.JsonDocument).FullName!, AnyTypeFinal },
-        { typeof(Uri).FullName!, new("string", "String") }
+        { typeof(Uri).FullName!, _dateTargetType }
     };
 
     static readonly Dictionary<string, Assembly> _assembliesByName = [];
@@ -252,6 +257,11 @@ public static class TypeExtensions
     /// <returns>The <see cref="TargetType"/>.</returns>
     public static TargetType GetTargetType(this Type type)
     {
+        if (type.IsEnum)
+        {
+            return new(type.Name, "Number");
+        }
+
         if (type.IsDictionary())
         {
             return AnyTypeFinal;

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -297,6 +297,7 @@ public static class TypeExtensions
             }
         }
         imports.AddRange(typesInvolved.GetImports(targetPath, type!.ResolveTargetPath(segmentsToSkip), segmentsToSkip));
+        imports = imports.Distinct().ToList();
 
         return new TypeDescriptor(
             type,

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -306,8 +306,11 @@ public static class TypeExtensions
                 imports.Add(new ImportStatement(property.Type, property.Module));
             }
         }
+
         imports.AddRange(typesInvolved.GetImports(targetPath, type!.ResolveTargetPath(segmentsToSkip), segmentsToSkip));
-        imports = imports.Distinct().ToList();
+        imports = imports
+                    .Distinct()
+                    .Where(_ => propertyDescriptors.Exists(pd => pd.Type == _.Type)).ToList();
 
         return new TypeDescriptor(
             type,
@@ -393,7 +396,7 @@ public static class TypeExtensions
     /// <param name="segmentsToSkip">Number of segments to skip from the namespace when generating the output path.</param>
     /// <returns>A collection of <see cref="ImportStatement"/>.</returns>
     public static IEnumerable<ImportStatement> GetImports(this IEnumerable<Type> types, string targetPath, string relativePath, int segmentsToSkip) =>
-         types.Select(_ =>
+        types.Select(_ =>
         {
             var targetType = _.GetTargetType();
             var importPath = targetType.Module;

--- a/Source/JavaScript/Applications.React.MVVM/index.ts
+++ b/Source/JavaScript/Applications.React.MVVM/index.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import 'reflect-metadata';
-import * as bindings from './Bindings';
 import * as browser from './browser';
 import * as messaging from './messaging';
+import { Bindings } from './Bindings';
 import { withViewModel } from './withViewModel';
 import { MVVM, MVVMContext, MVVMProps } from './MVVMContext';
 
 export {
-    bindings,
+    Bindings,
     browser,
     messaging,
     withViewModel,


### PR DESCRIPTION
### Fixed

- Fixing import for `Bindings` to not refer to it as a module for `@cratis/applications.react.mvvm` package.
- Removing duplicate imports types generated by proxy generator.
- Fixing imports to only include imports needed and not imports from types not in the file generated by proxy generator.
- Fixing proxies for queries and obsevable queries to generate correct signature for single item queries.
- Removing `number` referring to `pageNumber` from signature of generated query proxies, overlooked when changing this in version 12.0.0.

