### PR TITLE
Fix/from-request

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,11 +25,13 @@
             "cwd": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator",
             "program": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator/bin/Debug/net8.0/Cratis.Applications.ProxyGenerator.dll",
             "args": [
-                "/Volumes/Code/Cratis/Chronicle/Source/Api/bin/Debug/net8.0/Cratis.Chronicle.Api.dll",
-                "/Volumes/Code/Cratis/Chronicle/Source/Workbench/Api",
-                // "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
-                // "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
-                "2"
+                // "/Volumes/Code/KDI/Ocean/Source/Accounts/Api/bin/Debug/net8.0/Api.dll",
+                // "/Volumes/Code/KDI/Ocean/Source/Accounts/Web/Api",
+                // "/Volumes/Code/Cratis/Chronicle/Source/Api/bin/Debug/net8.0/Cratis.Chronicle.Api.dll",
+                // "/Volumes/Code/Cratis/Chronicle/Source/Workbench/Api",
+                "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
+                "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
+                "1"
             ],
             "stopAtEntry": false,
             "env": {

--- a/Samples/eCommerce/Basic/API/API.csproj
+++ b/Samples/eCommerce/Basic/API/API.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);ASP0018</NoWarn>
+    </PropertyGroup>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/Samples/eCommerce/Basic/API/Users/ChangeProfilePicture.cs
+++ b/Samples/eCommerce/Basic/API/Users/ChangeProfilePicture.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Concepts.Users;
+
+namespace API.Users;
+
+/// <summary>
+/// Represents the command for changing the profile picture of a user.
+/// </summary>
+/// <param name="Id">The user id.</param>
+/// <param name="Picture">The picture.</param>
+public record ChangeProfilePicture(
+    [FromRoute] UserId Id,
+    string Picture);

--- a/Samples/eCommerce/Basic/API/Users/Users.cs
+++ b/Samples/eCommerce/Basic/API/Users/Users.cs
@@ -1,0 +1,22 @@
+using Cratis.Applications.ModelBinding;
+
+namespace API.Users;
+
+/// <summary>
+/// Represents the users API.
+/// </summary>
+[Route("/api/users")]
+public class Users : ControllerBase
+{
+    /// <summary>
+    /// Change the profile picture for a user.
+    /// </summary>
+    /// <param name="changeProfilePicture"><see cref="ChangeProfilePicture"/> command.</param>
+    /// <returns>Awaitable task.</returns>
+    [HttpPost("{id}/change-profile-picture")]
+    public Task ChangeProfilePicture([FromRequest] ChangeProfilePicture changeProfilePicture)
+    {
+        Console.WriteLine(changeProfilePicture);
+        return Task.CompletedTask;
+    }
+}

--- a/Samples/eCommerce/Basic/Concepts/Users/UserId.cs
+++ b/Samples/eCommerce/Basic/Concepts/Users/UserId.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Concepts.Users;
+
+/// <summary>
+/// Represents the domain concept of a user identifier.
+/// </summary>
+/// <param name="value">Value to initialize with.</param>
+public record UserId(Guid value) : ConceptAs<Guid>(value)
+{
+    /// <summary>
+    /// The user id value representing not set.
+    /// </summary>
+    public static readonly UserId NotSet = Guid.Empty;
+
+    /// <summary>
+    /// Implicitly convert from a <see cref="Guid"/> to a <see cref="UserId"/>.
+    /// </summary>
+    /// <param name="value">Guid value to convert from.</param>
+    public static implicit operator UserId(Guid value) => new(value);
+}

--- a/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line header/header
 import { QueryFor, QueryResultWithState } from '@cratis/applications/queries';
-import { useQuery, PerformQuery, SetSorting} from '@cratis/applications.react/queries';
+import { useQuery, PerformQuery } from '@cratis/applications.react/queries';
 import { Cart } from './Cart';
 import Handlebars from 'handlebars';
 
@@ -26,7 +26,8 @@ export class CartForCurrentUser extends QueryFor<Cart> {
     }
 
 
-    static use(sorting?: Sorting): [QueryResultWithState<Cart[]>, PerformQuery, SetSorting] {
-        return useQuery<Cart[], CartForCurrentUser>(CartForCurrentUser, undefined, sorting);
+    static use(): [QueryResultWithState<Cart>, PerformQuery] {
+        const [result, perform] = useQuery<Cart, CartForCurrentUser>(CartForCurrentUser);
+        return [result, perform];
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
@@ -26,7 +26,8 @@ export class ObserveCartForCurrentUser extends ObservableQueryFor<Cart> {
     }
 
 
-    static use(sorting?: Sorting): [QueryResultWithState<Cart[]>, SetSorting] {
-        return useObservableQuery<Cart[], ObserveCartForCurrentUser>(ObserveCartForCurrentUser, undefined, sorting);
+    static use(): [QueryResultWithState<Cart>] {
+        const [result] = useObservableQuery<Cart, ObserveCartForCurrentUser>(ObserveCartForCurrentUser);
+        return result;
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
@@ -77,7 +77,7 @@ export class AllProducts extends QueryFor<Product[]> {
         return useQuery<Product[], AllProducts>(AllProducts, undefined, sorting);
     }
 
-    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, number, PerformQuery, SetSorting, SetPage, SetPageSize] {
+    static useWithPaging(pageSize: number, sorting?: Sorting): [QueryResultWithState<Product[]>, PerformQuery, SetSorting, SetPage, SetPageSize] {
         return useQueryWithPaging<Product[], AllProducts>(AllProducts, new Paging(0, pageSize), undefined, sorting);
     }
 }

--- a/Samples/eCommerce/Basic/Web/API/Users/ChangeProfilePicture.ts
+++ b/Samples/eCommerce/Basic/Web/API/Users/ChangeProfilePicture.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line header/header
+import { Command, CommandValidator, CommandPropertyValidators } from '@cratis/applications/commands';
+import { useCommand, SetCommandValues, ClearCommandValues } from '@cratis/applications.react/commands';
+import { Validator } from '@cratis/applications/validation';
+import { Guid } from '@cratis/fundamentals';
+import Handlebars from 'handlebars';
+
+const routeTemplate = Handlebars.compile('/api/users/{id}/change-profile-picture');
+
+export interface IChangeProfilePicture {
+    id?: Guid;
+    picture?: string;
+}
+
+export class ChangeProfilePictureValidator extends CommandValidator {
+    readonly properties: CommandPropertyValidators = {
+        id: new Validator(),
+        picture: new Validator(),
+    };
+}
+
+export class ChangeProfilePicture extends Command<IChangeProfilePicture> implements IChangeProfilePicture {
+    readonly route: string = '/api/users/{id}/change-profile-picture';
+    readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
+    readonly validation: CommandValidator = new ChangeProfilePictureValidator();
+
+    private _id!: Guid;
+    private _picture!: string;
+
+    constructor() {
+        super(Object, false);
+    }
+
+    get requestArguments(): string[] {
+        return [
+            'id',
+        ];
+    }
+
+    get properties(): string[] {
+        return [
+            'id',
+            'picture',
+        ];
+    }
+
+    get id(): Guid {
+        return this._id;
+    }
+
+    set id(value: Guid) {
+        this._id = value;
+        this.propertyChanged('id');
+    }
+    get picture(): string {
+        return this._picture;
+    }
+
+    set picture(value: string) {
+        this._picture = value;
+        this.propertyChanged('picture');
+    }
+
+    static use(initialValues?: IChangeProfilePicture): [ChangeProfilePicture, SetCommandValues<IChangeProfilePicture>, ClearCommandValues] {
+        return useCommand<ChangeProfilePicture, IChangeProfilePicture>(ChangeProfilePicture, initialValues);
+    }
+}

--- a/Samples/eCommerce/Basic/Web/API/Users/index.ts
+++ b/Samples/eCommerce/Basic/Web/API/Users/index.ts
@@ -3,15 +3,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 // eslint-disable-next-line header/header
-import { field } from '@cratis/fundamentals';
-import { Guid } from '@cratis/fundamentals';
-import { CartItem } from './CartItem';
-
-export class Cart {
-
-    @field(Guid)
-    id!: Guid;
-
-    @field(CartItem, true)
-    items!: CartItem[];
-}
+export * from './ChangeProfilePicture';

--- a/Samples/eCommerce/Basic/Web/index.tsx
+++ b/Samples/eCommerce/Basic/Web/index.tsx
@@ -9,11 +9,8 @@ import './Styles/tailwind.css';
 import './Styles/theme.css';
 import React from 'react';
 import { App } from './App';
-
-const Blah = () => {
-    console.log('Blah');
-    return (<></>);
-};
+import { Globals } from '@cratis/applications';
+Globals.microservice = 'eCommerce';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/Source/DotNET/Swagger/CommandResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/CommandResultOperationFilter.cs
@@ -13,8 +13,7 @@ namespace Cratis.Applications.Swagger;
 /// <summary>
 /// Represents an implementation of <see cref="IOperationFilter"/> that adds the command result to the operation for command methods.
 /// </summary>
-/// <param name="schemaGenerator">The <see cref="ISchemaGenerator"/> to use.</param>
-public class CommandResultOperationFilter(ISchemaGenerator schemaGenerator) : IOperationFilter
+public class CommandResultOperationFilter : IOperationFilter
 {
     /// <inheritdoc/>
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -37,7 +36,7 @@ public class CommandResultOperationFilter(ISchemaGenerator schemaGenerator) : IO
 
         commandResultType ??= typeof(CommandResult<>).MakeGenericType(returnType);
 
-        var schema = schemaGenerator.GenerateSchema(commandResultType, context.SchemaRepository);
+        var schema = context.SchemaGenerator.GenerateSchema(commandResultType, context.SchemaRepository);
         var response = operation.Responses.First().Value;
         if (response.Content.ContainsKey("application/json"))
         {

--- a/Source/DotNET/Swagger/CommandResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/CommandResultOperationFilter.cs
@@ -64,5 +64,14 @@ public class CommandResultOperationFilter : IOperationFilter
                 { "application/json", new OpenApiMediaType() { Schema = schema } }
             }
         });
+
+        operation.Responses.Add(((int)HttpStatusCode.InternalServerError).ToString(), new OpenApiResponse()
+        {
+            Description = "Internal server error - something went wrong. See the exception details.",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                { "application/json", new OpenApiMediaType() { Schema = schema } }
+            }
+        });
     }
 }

--- a/Source/DotNET/Swagger/Extensions.cs
+++ b/Source/DotNET/Swagger/Extensions.cs
@@ -19,6 +19,8 @@ public static class Extensions
     {
         options.SchemaFilter<ConceptSchemaFilter>();
         options.SchemaFilter<EnumSchemaFilter>();
+        options.SchemaFilter<FromRequestSchemaFilter>();
+        options.OperationFilter<FromRequestOperationFilter>();
         options.OperationFilter<CommandResultOperationFilter>();
         options.OperationFilter<QueryResultOperationFilter>();
     }

--- a/Source/DotNET/Swagger/FromRequestOperationFilter.cs
+++ b/Source/DotNET/Swagger/FromRequestOperationFilter.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Applications.ModelBinding;
+using Cratis.Reflection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Cratis.Applications.Swagger;
+
+/// <summary>
+/// Represents an implementation of <see cref="IOperationFilter"/> that adds support for <see cref="FromRequestAttribute"/> attribute.
+/// </summary>
+public class FromRequestOperationFilter : IOperationFilter
+{
+    /// <inheritdoc/>
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var parameterInfos = context.MethodInfo.GetParameters();
+
+        var parameters = context.ApiDescription.ParameterDescriptions.Where(_ => parameterInfos.Any(p =>
+            p.Name == _.Name && p.HasAttribute<FromRequestAttribute>())).ToArray();
+        if (parameters.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            var openApiParameter = operation.Parameters.FirstOrDefault(_ => _.Name == parameter.Name);
+            operation.Parameters.Remove(openApiParameter);
+
+            var schema = context.SchemaGenerator.GenerateSchema(parameter.Type, context.SchemaRepository);
+            operation.RequestBody = new()
+            {
+                Content =
+                {
+                    ["application/json"] = new()
+                    {
+                        Schema = schema
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Source/DotNET/Swagger/FromRequestSchemaFilter.cs
+++ b/Source/DotNET/Swagger/FromRequestSchemaFilter.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Cratis.Applications.Swagger;
+
+/// <summary>
+/// Represents an implementation of <see cref="ISchemaFilter"/> that removes properties that are decorated with <see cref="FromRouteAttribute"/> or <see cref="FromQueryAttribute"/>.
+/// </summary>
+public class FromRequestSchemaFilter : ISchemaFilter
+{
+    /// <inheritdoc/>
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        var parameters = context.Type.GetConstructors().SelectMany(_ => _.GetParameters()).ToArray();
+
+        bool HasConstructorParameterWithRequestArgument(PropertyInfo propertyInfo) =>
+            parameters.Any(_ => _.Name == propertyInfo.Name && (_.HasAttribute<FromRouteAttribute>() || _.HasAttribute<FromQueryAttribute>()));
+
+        var properties = context.Type.GetProperties()
+            .Where(_ =>
+                PropertyExtensions.HasAttribute<FromRouteAttribute>(_) ||
+                PropertyExtensions.HasAttribute<FromQueryAttribute>(_) ||
+                HasConstructorParameterWithRequestArgument(_))
+            .ToList();
+
+        if (properties.Count > 0)
+        {
+            foreach (var property in properties)
+            {
+                var propertyToRemove = schema.Properties.SingleOrDefault(_ => _.Key.Equals(property.Name, StringComparison.InvariantCultureIgnoreCase));
+                if (propertyToRemove.Value is not null)
+                {
+                    schema.Properties.Remove(propertyToRemove.Key);
+                }
+            }
+        }
+
+        if (context.Type.Name == "ChangeProfilePicture")
+        {
+            Console.WriteLine("ChangeProfilePicture");
+        }
+
+        properties.ForEach(_ => schema.Properties.Remove(_.Name));
+    }
+}

--- a/Source/DotNET/Swagger/QueryResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/QueryResultOperationFilter.cs
@@ -14,8 +14,7 @@ namespace Cratis.Applications.Swagger;
 /// <summary>
 /// Represents an implementation of <see cref="IOperationFilter"/> that adds the command result to the operation for command methods.
 /// </summary>
-/// <param name="schemaGenerator">The <see cref="ISchemaGenerator"/> to use.</param>
-public class QueryResultOperationFilter(ISchemaGenerator schemaGenerator) : IOperationFilter
+public class QueryResultOperationFilter : IOperationFilter
 {
     /// <inheritdoc/>
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -73,7 +72,7 @@ public class QueryResultOperationFilter(ISchemaGenerator schemaGenerator) : IOpe
             });
         }
 
-        var schema = schemaGenerator.GenerateSchema(queryResultType, context.SchemaRepository);
+        var schema = context.SchemaGenerator.GenerateSchema(queryResultType, context.SchemaRepository);
         var response = operation.Responses.First((kvp) => kvp.Key == ((int)HttpStatusCode.OK).ToString()).Value;
         if (response.Content.ContainsKey("application/json"))
         {

--- a/Source/DotNET/Swagger/QueryResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/QueryResultOperationFilter.cs
@@ -100,5 +100,15 @@ public class QueryResultOperationFilter : IOperationFilter
                 { "application/json", new OpenApiMediaType() { Schema = schema } }
             }
         });
+
+        operation.Responses.Add(((int)HttpStatusCode.InternalServerError).ToString(), new OpenApiResponse()
+        {
+            Description = "Internal server error - something went wrong. See the exception details.",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                { "application/json", new OpenApiMediaType() { Schema = schema } }
+            }
+        });
+
     }
 }

--- a/Source/DotNET/Swagger/QueryResultOperationFilter.cs
+++ b/Source/DotNET/Swagger/QueryResultOperationFilter.cs
@@ -109,6 +109,5 @@ public class QueryResultOperationFilter : IOperationFilter
                 { "application/json", new OpenApiMediaType() { Schema = schema } }
             }
         });
-
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -43,16 +43,11 @@ public static class CommandExtensions
         }
 
         var propertiesWithComplexTypes = properties.Where(_ => !_.OriginalType.IsKnownType());
+        var propertiesNeedingImportStatements = properties.Where(_ => _.OriginalType.HasModule()).ToList();
         typesInvolved.AddRange(propertiesWithComplexTypes.Select(_ => _.OriginalType));
-        var imports = typesInvolved.GetImports(targetPath, method.DeclaringType!.ResolveTargetPath(segmentsToSkip), segmentsToSkip).ToList();
-
-        foreach (var property in properties)
-        {
-            if (property.OriginalType.TryGetImportStatement(out var import))
-            {
-                imports.Add(import!);
-            }
-        }
+        var relativePath = method.DeclaringType!.ResolveTargetPath(segmentsToSkip);
+        var imports = typesInvolved.GetImports(targetPath, relativePath, segmentsToSkip).ToList();
+        imports.AddRange(propertiesNeedingImportStatements.Select(_ => _.OriginalType.GetImportStatement(targetPath, relativePath, segmentsToSkip)));
 
         if (responseModel.Type is not null && responseModel.Type.GetTargetType().TryGetImportStatement(out var responseTypeImportStatement))
         {

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -20,6 +20,29 @@ public static class PropertyExtensions
         ToPropertyDescriptor(property.PropertyType, property.Name);
 
     /// <summary>
+    /// Check if a property is a request argument which will make it part of the query string either as route variable or a query string parameter.
+    /// </summary>
+    /// <param name="property">Property to check.</param>
+    /// <returns>True if it is a request argument, false otherwise.</returns>
+    public static bool IsRequestArgument(this PropertyInfo property)
+    {
+        var attributes = property.GetCustomAttributesData().Select(_ => _.AttributeType.Name);
+        return attributes.Any(_ => _ == WellKnownTypes.FromRouteAttribute) ||
+               attributes.Any(_ => _ == WellKnownTypes.FromQueryAttribute);
+    }
+
+   /// <summary>
+    /// Convert a <see cref="PropertyInfo"/> to a <see cref="RequestArgumentDescriptor"/>.
+    /// </summary>
+    /// <param name="propertyInfo">Parameter to convert.</param>
+    /// <returns>Converted <see cref="RequestArgumentDescriptor"/>.</returns>
+    public static RequestArgumentDescriptor ToRequestArgumentDescriptor(this PropertyInfo propertyInfo)
+    {
+        var type = propertyInfo.PropertyType.GetTargetType();
+        return new RequestArgumentDescriptor(propertyInfo.PropertyType, propertyInfo.Name!, type.Type, false);
+    }
+
+    /// <summary>
     /// Convert a <see cref="ParameterInfo"/> to a <see cref="PropertyDescriptor"/>.
     /// </summary>
     /// <param name="parameterInfo">Parameter to convert.</param>

--- a/Source/DotNET/Tools/ProxyGenerator/WellKnownTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/WellKnownTypes.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.ProxyGenerator;
+
+/// <summary>
+/// Represents well known type strings.
+/// </summary>
+public static class WellKnownTypes
+{
+    /// <summary>
+    /// Gets the name of the RouteAttribute.
+    /// </summary>
+    public const string RouteAttribute = "RouteAttribute";
+
+    /// <summary>
+    /// Gets the name of the HttpGetAttribute.
+    /// </summary>
+    public const string HttpGetAttribute = "HttpGetAttribute";
+
+    /// <summary>
+    /// Gets the name of the HttpPostAttribute.
+    /// </summary>
+    public const string HttpPostAttribute = "HttpPostAttribute";
+
+    /// <summary>
+    /// Gets the name of the FromRouteAttribute.
+    /// </summary>
+    public const string FromRouteAttribute = "FromRouteAttribute";
+
+    /// <summary>
+    /// Gets the name of the FromQueryAttribute.
+    /// </summary>
+    public const string FromQueryAttribute = "FromQueryAttribute";
+
+    /// <summary>
+    /// Gets the name of the FromRequestAttribute.
+    /// </summary>
+    public const string FromRequestAttribute = "FromRequestAttribute";
+
+    /// <summary>
+    /// Gets the name of the AspNetResultAttribute.
+    /// </summary>
+    public const string AspNetResultAttribute = "AspNetResultAttribute";
+}


### PR DESCRIPTION
### Fixed

- Including HTTP 500 as error code in the Swagger definitions for Commands and Queries (#55)
- Proxy Generator now supports `[FromRequest]` adorned parameters (#58).
- Generating correct Swagger definition when using `[FromRequest]`on adorned parameters (#57).
- Supporting `ConceptAs<>` type of Guids and fixing so that it imports the `@cratis/fundamentals` module for this.
