### PR TITLE
Downgrading mongo to avoid problems upstream

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
     <PackageVersion Include="FluentValidation" Version="11.0.3" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.20.0" />
     <PackageVersion Include="handlebars.net" Version="2.1.4" />
     <PackageVersion Include="castle.core" Version="5.1.1" />
     <PackageVersion Include="polly.core" Version="8.3.1" />


### PR DESCRIPTION
### Fixed

- Downgrading MongoDB Driver from version 2.28.0 to 2.20.0 to avoid conflicts up stream.
