### PR TITLE
Seting MongoDB to be version 2.25.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
     <PackageVersion Include="FluentValidation" Version="11.0.3" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
     <PackageVersion Include="handlebars.net" Version="2.1.4" />
     <PackageVersion Include="castle.core" Version="5.1.1" />
     <PackageVersion Include="polly.core" Version="8.3.1" />


### PR DESCRIPTION
### Fixed

- Settings MongoDB to be version 2.25.0, as that is our lowest point at this point.
