### PR TITLE
Fixing so that the route templates are correct for arguments

### DIFF
--- a/Samples/eCommerce/Basic/Web/API/Products/SetStockForProduct.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/SetStockForProduct.ts
@@ -8,7 +8,7 @@ import { useCommand, SetCommandValues, ClearCommandValues } from '@cratis/applic
 import { Validator } from '@cratis/applications/validation';
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('/set-stock/{sku}');
+const routeTemplate = Handlebars.compile('/set-stock/{{sku}}');
 
 export interface ISetStockForProduct {
     sku?: string;

--- a/Samples/eCommerce/Basic/Web/API/Users/ChangeProfilePicture.ts
+++ b/Samples/eCommerce/Basic/Web/API/Users/ChangeProfilePicture.ts
@@ -9,7 +9,7 @@ import { Validator } from '@cratis/applications/validation';
 import { Guid } from '@cratis/fundamentals';
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('/api/users/{id}/change-profile-picture');
+const routeTemplate = Handlebars.compile('/api/users/{{id}}/change-profile-picture');
 
 export interface IChangeProfilePicture {
     id?: Guid;

--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -61,10 +61,13 @@ public static class CommandExtensions
 
         imports = imports.Distinct().ToList();
 
+        var route = method.GetRoute();
+
         return new(
             method.DeclaringType!,
             method,
-            method.GetRoute(),
+            route,
+            route.MakeRouteTemplate(),
             method.Name,
             properties,
             imports,

--- a/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
@@ -37,6 +37,14 @@ public static class MethodInfoExtensions
     }
 
     /// <summary>
+    /// Make a route template from a route.
+    /// </summary>
+    /// <param name="route">String representing the route.</param>
+    /// <returns>A template version of the route.</returns>
+    public static string MakeRouteTemplate(this string route) =>
+        route.Replace("{", "{{").Replace("}", "}}");
+
+    /// <summary>
     /// Get argument descriptors for a method.
     /// </summary>
     /// <param name="methodInfo">Method to get for.</param>

--- a/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
@@ -56,10 +56,13 @@ public static class QueryExtensions
             property.CollectTypesInvolved(additionalTypesInvolved);
         }
 
+        var route = method.GetRoute();
+
         return new(
             method.DeclaringType!,
             method,
-            method.GetRoute(),
+            route,
+            route.MakeRouteTemplate(),
             method.Name,
             responseModel.Name,
             responseModel.Constructor,

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
@@ -11,7 +11,7 @@ import { {{Type}} } from '{{Module}}';
 {{/Imports}}
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('{{{Route}}}');
+const routeTemplate = Handlebars.compile('{{RouteTemplate}}');
 
 export interface I{{Name}} {
     {{#Properties}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/CommandDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/CommandDescriptor.cs
@@ -11,6 +11,7 @@ namespace Cratis.Applications.ProxyGenerator.Templates;
 /// <param name="Type">The controller type that owns the command.</param>
 /// <param name="Method">The method that represents the command.</param>
 /// <param name="Route">API route for the command.</param>
+/// <param name="RouteTemplate">API route template for the command.</param>
 /// <param name="Name">Name of the command.</param>
 /// <param name="Properties">Properties on the command.</param>
 /// <param name="Imports">Additional import statements.</param>
@@ -22,6 +23,7 @@ public record CommandDescriptor(
     Type Type,
     MethodInfo Method,
     string Route,
+    string RouteTemplate,
     string Name,
     IEnumerable<PropertyDescriptor> Properties,
     IEnumerable<ImportStatement> Imports,

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -15,7 +15,7 @@ import { {{Type}} } from '{{Module}}';
 {{/Imports}}
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('{{{Route}}}');
+const routeTemplate = Handlebars.compile('{{RouteTemplate}}');
 
 {{#if IsEnumerable}}
 class {{Name}}SortBy {

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -15,7 +15,7 @@ import { {{Type}} } from '{{Module}}';
 {{/Imports}}
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('{{{Route}}}');
+const routeTemplate = Handlebars.compile('{{RouteTemplate}}');
 
 {{#if IsEnumerable}}
 class {{Name}}SortBy {

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/QueryDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/QueryDescriptor.cs
@@ -11,6 +11,7 @@ namespace Cratis.Applications.ProxyGenerator.Templates;
 /// <param name="Type">The controller type that owns the query.</param>
 /// <param name="Method">The method that represents the query.</param>
 /// <param name="Route">API route for the query.</param>
+/// <param name="RouteTemplate">API route template for the query.</param>
 /// <param name="Name">Name of the query.</param>
 /// <param name="Model">Type of model the query is for.</param>
 /// <param name="Constructor">The JavaScript constructor for the model type.</param>
@@ -24,6 +25,7 @@ public record QueryDescriptor(
     Type Type,
     MethodInfo Method,
     string Route,
+    string RouteTemplate,
     string Name,
     string Model,
     string Constructor,


### PR DESCRIPTION
### Fixed

- Proxy generator now generates correct route template when there are arguments, it needs double curly braces rather than single.

