### PR TITLE
Adding & when microservice argument is present

### DIFF
--- a/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
@@ -34,6 +34,8 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
         if (queryArguments) {
             if (url.indexOf('?') < 0) {
                 url = `${url}?`;
+            } else {
+                url = `${url}&`;
             }
             const query = Object.keys(queryArguments).map(key => `${key}=${queryArguments[key]}`).join('&');
             url = `${url}${query}`;


### PR DESCRIPTION
### Fixed

- Adding `&` on URL construction when the Microservice query string parameter is present for observable queries.
