### PR TITLE
Removing validator + disabling no-empty-interface rule

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
@@ -2,11 +2,11 @@
  *  **DO NOT EDIT** - This file is an automatically generated file.
  *--------------------------------------------------------------------------------------------*/
 
-// eslint-disable-next-line header/header
 /* eslint-disable sort-imports */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line header/header
 import { Command, CommandPropertyValidators, CommandValidator } from '@cratis/applications/commands';
 import { useCommand, SetCommandValues, ClearCommandValues } from '@cratis/applications.react/commands';
-import { Validator } from '@cratis/applications/validation';
 {{#Imports}}
 import { {{Type}} } from '{{Module}}';
 {{/Imports}}


### PR DESCRIPTION
### Fixed

- Removing unused `Validator` from the Command definition for proxies
- Disable the `no-empty-interface` ESLint rule for Command definition for proxies
