### PR TITLE
Adding a [Roles] attribute for specifying roles in a more meaningful way

### DIFF
--- a/Source/DotNET/Applications/Authorization/RolesAttribute.cs
+++ b/Source/DotNET/Applications/Authorization/RolesAttribute.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Cratis.Applications.Authorization;
+
+/// <summary>
+/// Represents an <see cref="AuthorizeAttribute"/> for specifying roles.
+/// </summary>
+public sealed class RolesAttribute : AuthorizeAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RolesAttribute"/> class.
+    /// </summary>
+    /// <param name="roles">Roles that is needed.</param>
+    public RolesAttribute(params string[] roles)
+    {
+        Roles = string.Join(',', roles);
+    }
+}


### PR DESCRIPTION
### Added

- Adding support for authorization of roles in a better way than the default `[Authorize]` attribute with a new `[Roles("role1", "role2")]` attribute. This is located in the `Authorization` namespace.
