### PR TITLE
Adding on* methods for command result

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.6" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.7" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />

--- a/Source/JavaScript/Applications.React.MVVM/package.json
+++ b/Source/JavaScript/Applications.React.MVVM/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.5",
+        "@cratis/fundamentals": "5.3.7",
         "mobx": "6.13.1",
         "mobx-react": "9.1.1",
         "react": "18.3.1",

--- a/Source/JavaScript/Applications.React/package.json
+++ b/Source/JavaScript/Applications.React/package.json
@@ -57,7 +57,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.5",
+        "@cratis/fundamentals": "5.3.7",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications.Vite/package.json
+++ b/Source/JavaScript/Applications.Vite/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.5",
+        "@cratis/fundamentals": "5.3.7",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications/commands/CommandResult.ts
+++ b/Source/JavaScript/Applications/commands/CommandResult.ts
@@ -6,6 +6,28 @@ import { ICommandResult } from './ICommandResult';
 import { ValidationResult } from '../validation/ValidationResult';
 import { Constructor, JsonSerializer } from '@cratis/fundamentals';
 
+
+/**
+ * Delegate type for the onSuccess callback.
+ */
+type OnSuccess = (<TResponse>(response: TResponse) => void) | (() => void);
+
+/**
+ * Delegate type for the onException callback.
+ */
+type OnException = (messages: string[], stackTrace: string) => void;
+
+/**
+ * Delegate type for the onUnauthorized callback.
+ */
+type OnUnauthorized = () => void;
+
+/**
+ * Delegate type for the onValidationFailure callback.
+ */
+type OnValidationFailure = (validationResults: ValidationResult[]) => void;
+
+
 /**
  * Represents the result from executing a {@link ICommand}.
  */
@@ -73,5 +95,53 @@ export class CommandResult<TResponse = {}> implements ICommandResult<TResponse> 
                 this.response = JsonSerializer.deserializeFromInstance(responseInstanceType, result.response) as any;
             }
         }
+    }
+
+    /**
+     * Set up a callback for when the command was successful.
+     * @param {OnSuccess} callback The callback to call when the command was successful.
+     * @returns {CommandResult} The instance of the command result.
+     */
+    onSuccess(callback: OnSuccess): CommandResult<TResponse> {
+        if (this.isSuccess) {
+            callback(this.response as TResponse);
+        }
+        return this;
+    }
+
+    /**
+     * Set up a callback for when the command failed with an exception.
+     * @param {OnException} callback The callback to call when the command had an exception.
+     * @returns {CommandResult} The instance of the command result.
+     */
+    onException(callback: OnException): CommandResult<TResponse> {
+        if (this.hasExceptions) {
+            callback(this.exceptionMessages, this.exceptionStackTrace);
+        }
+        return this;
+    }
+
+    /**
+     * Set up a callback for when the command was unauthorized.
+     * @param {OnUnauthorized} callback The callback to call when the command was unauthorized.
+     * @returns {CommandResult} The instance of the command result.
+     */
+    onUnauthorized(callback: OnUnauthorized): CommandResult<TResponse> {
+        if (!this.isAuthorized) {
+            callback();
+        }
+        return this;
+    }
+
+    /**
+     * Set up a callback for when the command had validation errors.
+     * @param {OnSuccess} callback The callback to call when the command was invalid.
+     * @returns {CommandResult} The instance of the command result.
+     */
+    onValidationFailure(callback: OnValidationFailure): CommandResult<TResponse> {
+        if (!this.isValid) {
+            callback(this.validationResults);
+        }
+        return this;
     }
 }

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_has_exceptions.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_has_exceptions.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '../../CommandResult';
+
+describe('when chaining callbacks and result has exceptions', () => {
+    const result = new CommandResult({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: true,
+        validationResults: [],
+        exceptionMessages: [
+            'Something went wrong',
+            'Something is not right'
+        ],
+        exceptionStackTrace: 'Some stack trace',
+        response: {}
+    }, Object, false);
+
+    let onSuccessCalled = false;
+    let onUnauthorizedCalled = false;
+    let onValidationFailureCalled = false;
+    let onExceptionCalled = false;
+    let receivedMessages: string[] = [];
+    let receivedStackTrace: string = '';
+
+    result
+        .onSuccess(() => onSuccessCalled = true)
+        .onUnauthorized(() => onUnauthorizedCalled = true)
+        .onValidationFailure(() => onValidationFailureCalled = true)
+        .onException((messages, stackTrace) => {
+            onExceptionCalled = true;
+            receivedMessages = messages;
+            receivedStackTrace = stackTrace;
+        });
+
+    it('should call the on success callback', () => onSuccessCalled.should.be.false);
+    it('should forward the exception messages to the callback', () => receivedMessages.should.equal(result.exceptionMessages));
+    it('should forward the exception stack trace to the callback', () => receivedStackTrace.should.equal(result.exceptionStackTrace));
+    it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
+    it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
+    it('should not call the on exception callback', () => onExceptionCalled.should.be.true);
+});
+

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_invalid.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_invalid.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationResult } from '../../../validation/ValidationResult';
+import { ValidationResultSeverity } from '../../../validation/ValidationResultSeverity';
+import { CommandResult } from '../../CommandResult';
+
+describe('when chaining callbacks and result is invalid', () => {
+    const result = new CommandResult({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [
+            new ValidationResult(ValidationResultSeverity.Error, 'Something went wrong', ['someProperty'], 'Something went wrong'),
+            new ValidationResult(ValidationResultSeverity.Warning, 'Something is not right', ['someOtherProperty'], 'Something is not right')
+        ],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        response: {}
+    }, Object, false);
+
+    let onSuccessCalled = false;
+    let onUnauthorizedCalled = false;
+    let onValidationFailureCalled = false;
+    let onExceptionCalled = false;
+    let receivedValidationResults: ValidationResult[] = [];
+
+    result
+        .onSuccess(() => onSuccessCalled = true)
+        .onUnauthorized(() => onUnauthorizedCalled = true)
+        .onValidationFailure(validationResults => {
+            onValidationFailureCalled = true;
+            receivedValidationResults = validationResults;
+        })
+        .onException(() => onExceptionCalled = true);
+
+    it('should call the on success callback', () => onSuccessCalled.should.be.false);
+    it('should forward the validation results to the callback', () => receivedValidationResults.should.equal(result.validationResults));
+    it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
+    it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.true);
+    it('should not call the on exception callback', () => onExceptionCalled.should.be.false);
+});
+

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_successful.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_successful.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '../../CommandResult';
+
+describe('when chaining callbacks and result is successful', () => {
+    const result = new CommandResult({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        response: "The ultimate response"
+    }, Object, false);
+
+    let onSuccessCalled = false;
+    let onUnauthorizedCalled = false;
+    let onValidationFailureCalled = false;
+    let onExceptionCalled = false;
+    let receivedResponse: any = null;
+
+    result
+        .onSuccess(response => {
+            onSuccessCalled = true;
+            receivedResponse = response;
+        })
+        .onUnauthorized(() => onUnauthorizedCalled = true)
+        .onValidationFailure(() => onValidationFailureCalled = true)
+        .onException(() => onExceptionCalled = true);
+
+    it('should call the on success callback', () => onSuccessCalled.should.be.true);
+    it('should pass the response to the callback', () => receivedResponse.should.equal(result.response));
+    it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
+    it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
+    it('should not call the on exception callback', () => onExceptionCalled.should.be.false);
+});
+

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_unauthorized.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_unauthorized.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '../../CommandResult';
+
+describe('when chaining callbacks and result is unauthorized', () => {
+    const result = new CommandResult({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: false,
+        isAuthorized: false,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        response: {}
+    }, Object, false);
+
+    let onSuccessCalled = false;
+    let onUnauthorizedCalled = false;
+    let onValidationFailureCalled = false;
+    let onExceptionCalled = false;
+
+    result
+        .onSuccess(() => onSuccessCalled = true)
+        .onUnauthorized(() => onUnauthorizedCalled = true)
+        .onValidationFailure(() => onValidationFailureCalled = true)
+        .onException(() => onExceptionCalled = true);
+
+    it('should call the on success callback', () => onSuccessCalled.should.be.false);
+    it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.true);
+    it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
+    it('should not call the on exception callback', () => onExceptionCalled.should.be.false);
+});
+


### PR DESCRIPTION
### Added

- Adding `.on*` methods for JavaScript `CommandResult` giving you a way of chaining from the result methods for reacting to the different states. (#65)

```javascript
const result = await command.execute();
result
   .onSuccess(response => ...)
   .onUnauthorized(() => ...)
   .onException((messages, stackTrace) => ...)
   .onValidationFailure(validationResults => ...);
```
