### PR TITLE
Fix/observable-queries-disconnect

### DIFF
--- a/Source/JavaScript/Applications/queries/ValidateRequestArguments.ts
+++ b/Source/JavaScript/Applications/queries/ValidateRequestArguments.ts
@@ -18,7 +18,8 @@ export function ValidateRequestArguments(requestName: string, expectedRequestArg
             for (const argument of expectedRequestArguments) {
                 if (!actualArguments.hasOwnProperty(argument) ||
                     actualArguments[argument] == undefined ||
-                    actualArguments[argument] == null) {
+                    actualArguments[argument] == null ||
+                    actualArguments[argument] == '') {
                     missing.push(argument);
                 }
             }


### PR DESCRIPTION
### Fixed

- Fixing `ObservableQueryFor` to disconnect an existing connection. This would for instance be the case for queries that changes its arguments.
- Fixing request argument validation to consider empty string a missing argument. This means that routes that would end up with `//` due to an empty string that is supposed to be part of the route would not be considered valid and we won't connect to the server.
