### PR TITLE
Remove console log

### DIFF
--- a/Source/JavaScript/Applications.React/queries/useQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useQuery.ts
@@ -39,7 +39,6 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
             try {
                 const queryResult = await performer(queryInstance.current!);
                 setResult(QueryResultWithState.fromQueryResult(queryResult, false));
-                console.log('Query executed');
             } catch (error) {
                 // Ignore
             }


### PR DESCRIPTION
### Fixed

- Remove `console.log()` when query was executed.
