### PR TITLE
If command fails during fetch - we now return a failed command

### DIFF
--- a/Source/JavaScript/Applications/commands/CommandResult.ts
+++ b/Source/JavaScript/Applications/commands/CommandResult.ts
@@ -45,6 +45,20 @@ export class CommandResult<TResponse = {}> implements ICommandResult<TResponse> 
         response: null
     }, Object, false);
 
+    static failed = (exceptionMessages: string[]): CommandResult => {
+        return new CommandResult({
+            correlationId: Guid.empty.toString(),
+            isSuccess: false,
+            isAuthorized: true,
+            isValid: true,
+            hasExceptions: true,
+            validationResults: [],
+            exceptionMessages: exceptionMessages,
+            exceptionStackTrace: '',
+            response: null
+        }, Object, false);
+    };
+
     /** @inheritdoc */
     readonly correlationId: Guid;
 


### PR DESCRIPTION
### Fixed

- Failed commands due to errors during `fetch` operation are now considered failed an information is added as exception message.
