### PR TITLE
Plugin for adding query string to imports

### DIFF
--- a/Source/JavaScript/Applications.Vite/AddQueryStringToImports.ts
+++ b/Source/JavaScript/Applications.Vite/AddQueryStringToImports.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export const AddQueryStringToImports = (queryString: string) => {
+    return {
+        name: 'add-query-string-to-imports',
+        enforce: 'post', // Ensure it runs after the default processes
+        generateBundle(options, bundle) {
+            for (const file in bundle) {
+                const chunk = bundle[file];
+                if (chunk.type === 'chunk') {
+                    chunk.code = chunk.code.replace(
+                        `/(import\s+.*?from\s+['"])(.*?)(['"])/g, '$1$2?${queryString}$3'`
+                    );
+                    chunk.code = chunk.code.replace(
+                        `/(export\s+.*?from\s+['"])(.*?)(['"])/g, '$1$2?${queryString}$3'`
+                    );
+                }
+
+                if (chunk.type === 'asset' && chunk.fileName.endsWith('.css')) {
+                    // Modify CSS url() references
+                    chunk.source = chunk.source.replace(/(url\(['"]?)(.*?)(['"]?\))/g, '$1$2?x-cratis-microservice=accounts$3');
+                }
+            }
+        },
+    };
+};

--- a/Source/JavaScript/Applications.Vite/AddQueryStringToReferences.ts
+++ b/Source/JavaScript/Applications.Vite/AddQueryStringToReferences.ts
@@ -9,17 +9,13 @@ export const AddQueryStringToReferences = (queryString: string) => {
             for (const file in bundle) {
                 const chunk = bundle[file];
                 if (chunk.type === 'chunk') {
-                    chunk.code = chunk.code.replace(
-                        `/(import\s+.*?from\s+['"])(.*?)(['"])/g, '$1$2?${queryString}$3'`
-                    );
-                    chunk.code = chunk.code.replace(
-                        `/(export\s+.*?from\s+['"])(.*?)(['"])/g, '$1$2?${queryString}$3'`
-                    );
+                    chunk.code = chunk.code.replace(/(import\s+.*?from\s+['"])(.*?)(['"])/g, `$1$2?${queryString}$3`);
+                    chunk.code = chunk.code.replace(/(export\s+.*?from\s+['"])(.*?)(['"])/g, `$1$2?${queryString}$3`);
                 }
 
                 if (chunk.type === 'asset' && chunk.fileName.endsWith('.css')) {
                     // Modify CSS url() references
-                    chunk.source = chunk.source.replace(/(url\(['"]?)(.*?)(['"]?\))/g, '$1$2?x-cratis-microservice=accounts$3');
+                    chunk.source = chunk.source.replace(/(url\(\/['"]?)(.*?)(['"]?\))/g, `$1$2?${queryString}$3`);
                 }
             }
         },

--- a/Source/JavaScript/Applications.Vite/AddQueryStringToReferences.ts
+++ b/Source/JavaScript/Applications.Vite/AddQueryStringToReferences.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export const AddQueryStringToImports = (queryString: string) => {
+export const AddQueryStringToReferences = (queryString: string) => {
     return {
-        name: 'add-query-string-to-imports',
+        name: 'add-query-string-to-references',
         enforce: 'post', // Ensure it runs after the default processes
         generateBundle(options, bundle) {
             for (const file in bundle) {

--- a/Source/JavaScript/Applications.Vite/index.ts
+++ b/Source/JavaScript/Applications.Vite/index.ts
@@ -1,4 +1,5 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './AddQueryStringToImports';
 export * from './EmitMetadataPlugin';

--- a/Source/JavaScript/Applications.Vite/index.ts
+++ b/Source/JavaScript/Applications.Vite/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export * from './AddQueryStringToImports';
+export * from './AddQueryStringToReferences';
 export * from './EmitMetadataPlugin';


### PR DESCRIPTION
### Added

- Added Vite plugin for being able to add query string to references in generated files. This includes imports and CSS files with `url` references.
