### PR TITLE
Fixing standard dialogs to be called confirmation dialogs

### DIFF
--- a/Samples/eCommerce/Basic/Web/App.tsx
+++ b/Samples/eCommerce/Basic/Web/App.tsx
@@ -5,13 +5,13 @@ import { ApplicationModel } from '@cratis/applications.react';
 import { MVVM } from '@cratis/applications.react.mvvm';
 import { BrowserRouter } from "react-router-dom";
 import { Feature } from './Feature';
-import { StandardDialogs } from '@cratis/applications.react.mvvm/dialogs';
-import { StandardDialog } from './StandardDialog';
+import { ConfirmationDialogs } from '@cratis/applications.react.mvvm/dialogs';
+import { ConfirmationDialog } from './ConfirmationDialog';
 
 export const App = () => {
     return (
         <ApplicationModel microservice='e-commerce'>
-            <StandardDialogs component={StandardDialog}>
+            <ConfirmationDialogs component={ConfirmationDialog}>
                 <MVVM>
                     <BrowserRouter>
                         <Feature blah='Horse' />
@@ -19,7 +19,7 @@ export const App = () => {
                         {/* <ObservingCatalog /> */}
                     </BrowserRouter>
                 </MVVM>
-            </StandardDialogs>
+            </ConfirmationDialogs>
         </ApplicationModel>
     );
-}
+};

--- a/Samples/eCommerce/Basic/Web/ConfirmationDialog.tsx
+++ b/Samples/eCommerce/Basic/Web/ConfirmationDialog.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Dialog } from 'primereact/dialog'
-import { DialogButtons, StandardDialogRequest, useDialogContext } from '@cratis/applications.react.mvvm/dialogs'
-import { DialogResult } from '@cratis/applications.react/dialogs'
+import { Dialog } from 'primereact/dialog';
+import { DialogButtons, ConfirmationDialogRequest, useDialogContext } from '@cratis/applications.react.mvvm/dialogs';
+import { DialogResult } from '@cratis/applications.react/dialogs';
 import { Button } from 'primereact/button';
 
-export const StandardDialog = () => {
-    const { request, resolver } = useDialogContext<StandardDialogRequest, DialogResult>();
+export const ConfirmationDialog = () => {
+    const { request, resolver } = useDialogContext<ConfirmationDialogRequest, DialogResult>();
 
     const headerElement = (
         <div className="inline-flex align-items-center justify-content-center gap-2">
@@ -71,5 +71,5 @@ export const StandardDialog = () => {
                 </p>
             </Dialog>
         </>
-    )
-}
+    );
+};

--- a/Samples/eCommerce/Basic/Web/Feature.tsx
+++ b/Samples/eCommerce/Basic/Web/Feature.tsx
@@ -6,7 +6,7 @@ import { FeatureViewModel } from './FeatureViewModel';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { useIdentity } from '@cratis/applications.react/identity';
-import { useDialogRequest, StandardDialogRequest } from '@cratis/applications.react.mvvm/dialogs';
+import { useDialogRequest, ConfirmationDialogRequest } from '@cratis/applications.react.mvvm/dialogs';
 import { Dialog } from 'primereact/dialog';
 import { Button } from 'primereact/button';
 

--- a/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
+++ b/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
@@ -38,7 +38,7 @@ export class FeatureViewModel {
     }
 
     async doOtherStuff() {
-        const result = await this._dialogs.showStandard('Delete?', 'Are you sure you want to delete?', DialogButtons.YesNo);
+        const result = await this._dialogs.showConfirmation('Delete?', 'Are you sure you want to delete?', DialogButtons.YesNo);
         console.log(`Result: ${result}`);
     }
 }

--- a/Source/JavaScript/Applications.React.MVVM/dialogs/ConfirmationDialogRequest.ts
+++ b/Source/JavaScript/Applications.React.MVVM/dialogs/ConfirmationDialogRequest.ts
@@ -6,10 +6,10 @@ import { DialogButtons } from './DialogButtons';
 /**
  * Represents the request for a standard dialog.
  */
-export class StandardDialogRequest {
+export class ConfirmationDialogRequest {
 
     /**
-     * Initializes a new instance of {@link StandardDialogRequest}.
+     * Initializes a new instance of {@link ConfirmationDialogRequest}.
      * @param {String} title The title of the dialog.
      * @param {String} message The message to show in the dialog.
      * @param {DialogButtons} buttons Buttons to use in the dialog.

--- a/Source/JavaScript/Applications.React.MVVM/dialogs/ConfirmationDialogs.tsx
+++ b/Source/JavaScript/Applications.React.MVVM/dialogs/ConfirmationDialogs.tsx
@@ -2,39 +2,39 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React, { useMemo, useRef } from 'react';
-import { StandardDialogRequest } from './StandardDialogRequest';
+import { ConfirmationDialogRequest } from './ConfirmationDialogRequest';
 import { DialogResult } from '@cratis/applications.react/dialogs';
 import { useDialogRequest } from './useDialogRequest';
 import { DialogMediator } from './DialogMediator';
 import { DialogMediatorHandler } from './DialogMediatorHandler';
 import { IDialogMediatorHandler } from './IDialogMediatorHandler';
 
-export interface IStandardDialogContext {
+export interface IConfirmationDialogContext {
 }
 
-export const StandardDialogContext = React.createContext<IStandardDialogContext>({});
+export const ConfirmationDialogContext = React.createContext<IConfirmationDialogContext>({});
 
-export interface StandardDialogsProps {
+export interface ConfirmationDialogsProps {
     children?: JSX.Element | JSX.Element[];
     component: React.FC | React.FC<any>;
 }
 
-const StandardDialogWrapper = (props: StandardDialogsProps) => {
-    const [StandardDialog] = useDialogRequest<StandardDialogRequest, DialogResult>(StandardDialogRequest);
+const ConfirmationDialogWrapper = (props: ConfirmationDialogsProps) => {
+    const [StandardDialog] = useDialogRequest<ConfirmationDialogRequest, DialogResult>(ConfirmationDialogRequest);
 
     return (
-        <StandardDialogContext.Provider value={{}}>
+        <ConfirmationDialogContext.Provider value={{}}>
             <>
                 {props.children}
                 <StandardDialog>
                     <props.component />
                 </StandardDialog>
             </>
-        </StandardDialogContext.Provider>
+        </ConfirmationDialogContext.Provider>
     );
 };
 
-export const StandardDialogs = (props: StandardDialogsProps) => {
+export const ConfirmationDialogs = (props: ConfirmationDialogsProps) => {
 
     const mediatorHandler = useRef<IDialogMediatorHandler | null>(null);
     mediatorHandler.current = useMemo(() => {
@@ -43,9 +43,9 @@ export const StandardDialogs = (props: StandardDialogsProps) => {
 
     return (
         <DialogMediator handler={mediatorHandler.current!}>
-            <StandardDialogWrapper component={props.component}>
+            <ConfirmationDialogWrapper component={props.component}>
                 {props.children}
-            </StandardDialogWrapper>
+            </ConfirmationDialogWrapper>
         </DialogMediator>
     );
 };

--- a/Source/JavaScript/Applications.React.MVVM/dialogs/Dialogs.ts
+++ b/Source/JavaScript/Applications.React.MVVM/dialogs/Dialogs.ts
@@ -4,7 +4,7 @@
 import { DialogResult } from '@cratis/applications.react/dialogs';
 import { DialogButtons } from './DialogButtons';
 import { IDialogs } from './IDialogs';
-import { StandardDialogRequest } from './StandardDialogRequest';
+import { ConfirmationDialogRequest } from './ConfirmationDialogRequest';
 import { IDialogMediatorHandler } from './IDialogMediatorHandler';
 
 /**
@@ -25,7 +25,7 @@ export class Dialogs extends IDialogs {
     }
 
     /** @inheritdoc */
-    showStandard(title: string, message: string, buttons: DialogButtons): Promise<DialogResult> {
-        return this.show<StandardDialogRequest, DialogResult>(new StandardDialogRequest(title, message, buttons));
+    showConfirmation(title: string, message: string, buttons: DialogButtons): Promise<DialogResult> {
+        return this.show<ConfirmationDialogRequest, DialogResult>(new ConfirmationDialogRequest(title, message, buttons));
     }
 }

--- a/Source/JavaScript/Applications.React.MVVM/dialogs/IDialogs.ts
+++ b/Source/JavaScript/Applications.React.MVVM/dialogs/IDialogs.ts
@@ -15,10 +15,10 @@ export abstract class IDialogs {
     abstract show<TInput extends {}, TOutput>(input: TInput): Promise<TOutput>;
 
     /**
-     * Show a standard dialog.
+     * Show a standard confirmation dialog.
      * @param {String} title Title of the dialog.
      * @param {String} message Message to show inside the dialog.
      * @param {DialogButtons} buttons Buttons to have on the dialog
      */
-    abstract showStandard(title: string, message: string, buttons: DialogButtons): Promise<DialogResult>;
+    abstract showConfirmation(title: string, message: string, buttons: DialogButtons): Promise<DialogResult>;
 }

--- a/Source/JavaScript/Applications.React.MVVM/dialogs/index.ts
+++ b/Source/JavaScript/Applications.React.MVVM/dialogs/index.ts
@@ -9,6 +9,6 @@ export * from './Dialogs';
 export * from './IDialogMediatorHandler';
 export * from './IDialogs';
 export * from './Dialogs';
-export * from './StandardDialogRequest';
-export * from './StandardDialogs';
+export * from './ConfirmationDialogRequest';
+export * from './ConfirmationDialogs';
 export * from './useDialogRequest';


### PR DESCRIPTION
### Fixed

- Messed up the name of dialogs, instead of `StandardDialogs` it was supposed to be called `ConfirmationDialogs`. Even though this is a breaking change, we considered it to be ok to release as a patch since it hasn't gotten to be consumed due to lacking documentation.
