### PR TITLE
Fix/upgrade-fundamentals

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.8" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="5.3.9" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />

--- a/Source/DotNET/Applications/Commands/CommandResult.cs
+++ b/Source/DotNET/Applications/Commands/CommandResult.cs
@@ -16,7 +16,7 @@ public class CommandResult
     /// <summary>
     /// Gets the <see cref="CorrelationId"/> associated with the command.
     /// </summary>
-    public CorrelationId CorrelationId { get; init; } = new(Guid.Empty.ToString());
+    public CorrelationId CorrelationId { get; init; } = new(Guid.Empty);
 
     /// <summary>
     /// Gets whether or not the command executed successfully.

--- a/Source/DotNET/Applications/Execution/CorrelationIdAccessor.cs
+++ b/Source/DotNET/Applications/Execution/CorrelationIdAccessor.cs
@@ -15,7 +15,7 @@ public class CorrelationIdAccessor : ICorrelationIdAccessor
     static readonly AsyncLocal<CorrelationId> _current = new();
 
     /// <inheritdoc/>
-    public CorrelationId Current => _current.Value ?? string.Empty;
+    public CorrelationId Current => _current.Value ?? Guid.Empty;
 
     /// <summary>
     /// Internal: Set the current correlation ID.

--- a/Source/DotNET/Applications/Execution/CorrelationIdActionFilter.cs
+++ b/Source/DotNET/Applications/Execution/CorrelationIdActionFilter.cs
@@ -15,13 +15,14 @@ public class CorrelationIdActionFilter(IOptions<ApplicationModelOptions> options
     /// <inheritdoc/>
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        var correlationId = context.HttpContext.Request.Headers[options.Value.CorrelationId.HttpHeader].ToString() ?? string.Empty;
-        if (string.IsNullOrEmpty(correlationId))
+        var correlationIdAsString = context.HttpContext.Request.Headers[options.Value.CorrelationId.HttpHeader].ToString() ?? Guid.Empty.ToString();
+        if (string.IsNullOrEmpty(correlationIdAsString))
         {
-            correlationId = Guid.NewGuid().ToString();
-            context.HttpContext.Request.Headers[Constants.DefaultCorrelationIdHeader] = correlationId;
+            correlationIdAsString = Guid.NewGuid().ToString();
+            context.HttpContext.Request.Headers[Constants.DefaultCorrelationIdHeader] = correlationIdAsString;
         }
 
+        var correlationId = Guid.Parse(correlationIdAsString);
         context.HttpContext.Items[Constants.CorrelationIdItemKey] = correlationId;
         CorrelationIdAccessor.SetCurrent(correlationId);
 

--- a/Source/DotNET/Applications/Execution/HttpContextCorrelationIdExtensions.cs
+++ b/Source/DotNET/Applications/Execution/HttpContextCorrelationIdExtensions.cs
@@ -23,8 +23,17 @@ public static class HttpContextCorrelationIdExtensions
     {
         if (httpContext.Items.TryGetValue(Constants.CorrelationIdItemKey, out var correlationId))
         {
-            return new CorrelationId((string)correlationId!);
+            if (correlationId is Guid guid)
+            {
+                return new CorrelationId(guid);
+            }
+
+            if (Guid.TryParse(correlationId?.ToString(), out var parsedGuid))
+            {
+                return new CorrelationId(parsedGuid);
+            }
         }
-        return new CorrelationId(string.Empty);
+
+        return new CorrelationId(Guid.Empty);
     }
 }

--- a/Source/DotNET/Applications/Queries/QueryResult.cs
+++ b/Source/DotNET/Applications/Queries/QueryResult.cs
@@ -25,7 +25,7 @@ public class QueryResult<T>
     /// <summary>
     /// Gets the <see cref="CorrelationId"/> associated with the command.
     /// </summary>
-    public CorrelationId CorrelationId { get; init; } = new(Guid.Empty.ToString());
+    public CorrelationId CorrelationId { get; init; } = new(Guid.Empty);
 
     /// <summary>
     /// The data returned.

--- a/Source/JavaScript/Applications.React.MVVM/package.json
+++ b/Source/JavaScript/Applications.React.MVVM/package.json
@@ -52,7 +52,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.8",
+        "@cratis/fundamentals": "5.3.9",
         "mobx": "6.13.1",
         "mobx-react": "9.1.1",
         "react": "18.3.1",

--- a/Source/JavaScript/Applications.React/package.json
+++ b/Source/JavaScript/Applications.React/package.json
@@ -57,7 +57,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.8",
+        "@cratis/fundamentals": "5.3.9",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications.Vite/package.json
+++ b/Source/JavaScript/Applications.Vite/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.3.8",
+        "@cratis/fundamentals": "5.3.9",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications/package.json
+++ b/Source/JavaScript/Applications/package.json
@@ -51,7 +51,7 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "5.3.8",
+        "@cratis/fundamentals": "5.3.9",
         "handlebars": "4.7.8"
     }
 }


### PR DESCRIPTION
### Fixed

- Upgrading Cratis.Fundamentals to 5.3.9
- Fixing all usage of `CorrelationId` to now use it as a `Guid` as this has changed.
