### PR TITLE
Fixing so that we only stop queries for required arguments not set

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="5.4.2" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="5.5.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />

--- a/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/CartForCurrentUser.ts
@@ -21,7 +21,7 @@ export class CartForCurrentUser extends QueryFor<Cart> {
         super(Cart, false);
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
         ];
     }

--- a/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
+++ b/Samples/eCommerce/Basic/Web/API/Carts/ObserveCartForCurrentUser.ts
@@ -21,7 +21,7 @@ export class ObserveCartForCurrentUser extends ObservableQueryFor<Cart> {
         super(Cart, false);
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
         ];
     }

--- a/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/AllProducts.ts
@@ -61,7 +61,7 @@ export class AllProducts extends QueryFor<Product[]> {
         this._sortBy = new AllProductsSortBy(this);
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
         ];
     }

--- a/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
+++ b/Samples/eCommerce/Basic/Web/API/Products/ObserveAllProducts.ts
@@ -61,7 +61,7 @@ export class ObserveAllProducts extends ObservableQueryFor<Product[]> {
         this._sortBy = new ObserveAllProductsSortBy(this);
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
         ];
     }

--- a/Source/DotNET/Tools/ProxyGenerator/ParameterInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ParameterInfoExtensions.cs
@@ -19,7 +19,8 @@ public static class ParameterInfoExtensions
     public static RequestArgumentDescriptor ToRequestArgumentDescriptor(this ParameterInfo parameterInfo)
     {
         var type = parameterInfo.ParameterType.GetTargetType();
-        return new RequestArgumentDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, parameterInfo.HasDefaultValue);
+        var optional = parameterInfo.IsOptional() || parameterInfo.HasDefaultValue;
+        return new RequestArgumentDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, optional);
     }
 
     /// <summary>
@@ -34,6 +35,17 @@ public static class ParameterInfoExtensions
         bool HasConstructorParameterWithRequestArgument(PropertyInfo propertyInfo) => parameters.Any(_ => _.Name == propertyInfo.Name && _.IsRequestArgument());
         var requestProperties = properties.Where(_ => _.IsRequestArgument() || HasConstructorParameterWithRequestArgument(_)).ToArray();
         return requestProperties.Select(_ => _.ToRequestArgumentDescriptor());
+    }
+
+    /// <summary>
+    /// Check if a parameter is optional - typically for arguments or properties.
+    /// </summary>
+    /// <param name="parameter">Parameter to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsOptional(this ParameterInfo parameter)
+    {
+        return parameter.CustomAttributes.Any(_ =>
+            _.AttributeType.FullName?.StartsWith("System.Runtime.CompilerServices.NullableAttribute") ?? false);
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -31,7 +31,7 @@ public static class PropertyExtensions
                attributes.Any(_ => _ == WellKnownTypes.FromQueryAttribute);
     }
 
-   /// <summary>
+    /// <summary>
     /// Convert a <see cref="PropertyInfo"/> to a <see cref="RequestArgumentDescriptor"/>.
     /// </summary>
     /// <param name="propertyInfo">Parameter to convert.</param>
@@ -39,7 +39,19 @@ public static class PropertyExtensions
     public static RequestArgumentDescriptor ToRequestArgumentDescriptor(this PropertyInfo propertyInfo)
     {
         var type = propertyInfo.PropertyType.GetTargetType();
-        return new RequestArgumentDescriptor(propertyInfo.PropertyType, propertyInfo.Name!, type.Type, false);
+        var optional = propertyInfo.IsOptional();
+        return new RequestArgumentDescriptor(propertyInfo.PropertyType, propertyInfo.Name!, type.Type, optional);
+    }
+
+    /// <summary>
+    /// Check if a property is optional - typically for arguments or properties.
+    /// </summary>
+    /// <param name="property">Property to check.</param>
+    /// <returns>True if it is, false if not.</returns>
+    public static bool IsOptional(this PropertyInfo property)
+    {
+        return property.CustomAttributes.Any(_ =>
+            _.AttributeType.FullName?.StartsWith("System.Runtime.CompilerServices.NullableAttribute") ?? false);
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
@@ -69,7 +69,8 @@ public static class QueryExtensions
             responseModel.IsEnumerable,
             responseModel.IsObservable,
             imports.ToOrderedImports(),
-            method.GetArgumentDescriptors(),
+            arguments,
+            arguments.Where(_ => !_.IsOptional).ToList(),
             propertyDescriptors,
             [.. typesInvolved, .. additionalTypesInvolved]);
     }

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -89,11 +89,11 @@ export class {{Name}} extends ObservableQueryFor<{{Model}}> {
 {{/if}}
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
-            {{#Arguments}}
+            {{#RequiredArguments}}
             '{{camelcase Name}}',
-            {{/Arguments}}
+            {{/RequiredArguments}}
         ];
     }
 

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -90,11 +90,11 @@ export class {{Name}} extends QueryFor<{{Model}}> {
 {{/if}}
     }
 
-    get requestArguments(): string[] {
+    get requiredRequestArguments(): string[] {
         return [
-            {{#Arguments}}
+            {{#RequiredArguments}}
             '{{camelcase Name}}',
-            {{/Arguments}}
+            {{/RequiredArguments}}
         ];
     }
 

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/QueryDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/QueryDescriptor.cs
@@ -19,6 +19,7 @@ namespace Cratis.Applications.ProxyGenerator.Templates;
 /// <param name="IsObservable">Whether or not it is an observable query or not.</param>
 /// <param name="Imports">Additional import statements.</param>
 /// <param name="Arguments">Arguments for the query.</param>
+/// <param name="RequiredArguments">Arguments that are required for the query.</param>
 /// <param name="Properties">Properties for the query.</param>
 /// <param name="TypesInvolved">Collection of types involved in the query.</param>
 public record QueryDescriptor(
@@ -33,5 +34,6 @@ public record QueryDescriptor(
     bool IsObservable,
     IOrderedEnumerable<ImportStatement> Imports,
     IEnumerable<RequestArgumentDescriptor> Arguments,
+    IEnumerable<RequestArgumentDescriptor> RequiredArguments,
     IEnumerable<PropertyDescriptor> Properties,
     IEnumerable<Type> TypesInvolved) : IDescriptor;

--- a/Source/JavaScript/Applications.React.MVVM/package.json
+++ b/Source/JavaScript/Applications.React.MVVM/package.json
@@ -52,7 +52,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.4.2",
+        "@cratis/fundamentals": "5.5.0",
         "mobx": "6.13.1",
         "mobx-react": "9.1.1",
         "react": "18.3.1",

--- a/Source/JavaScript/Applications.React/package.json
+++ b/Source/JavaScript/Applications.React/package.json
@@ -57,7 +57,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.4.2",
+        "@cratis/fundamentals": "5.5.0",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
@@ -25,7 +25,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
     }, [currentPaging, currentSorting]);
 
     const [result, setResult] = useState<QueryResultWithState<TDataType>>(QueryResultWithState.empty(queryInstance.current.defaultValue));
-    const argumentsDependency = queryInstance.current.requestArguments.map(_ => args?.[_]);
+    const argumentsDependency = queryInstance.current.requiredRequestArguments.map(_ => args?.[_]);
 
     useEffect(() => {
         const subscription = queryInstance.current!.subscribe(response => {

--- a/Source/JavaScript/Applications.Vite/package.json
+++ b/Source/JavaScript/Applications.Vite/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@cratis/applications": "1.0.0",
-        "@cratis/fundamentals": "5.4.2",
+        "@cratis/fundamentals": "5.5.0",
         "handlebars": "4.7.8",
         "react": "18.3.1"
     },

--- a/Source/JavaScript/Applications/package.json
+++ b/Source/JavaScript/Applications/package.json
@@ -51,7 +51,7 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "5.4.2",
+        "@cratis/fundamentals": "5.5.0",
         "handlebars": "4.7.8"
     }
 }

--- a/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
@@ -20,7 +20,7 @@ export type OnNextResult<TDataType> = (data: TDataType) => void;
 export interface IObservableQueryFor<TDataType, TArguments = {}> {
     readonly route: string;
     readonly routeTemplate: Handlebars.TemplateDelegate;
-    readonly requestArguments: string[];
+    readonly requiredRequestArguments: string[];
     readonly defaultValue: TDataType;
 
     /**

--- a/Source/JavaScript/Applications/queries/IQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IQueryFor.ts
@@ -14,7 +14,7 @@ import { Sorting } from './Sorting';
 export interface IQueryFor<TDataType, TArguments = {}> {
     readonly route: string;
     readonly routeTemplate: Handlebars.TemplateDelegate;
-    readonly requestArguments: string[];
+    readonly requiredRequestArguments: string[];
     readonly defaultValue: TDataType;
 
     /**

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -27,7 +27,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
     abstract readonly route: string;
     abstract readonly routeTemplate: Handlebars.TemplateDelegate<any>;
     abstract readonly defaultValue: TDataType;
-    abstract get requestArguments(): string[];
+    abstract get requiredRequestArguments(): string[];
     sorting: Sorting;
     paging: Paging | undefined;
 
@@ -65,7 +65,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
             connectionQueryArguments.sortDirection = (this.sorting.direction === SortDirection.descending) ? 'desc' : 'asc';
         }
 
-        if (!ValidateRequestArguments(this.constructor.name, this.requestArguments, args)) {
+        if (!ValidateRequestArguments(this.constructor.name, this.requiredRequestArguments, args)) {
             this._connection = new NullObservableQueryConnection(this.defaultValue);
         } else {
             actualRoute = this.routeTemplate(args);

--- a/Source/JavaScript/Applications/queries/QueryFor.ts
+++ b/Source/JavaScript/Applications/queries/QueryFor.ts
@@ -19,7 +19,7 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
     private _microservice: string;
     abstract readonly route: string;
     abstract readonly routeTemplate: Handlebars.TemplateDelegate;
-    abstract get requestArguments(): string[];
+    abstract get requiredRequestArguments(): string[];
     abstract defaultValue: TDataType;
     abortController?: AbortController;
     sorting: Sorting;
@@ -49,7 +49,7 @@ export abstract class QueryFor<TDataType, TArguments = {}> implements IQueryFor<
         args = args || this.arguments;
 
         let actualRoute = this.route;
-        if (!ValidateRequestArguments(this.constructor.name, this.requestArguments, args)) {
+        if (!ValidateRequestArguments(this.constructor.name, this.requiredRequestArguments, args)) {
             return new Promise<QueryResult<TDataType>>((resolve) => {
                 resolve(noSuccess);
             });


### PR DESCRIPTION
### Fixed

- Only actual required arguments for queries will now stop a query from not being performed. This means that if you have nullables as arguments, these don't have to be set. Same if there is a default value for a parameter on the method signature of the action representing the query. This is now generated correctly by the proxy generator.
