### PR TITLE
Make sure we pass the correct total items from query context

### DIFF
--- a/Source/DotNET/Applications/Queries/QueryContext.cs
+++ b/Source/DotNET/Applications/Queries/QueryContext.cs
@@ -14,7 +14,7 @@ namespace Cratis.Applications.Queries;
 public record QueryContext(CorrelationId CorrelationId, Paging Paging, Sorting Sorting)
 {
     /// <summary>
-    /// Gets the total number of items in the query.
+    /// Gets or sets the total number of items in the query.
     /// </summary>
-    public long TotalItems { get; set; }
+    public int TotalItems { get; set; }
 }

--- a/Source/DotNET/Applications/Queries/QueryProviders.cs
+++ b/Source/DotNET/Applications/Queries/QueryProviders.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
+using Cratis.Execution;
 using Cratis.Types;
 
 namespace Cratis.Applications.Queries;
@@ -10,10 +11,12 @@ namespace Cratis.Applications.Queries;
 /// Represents an implementation of <see cref="IQueryProviders"/>.
 /// </summary>
 /// <param name="queryContextManager"><see cref="IQueryContextManager"/> for managing query contexts.</param>
+/// <param name="correlationIdAccessor"><see cref="ICorrelationIdAccessor"/> for getting the current correlation ID.</param>
 /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
 /// <param name="serviceProvider"><see cref="IServiceProvider"/> for getting instances of query providers.</param>
 public class QueryProviders(
     IQueryContextManager queryContextManager,
+    ICorrelationIdAccessor correlationIdAccessor,
     ITypes types,
     IServiceProvider serviceProvider) : IQueryProviders
 {
@@ -24,9 +27,10 @@ public class QueryProviders(
     {
         var queryType = query.GetType();
         var queryProviderType = _queryProviders.FirstOrDefault(_ => queryType.IsAssignableTo(_.GetInterface(typeof(IQueryProviderFor<>).Name)!.GetGenericArguments()[0]));
+        var queryContext = queryContextManager.Current ?? new QueryContext(correlationIdAccessor.Current, Paging.NotPaged, Sorting.None);
         if (queryProviderType == null)
         {
-            return new(0, (query as IEnumerable)!);
+            return new(queryContext.TotalItems, (query as IEnumerable)!);
         }
 
         var queryProvider = serviceProvider.GetService(queryProviderType);

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -266,7 +266,7 @@ public static class MongoCollectionExtensions
 
     static async Task UpdateTotalItems<TDocument>(QueryContext queryContext, IFindFluent<TDocument, TDocument> query)
     {
-        queryContext.TotalItems = await query.CountDocumentsAsync();
+        queryContext.TotalItems = (int)await query.CountDocumentsAsync();
     }
 
     static async Task<List<TDocument>> HandleChange<TDocument, TResult>(


### PR DESCRIPTION
### Fixed

- Fixing so that the `TotalItems` from the `QueryContext` gets passed in `QueryResult` for all types of queries. This way, you can easily work with paging for any types without having to implement a specific query provider.
