### PR TITLE
Filter imports for a type itself - to avoid recursiveness

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/TargetType.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TargetType.cs
@@ -6,8 +6,9 @@ namespace Cratis.Applications.ProxyGenerator;
 /// <summary>
 /// Represents a target type and optional import module.
 /// </summary>
+/// <param name="OriginalType">The original type.</param>
 /// <param name="Type">Type.</param>
 /// <param name="Constructor">The JavaScript constructor type.</param>
 /// <param name="Module">Module the type should be imported from. default or empty means no need to import.</param>
 /// <param name="Final">Whether or not it absolutely is this type and do not try to resolve a more specific one.</param>
-public record TargetType(string Type, string Constructor, string Module = "", bool Final = false);
+public record TargetType(Type OriginalType, string Type, string Constructor, string Module = "", bool Final = false);

--- a/Source/DotNET/Tools/ProxyGenerator/TargetTypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TargetTypeExtensions.cs
@@ -23,7 +23,7 @@ public static class TargetTypeExtensions
         var requiresImport = !string.IsNullOrEmpty(targetType.Module);
         if (requiresImport)
         {
-            importStatement = new ImportStatement(targetType.Type, targetType.Module);
+            importStatement = new ImportStatement(targetType.OriginalType, targetType.Type, targetType.Module);
         }
         return requiresImport;
     }

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ImportStatement.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ImportStatement.cs
@@ -11,13 +11,20 @@ public record ImportStatement
     /// <summary>
     /// Initializes a new instance of the <see cref="ImportStatement"/> class.
     /// </summary>
+    /// <param name="originalType">The original type of the property.</param>
     /// <param name="type">Type to use.</param>
     /// <param name="module">Source module the type is originating from.</param>
-    public ImportStatement(string type, string module)
+    public ImportStatement(Type originalType, string type, string module)
     {
+        OriginalType = originalType;
         Type = type;
         Module = module.Replace('\\', '/');
     }
+
+    /// <summary>
+    /// Gets the original type.
+    /// </summary>
+    public Type OriginalType { get; }
 
     /// <summary>
     /// Gets the type to use.


### PR DESCRIPTION
### Fixed

- Proxy generator will now ignore importing types that are recursively referring to themselves. This caused a TS compiler error.
