### PR TITLE
Making sure all import statements are unique per type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,12 +25,12 @@
             "cwd": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator",
             "program": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator/bin/Debug/net8.0/Cratis.Applications.ProxyGenerator.dll",
             "args": [
-                // "/Volumes/Code/KDI/Ocean/Source/Accounts/Api/bin/Debug/net8.0/Api.dll",
-                // "/Volumes/Code/KDI/Ocean/Source/Accounts/Web/Api",
+                "/Volumes/Code/KDI/Ocean/Source/Exercises/Main/bin/Debug/net8.0/Kongsberg.KSim.Ocean.Exercises.Main.dll",
+                "/Volumes/Code/KDI/Ocean/Source/Exercises/Web/Api",
                 // "/Volumes/Code/Cratis/Chronicle/Source/Api/bin/Debug/net8.0/Cratis.Chronicle.Api.dll",
                 // "/Volumes/Code/Cratis/Chronicle/Source/Workbench/Api",
-                "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
-                "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
+                // "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
+                // "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
                 "1"
             ],
             "stopAtEntry": false,

--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -59,7 +59,7 @@ public static class CommandExtensions
             property.CollectTypesInvolved(additionalTypesInvolved);
         }
 
-        imports = imports.Distinct().ToList();
+        imports = imports.DistinctBy(_ => _.Type).ToList();
 
         var route = method.GetRoute();
 

--- a/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
@@ -42,7 +42,10 @@ public static class QueryExtensions
         var argumentsWithComplexTypes = arguments.Where(_ => !_.OriginalType.IsKnownType());
         typesInvolved.AddRange(argumentsWithComplexTypes.Select(_ => _.OriginalType));
 
-        var imports = typesInvolved.GetImports(targetPath, method.DeclaringType!.ResolveTargetPath(segmentsToSkip), segmentsToSkip).ToList();
+        var imports = typesInvolved
+                        .GetImports(targetPath, method.DeclaringType!.ResolveTargetPath(segmentsToSkip), segmentsToSkip)
+                        .DistinctBy(_ => _.Type)
+                        .ToList();
 
         var additionalTypesInvolved = new List<Type>();
         foreach (var argument in argumentsWithComplexTypes)

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -300,8 +300,9 @@ public static class TypeExtensions
 
         imports.AddRange(typesInvolved.GetImports(targetPath, type!.ResolveTargetPath(segmentsToSkip), segmentsToSkip));
         imports = imports
-                    .Distinct()
-                    .Where(_ => propertyDescriptors.Exists(pd => pd.Type == _.Type) && _.OriginalType != type).ToList();
+                    .DistinctBy(_ => _.Type)
+                    .Where(_ => propertyDescriptors.Exists(pd => pd.Type == _.Type) && _.OriginalType != type)
+                    .ToList();
 
         return new TypeDescriptor(
             type,


### PR DESCRIPTION
### Fixed

- Fixing a problem with multiple import statements that could occur if you had a type that had multiple properties of the same type that needed import statements. Also making sure both Commands and Queries have distinct import statements.
