### PR TITLE
Avoiding problems if multiple calls to unsubscribe

### DIFF
--- a/Source/JavaScript/Applications/queries/ObservableQuerySubscription.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQuerySubscription.ts
@@ -19,7 +19,9 @@ export class ObservableQuerySubscription<TDataType> {
      * Unsubscribe subscription.
      */
     unsubscribe() {
-        this._connection.disconnect();
-        this._connection = undefined!;
+        if (this._connection) {
+            this._connection.disconnect();
+            this._connection = undefined!;
+        }
     }
 }


### PR DESCRIPTION
### Fixed

- Making `ObservableQuerySubscription` deal with multiple calls to it so it doesn't crash if that happens.
