### PR TITLE
Fix/cancel

### DIFF
--- a/Samples/eCommerce/Basic/Web/vite.config.mts
+++ b/Samples/eCommerce/Basic/Web/vite.config.mts
@@ -24,14 +24,14 @@ export default defineConfig({
         open: false,
         proxy: {
             '/api': {
-                target: 'http://localhost:5001',
+                target: 'http://localhost:5600',
                 ws: true
             },
             '/swagger': {
-                target: 'http://localhost:5001'
+                target: 'http://localhost:5600'
             },
             '/.cratis': {
-                target: 'http://localhost:5001'
+                target: 'http://localhost:5600'
             }
         }
     },

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -9,6 +9,6 @@ namespace MongoDB.Driver;
 
 internal static partial class MongoCollectionExtensionsLogMessages
 {
-    [LoggerMessage(LogLevel.Trace, "Cursor '{Name}' disposed")]
-    internal static partial void CursorDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger, string name);
+    [LoggerMessage(LogLevel.Trace, "Cursor disposed")]
+    internal static partial void CursorDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 }


### PR DESCRIPTION
### Fixed

- Making sure to cancel the cancellation token source for MongoDB observations, also passing along the `CancellationToken` to the `WatchAsync()` method.