### PR TITLE
Feature/query-provider

### DIFF
--- a/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
+++ b/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
@@ -7,6 +7,7 @@ import { DialogButtons, IDialogs } from '@cratis/applications.react.mvvm/dialogs
 import { CustomDialogRequest } from './CustomDialog';
 import { IMessenger } from '@cratis/applications.react.mvvm/messaging';
 import { IViewModelDetached } from '@cratis/applications.react.mvvm';
+import { IQueryProvider } from '@cratis/applications/queries';
 
 export class Something {
     constructor(readonly value: string) {
@@ -18,10 +19,13 @@ export class Something {
 export class FeatureViewModel implements IViewModelDetached {
     constructor(
         private readonly _messenger: IMessenger,
-        private readonly _dialogs: IDialogs) {
+        private readonly _dialogs: IDialogs,
+        private readonly queryProvider: IQueryProvider) {
         // query.subscribe(async result => {
         //     this.cart = result.data;
         // });
+
+        const query = queryProvider.get(ObserveCartForCurrentUser);
 
         _messenger.subscribe(Something, something => {
             console.log(`Got something: ${something.value}`);

--- a/Source/JavaScript/Applications.React.MVVM/index.ts
+++ b/Source/JavaScript/Applications.React.MVVM/index.ts
@@ -5,17 +5,13 @@ import 'reflect-metadata';
 import * as browser from './browser';
 import * as messaging from './messaging';
 import * as dialogs from './dialogs';
-import { Bindings } from './Bindings';
-import { MVVM, MVVMContext, MVVMProps } from './MVVMContext';
+export * from './Bindings';
+export * from './MVVMContext';
 export * from './withViewModel';
 export * from './IViewModelDetached';
 
 export {
-    Bindings,
     browser,
     messaging,
-    dialogs,
-    MVVM,
-    MVVMContext,
-    MVVMProps
+    dialogs
 };

--- a/Source/JavaScript/Applications.React.MVVM/tsconfig.json
+++ b/Source/JavaScript/Applications.React.MVVM/tsconfig.json
@@ -7,6 +7,9 @@
     "references": [
         {
             "path": "../Applications"
+        },
+        {
+            "path": "../Applications.React"
         }
     ],
     "exclude": [

--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -4,7 +4,8 @@
 import { Globals } from '@cratis/applications';
 import { CommandScope } from './commands';
 import { IdentityProvider } from './identity';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { Bindings } from './Bindings';
 
 export interface ApplicationModelProps {
     children?: JSX.Element | JSX.Element[];
@@ -23,6 +24,9 @@ export const ApplicationModel = (props: ApplicationModelProps) => {
     const configuration: ApplicationModelConfiguration = {
         microservice: props.microservice
     };
+
+    Bindings.initialize(configuration.microservice);
+
     return (
         <ApplicationModelContext.Provider value={configuration}>
             <IdentityProvider>

--- a/Source/JavaScript/Applications.React/Bindings.ts
+++ b/Source/JavaScript/Applications.React/Bindings.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { container } from 'tsyringe';
+import { IQueryProvider, QueryProvider } from '@cratis/applications/queries';
+import { Constructor } from '@cratis/fundamentals';
+
+export class Bindings {
+    static initialize(microservice: string) {
+        container.registerSingleton('Microservice', microservice);
+        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice) });
+    }
+}

--- a/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IObservableQueryFor.ts
@@ -4,8 +4,7 @@
 import Handlebars from 'handlebars';
 import { ObservableQuerySubscription } from './ObservableQuerySubscription';
 import { QueryResult } from './QueryResult';
-import { Paging } from './Paging';
-import { Sorting } from './Sorting';
+import { IQuery } from './IQuery';
 
 /**
  * The delegate type representing the callback of result from the server.
@@ -17,37 +16,11 @@ export type OnNextResult<TDataType> = (data: TDataType) => void;
  * @template TDataType Type of model the query is for.
  * @template TArguments Optional type of arguments to use for the query.
  */
-export interface IObservableQueryFor<TDataType, TArguments = {}> {
+export interface IObservableQueryFor<TDataType, TArguments = {}> extends IQuery {
     readonly route: string;
     readonly routeTemplate: Handlebars.TemplateDelegate;
     readonly requiredRequestArguments: string[];
     readonly defaultValue: TDataType;
-
-    /**
-     * Gets the sorting for the query.
-     */
-    get sorting(): Sorting;
-
-    /**
-     * Sets the sorting for the query.
-     */
-    set sorting(value: Sorting);
-
-    /**
-     * Gets the paging for the query.
-     */
-    get paging(): Paging | undefined;
-
-    /**
-     * Sets the paging for the query.
-     */ 
-    set paging(value: Paging);
-
-    /**
-     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
-     * @param microservice Name of microservice
-     */
-    setMicroservice(microservice: string);
 
     /**
      * Subscribe to the query. This will create a subscription onto the server.

--- a/Source/JavaScript/Applications/queries/IQuery.ts
+++ b/Source/JavaScript/Applications/queries/IQuery.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Paging } from './Paging';
+import { Sorting } from './Sorting';
+
+/**
+ * Defines the commonalities between all query types.
+ */
+export interface IQuery {
+    /**
+     * Gets the sorting for the query.
+     */
+    get sorting(): Sorting;
+
+    /**
+     * Sets the sorting for the query.
+     */
+    set sorting(value: Sorting);
+
+    /**
+     * Gets the paging for the query.
+     */
+    get paging(): Paging;
+
+    /**
+     * Sets the paging for the query.
+     */
+    set paging(value: Paging);
+
+    /**
+     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
+     * @param microservice Name of microservice
+     */
+    setMicroservice(microservice: string);
+}

--- a/Source/JavaScript/Applications/queries/IQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IQueryFor.ts
@@ -1,57 +1,30 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Paging } from './Paging';
 import { QueryResult } from './QueryResult';
 import Handlebars from 'handlebars';
-import { Sorting } from './Sorting';
+import { IQuery } from './IQuery';
 
 /**
  * Defines the base of a query.
  * @template TDataType Type of model the query is for.
  * @template TArguments Optional type of arguments to use for the query.
  */
-export interface IQueryFor<TDataType, TArguments = {}> {
+export interface IQueryFor<TDataType, TArguments = {}> extends IQuery {
     readonly route: string;
     readonly routeTemplate: Handlebars.TemplateDelegate;
     readonly requiredRequestArguments: string[];
     readonly defaultValue: TDataType;
 
     /**
-     * Gets the sorting for the query.
-     */
-    get sorting(): Sorting;
-
-    /**
-     * Sets the sorting for the query.
-     */
-    set sorting(value: Sorting);
-
-    /**
-     * Gets the paging for the query.
-     */
-    get paging(): Paging;
-
-    /**
-     * Sets the paging for the query.
-     */ 
-    set paging(value: Paging);
-
-    /**
      * Gets the current arguments for the query.
-     */    
+     */
     get arguments(): TArguments | undefined;
 
     /**
      * Sets the current arguments for the query.
-     */    
-    set arguments(value: TArguments);
-
-    /**
-     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
-     * @param microservice Name of microservice
      */
-    setMicroservice(microservice: string);
+    set arguments(value: TArguments);
 
     /**
      * Perform the query, optionally giving arguments to use. If not given, it will use the arguments that has been set.

--- a/Source/JavaScript/Applications/queries/IQueryProvider.ts
+++ b/Source/JavaScript/Applications/queries/IQueryProvider.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { IQuery } from './IQuery';
+
+/**
+ * Defines the provider for queries.
+ */
+export abstract class IQueryProvider {
+
+    /**
+     * Gets a new instance of a specific query type.
+     * @param {Constructor} queryType Type of query to get an instance of.
+     */
+    abstract get<T extends IQuery>(queryType: Constructor<T>): T;
+}

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -29,7 +29,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
     abstract readonly defaultValue: TDataType;
     abstract get requiredRequestArguments(): string[];
     sorting: Sorting;
-    paging: Paging | undefined;
+    paging: Paging;
 
     /**
      * Initializes a new instance of the {@link ObservableQueryFor<,>}} class.
@@ -38,6 +38,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = {}> implements 
      */
     constructor(readonly modelType: Constructor, readonly enumerable: boolean) {
         this.sorting = Sorting.none;
+        this.paging = Paging.noPaging;
         this._microservice = Globals.microservice ?? '';
     }
 

--- a/Source/JavaScript/Applications/queries/QueryProvider.ts
+++ b/Source/JavaScript/Applications/queries/QueryProvider.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { IQueryProvider } from './IQueryProvider';
+import { IQuery } from './IQuery';
+
+/**
+ * Represents an implementation of {@link IQueryProvider}
+ */
+export class QueryProvider implements IQueryProvider {
+
+    /**
+     * Initializes a new instance of {@link QueryProvider}
+     * @param _microservice Name of the microservice to provide queries for.
+     */
+    constructor(private readonly _microservice: string) { }
+
+    /** @inheritdoc */
+    get<T extends IQuery>(queryType: Constructor<T>): T {
+        const query = new queryType();
+        query.setMicroservice(this._microservice);
+        return query;
+    }
+}

--- a/Source/JavaScript/Applications/queries/index.ts
+++ b/Source/JavaScript/Applications/queries/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './IQuery';
 export * from './IQueryFor';
 export * from './Paging';
 export * from './Sorting';
@@ -16,3 +17,5 @@ export * from './ObservableQueryFor';
 export * from './IObservableQueryConnection';
 export * from './ObservableQueryConnection';
 export * from './ObservableQuerySubscription';
+export * from './IQueryProvider';
+export * from './QueryProvider';


### PR DESCRIPTION
### Added

- Adding a provider that can provide instances of queries through the interface `IQueryProvider` and implementation `QueryProvider` in `@cratis/applications/queries`. The purpose of this is to be able to provide instances that are automatically configured correctly with things like the current microservice. This can now be injected in things like a view model.
