### PR TITLE
Separating out identity to be able to use it without React and from view models

### DIFF
--- a/Documentation/frontend/core/identity.md
+++ b/Documentation/frontend/core/identity.md
@@ -1,0 +1,83 @@
+# Identity
+
+The frontend identity is based on information it gets from a cookie called `.cratis-identity`. The purpose of this is to be able to
+provide identity information to the client at the first render. This allows for a better developer and user experience, as there is no need
+to call the backend for details about the user.
+
+While in development mode on your local machine, if this cookie does not exist it will call the `.cratis/me` endpoint from the frontend
+itself. This makes it possible to work without having to simulate the entire production environment locally.
+
+> Important note: Since local development is not configured with the identity provider, but you still need a way to test that both the backend and the frontend
+> deals with the identity in the correct way. This can be achieved by creating the correct token and injecting it as request headers using
+> a browser extension. Read more [here](../../general/generating-principal.md).
+
+This information found in the cookie is a base64 encoded string containing the JSON structure that is expected.
+
+## Identity provider
+
+Identity is a read only feature in the frontend. It can't be manipulated, as it is owned by the backend or the ingress.
+All access to identity goes through what is called `IdentityProvider`.
+
+The `IdentityProvider` provides functionality for getting the current identity.
+
+```typescript
+import { IdentityProvider } from '@cratis/applications/identity';
+
+const identity = await IdentityProvider.getCurrent();
+
+console.log(`Hello '${identity.name}'`);
+```
+
+> Note that the `getCurrent()` method is an asynchronous operation that returns a promise.
+> The reason for this is that if the cookie is not found, it will call the `.cratis/me` endpoint to try to get the identity.
+
+## Details
+
+Part of the identity can hold details that are beyond what the identity provider provides. These details are application specific and something that your
+application or ingress should be responsible for filling out. Details can be considered optional, as that might not be a requirement for your application.
+
+The `getCurrent()` method takes a generic parameter that allows you to specify the type of the details object.
+
+```typescript
+import { IdentityProvider } from '@cratis/applications/identity';
+
+type IdentityDetails = {
+    department: string,
+    age: number
+};
+
+const identity = await IdentityProvider.getCurrent<IdentityDetails>();
+
+console.log(`Hello '${identity.name}' from ´${identity.details.department}`);
+```
+
+## IIdentity
+
+The return type coming from `getCurrent()` looks like the following:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| id | string | The unique identifier from the identity provider |
+| name | string | The user name |
+| claims | { [key: string]: string; } | Key/value of strings holding claims |
+| details | any / type | Any additional identity details with type given, defaults to `any` |
+
+## Refresh
+
+In some scenarios you might need to refresh the identity. Typically if the user has been granted more access or details has been updated.
+Rather than having your user log out and back in again, you can issue a refresh. Since the cookie is there and not governed by the frontend, it
+needs to call the backend or ingress to perform the refresh. The refresh calls the `.cratis/me` endpoint which returns the identity and details.
+This endpoint should also be responsible for updating the cookie so that any call to `getCurrent()` on the `IdentityProvider` gives you the correct
+identity and details.
+
+To refresh the identity you can call the `refresh()` method on the identity object itself.
+
+```typescript
+import { IdentityProvider } from '@cratis/applications/identity';
+
+let identity = await IdentityProvider.getCurrent();
+identity = await identity.refresh();
+```
+
+The identity object is designed to be immutable, leading to the `refresh()` method having to return a new instance.
+This means that the original `identity` instance won't be updated and you would have to replace it if you have it as a variable.

--- a/Documentation/frontend/core/index.md
+++ b/Documentation/frontend/core/index.md
@@ -1,0 +1,5 @@
+# Core
+
+| Topic | Description |
+| ------- | ----------- |
+| Identity | Details about how identity works in the frontend |

--- a/Documentation/frontend/core/toc.yml
+++ b/Documentation/frontend/core/toc.yml
@@ -1,0 +1,2 @@
+- name: Identity
+  href: identity.md

--- a/Documentation/frontend/react.mvvm/identity.md
+++ b/Documentation/frontend/react.mvvm/identity.md
@@ -1,0 +1,31 @@
+# Identity
+
+The MVVM implementation of identity is built on top of what you find the [core](../core/identity.md).
+To access identity in an MVVM solution with a view model, the `IdentityProvider` is hooked up to the [container](./tsyringe.md)
+through its interface `IIdentityProvider`.
+
+> Note: This depends on the [MVVM Context](./mvvm-context.md) being used.
+
+```typescript
+import { injectable } from 'tsyringe';
+import { IIdentityProvider } from '@cratis/applications/identity';
+
+type IdentityDetails = {
+    department: string,
+    age: number
+};
+
+@injectable()
+export class MyViewModel {
+    constructor(private readonly _identityProvider: IIdentityProvider) {
+    }
+
+    async sayHello() {
+        const identity = await this._identityProvider.getCurrent<IdentityDetails>();
+        console.log(`Hello '${identity.name}' from ´${identity.details.department}`);
+    }
+}
+```
+
+The code takes a dependency to the abstract class called `IIdentityProvider` representing the interface for the identity provider.
+With this the code simply calls the `getCurrent()` method to get the identity.

--- a/Documentation/frontend/react.mvvm/index.md
+++ b/Documentation/frontend/react.mvvm/index.md
@@ -6,5 +6,6 @@
 | [Tsyringe and Bindings](./tsyringe.md) | How to configure the IoC for your application. |
 | [Using a ViewModel](./using-view-model.md) | Working with view models. |
 | [Messaging](./messaging.md) | Working with messaging for inter-component communication. |
+| [Identity](./identity.md) | Working with identity, typically from a view model. |
 | [Dialogs](./dialogs.md) | How to work with dialogs in a decoupled world. |
 | [Browser Interfaces](./browser.md) | Getting access to browser functionality without using `window`or `document`. |

--- a/Documentation/frontend/react.mvvm/toc.yml
+++ b/Documentation/frontend/react.mvvm/toc.yml
@@ -4,6 +4,8 @@
   href: browser.md
 - name: Messaging
   href: messaging.md
+- name: Identity
+  href: identity.md
 - name: MVVM Context
   href: mvvm-context.md
 - name: TSyringe

--- a/Documentation/frontend/react/identity.md
+++ b/Documentation/frontend/react/identity.md
@@ -1,27 +1,16 @@
 # Identity
 
-Based on the output of the [Cratis Middleware](https://github.com/cratis/IngressMiddleware), the frontend benefits from
-getting the user details provided by the application all the way into the frontend without having to make an extra call to the
-backend.
+The React implementation of identity is built on top of what you find the [core](../core/identity.md).
+It provides an encapsulation that feels more natural to a React application.
 
-While in development mode on your local machine, if there is no cookie it will call the `.cratis/me` endpoint from the frontend
-itself. This makes it possible to work without having to simulate the production environment.
-
-> Important note: Since local development is not configured with the identity provider, but you still need a way to test that both the backend and the frontend
-> deals with the identity in the correct way. This can be achieved by creating the correct token and injecting it as request headers using
-> a browser extension. Read more [here](../general/generating-principal.md).
-
-This information is stored in a cookie called `.cratis-identity`. The content of this is a base64 encoded string containing the
-JSON structure returned by the backend to the ingress middleware.
-
-## Identity context
+## Identity provider context
 
 To use the identity system you need to provide the identity context for your application.
 
 At the top level of your application, typically in your `App.tsx` file you would add the provider by doing the following:
 
 ```typescript
-import { IdentityProvider } from '@cratis/applications/identity';
+import { IdentityProvider } from '@cratis/applications.react/identity';
 
 export const App = () => {
     return (
@@ -35,7 +24,7 @@ export const App = () => {
 This context can then be used anywhere by consuming the React context directly:
 
 ```typescript
-import { IdentityProviderContext } from '@cratis/applications/identity';
+import { IdentityProviderContext } from '@cratis/applications.react/identity';
 
 export const SomeComponent = () => {
     return (
@@ -61,7 +50,7 @@ the context you find a method called `refresh()`. Calling this will invalidate t
 the backend to get the current identity details.
 
 ```typescript
-import { IdentityProviderContext } from '@cratis/applications/identity';
+import { IdentityProviderContext } from '@cratis/applications.react/identity';
 
 export const SomeComponent = () => {
     return (
@@ -85,7 +74,7 @@ export const SomeComponent = () => {
 Anywhere within your application you can then access the identity by adding using the `useIdentity()` hook:
 
 ```typescript
-import { useIdentity } from '@cratis/applications/identity';
+import { useIdentity } from '@cratis/applications.react/identity';
 
 export const Home = () => {
     const identity = useIdentity();
@@ -103,7 +92,7 @@ By default, if not specified, the type of the details is `any`. You can change t
 the exact shape of what's expected:
 
 ```typescript
-import { useIdentity } from '@cratis/applications/identity';
+import { useIdentity } from '@cratis/applications.react/identity';
 
 type Identity = {
     firstName: string;
@@ -125,7 +114,7 @@ Since the `useIdentity()` returns an instance of the `IIdentityContext`. So for 
 accessible:
 
 ```typescript
-import { useIdentity } from '@cratis/applications/identity';
+import { useIdentity } from '@cratis/applications.react/identity';
 
 type Identity = {
     firstName: string;
@@ -153,7 +142,7 @@ This is especially useful when working in local development and the cookie has n
 The default value can be provided as an argument to the `useIdentity()` hook:
 
 ```typescript
-import { useIdentity } from '@cratis/applications/identity';
+import { useIdentity } from '@cratis/applications.react/identity';
 
 type Identity = {
     firstName: string;

--- a/Documentation/frontend/toc.yml
+++ b/Documentation/frontend/toc.yml
@@ -1,3 +1,5 @@
+- name: Core
+  href: core/toc.yml
 - name: React
   href: react/toc.yml
 - name: MVVM with React

--- a/Samples/eCommerce/Basic/Main/Program.cs
+++ b/Samples/eCommerce/Basic/Main/Program.cs
@@ -86,6 +86,7 @@ if (RuntimeEnvironment.IsDevelopment)
 
 app.UseWebSockets();
 app.MapControllers();
+app.MapIdentityProvider();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapFallbackToFile("/index.html");

--- a/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
+++ b/Samples/eCommerce/Basic/Web/FeatureViewModel.ts
@@ -8,6 +8,7 @@ import { CustomDialogRequest } from './CustomDialog';
 import { IMessenger } from '@cratis/applications.react.mvvm/messaging';
 import { IViewModelDetached } from '@cratis/applications.react.mvvm';
 import { IQueryProvider } from '@cratis/applications/queries';
+import { IIdentityProvider } from '@cratis/applications/identity';
 
 export class Something {
     constructor(readonly value: string) {
@@ -20,12 +21,17 @@ export class FeatureViewModel implements IViewModelDetached {
     constructor(
         private readonly _messenger: IMessenger,
         private readonly _dialogs: IDialogs,
-        private readonly queryProvider: IQueryProvider) {
+        private readonly queryProvider: IQueryProvider,
+        private readonly identityProvider: IIdentityProvider) {
         // query.subscribe(async result => {
         //     this.cart = result.data;
         // });
 
         const query = queryProvider.get(ObserveCartForCurrentUser);
+
+        identityProvider.getCurrent().then(identity => {
+            console.log(`Hello ${identity.name}`);
+        });
 
         _messenger.subscribe(Something, something => {
             console.log(`Got something: ${something.value}`);

--- a/Source/JavaScript/Applications.React.MVVM/Bindings.ts
+++ b/Source/JavaScript/Applications.React.MVVM/Bindings.ts
@@ -5,11 +5,13 @@ import { container } from 'tsyringe';
 import { IMessenger, Messenger } from './messaging';
 import { Constructor } from '@cratis/fundamentals';
 import { ILocalStorage, INavigation, Navigation } from './browser';
+import { IdentityProvider, IIdentityProvider } from '@cratis/applications/identity';
 
 export class Bindings {
     static initialize() {
         container.registerSingleton(IMessenger as Constructor<IMessenger>, Messenger);
         container.registerSingleton(INavigation as Constructor<INavigation>, Navigation);
+        container.registerSingleton(IIdentityProvider as Constructor<IIdentityProvider>, IdentityProvider);
         container.registerInstance(ILocalStorage as Constructor<ILocalStorage>, localStorage);
     }
 }

--- a/Source/JavaScript/Applications.React/identity/IdentityProvider.tsx
+++ b/Source/JavaScript/Applications.React/identity/IdentityProvider.tsx
@@ -2,81 +2,45 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { IIdentityContext } from './IIdentityContext';
 import { useState, useEffect } from 'react';
+import { IIdentity } from '@cratis/applications/identity';
+import { IdentityProvider as RootIdentityProvider } from '@cratis/applications/identity';
 
-const defaultIdentityContext: IIdentityContext = {
+const defaultIdentityContext: IIdentity = {
     id: '',
     name: '',
     claims: {},
     details: {},
     isSet: false,
-    refresh() { }
+    refresh: () => {
+        return new Promise((resolve, reject) => {
+            reject('Not implemented');
+        });
+    }
 };
 
-export type IdentityProviderResult = {
-    id: string;
-    name: string;
-    claims: { [key: string]: string };
-    details: any;
-}
-
-export const IdentityProviderContext = React.createContext<IIdentityContext>(defaultIdentityContext);
-
-const cookieName = '.cratis-identity';
+export const IdentityProviderContext = React.createContext<IIdentity>(defaultIdentityContext);
 
 export interface IdentityProviderProps {
     children?: JSX.Element | JSX.Element[]
 }
 
-function getCookie(name: string) {
-    const decoded = decodeURIComponent(document.cookie);
-    const cookies = decoded.split(';');
-    const cookie = cookies.find(_ => _.trim().indexOf(`${name}=`) == 0);
-    if (cookie) {
-        const keyValue = cookie.split('=');
-        return [keyValue[0].trim(), keyValue[1].trim()];
-    }
-    return [];
-}
-
-function clearCookie(name: string) {
-    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
-}
-
 export const IdentityProvider = (props: IdentityProviderProps) => {
-    const [context, setContext] = useState<IIdentityContext>(defaultIdentityContext);
-    const refresh = () => {
-        clearCookie(cookieName);
-        fetch('/.cratis/me').then(async response => {
-            const result = await response.json() as IdentityProviderResult;
+    const [context, setContext] = useState<IIdentity>(defaultIdentityContext);
 
-            setContext({
-                id: result.id,
-                name: result.name,
-                claims: result.claims,
-                details: result.details,
-                isSet: true,
-                refresh
-            });
-        });
-    };
-    const identityCookie = getCookie(cookieName);
     useEffect(() => {
-        if (identityCookie.length == 2) {
-            const json = atob(identityCookie[1]);
-            const result = JSON.parse(json) as IdentityProviderResult;
-            setContext({
-                id: result.id,
-                name: result.name,
-                claims: result.claims,
-                details: result.details,
-                isSet: true,
-                refresh
-            });
-        } else {
-            refresh();
-        }
+        RootIdentityProvider.getCurrent().then(identity => {
+            const refresh = identity.refresh;
+            identity.refresh = () => {
+                return new Promise<IIdentity>(resolve => {
+                    refresh().then(newIdentity => {
+                        setContext(newIdentity);
+                        resolve(newIdentity);
+                    });
+                });
+            };
+            setContext(identity);
+        });
     }, []);
 
     return (

--- a/Source/JavaScript/Applications.React/identity/useIdentity.ts
+++ b/Source/JavaScript/Applications.React/identity/useIdentity.ts
@@ -3,15 +3,15 @@
 
 import React from 'react';
 import { IdentityProviderContext } from './IdentityProvider';
-import { IIdentityContext } from './IIdentityContext';
+import { IIdentity } from '@cratis/applications/identity';
 
 /**
  * Hook to get the identity context.
  * @param defaultDetails Optional default details to use if the context is not set.
  * @returns An identity context.
  */
-export function useIdentity<TDetails = {}>(defaultDetails?: TDetails | undefined | null): IIdentityContext<TDetails> {
-    const context = React.useContext(IdentityProviderContext) as IIdentityContext<TDetails>;
+export function useIdentity<TDetails = {}>(defaultDetails?: TDetails | undefined | null): IIdentity<TDetails> {
+    const context = React.useContext(IdentityProviderContext) as IIdentity<TDetails>;
     if (context.isSet === false && defaultDetails !== undefined) {
         context.details = defaultDetails!;
     }

--- a/Source/JavaScript/Applications/identity/IIdentity.ts
+++ b/Source/JavaScript/Applications/identity/IIdentity.ts
@@ -4,7 +4,7 @@
 /**
  * Defines the context for identity.
  */
-export interface IIdentityContext<TDetails = {}> {
+export interface IIdentity<TDetails = {}> {
 
     /**
      * The id of the identity.
@@ -19,7 +19,7 @@ export interface IIdentityContext<TDetails = {}> {
     /**
      * The claims for the identity.
      */
-    claims: { [key: string]: string };
+    claims: { [key: string]: string; };
 
     /**
      * The application specific details for the identity.
@@ -34,5 +34,5 @@ export interface IIdentityContext<TDetails = {}> {
     /**
      * Refreshes the identity context.
      */
-    refresh(): void;
+    refresh(): Promise<IIdentity<TDetails>>;
 }

--- a/Source/JavaScript/Applications/identity/IIdentityProvider.ts
+++ b/Source/JavaScript/Applications/identity/IIdentityProvider.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IIdentity } from './IIdentity';
+
+/**
+ * Defines the identity provider.
+ */
+export abstract class IIdentityProvider {
+
+    /**
+     * Gets the current identity by optionally specifying the details type.
+     * @returns The current identity as {@link IIdentity}.
+     */
+    abstract getCurrent<TDetails = {}>(): Promise<IIdentity<TDetails>>;
+}

--- a/Source/JavaScript/Applications/identity/IdentityProvider.ts
+++ b/Source/JavaScript/Applications/identity/IdentityProvider.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { IIdentityProvider } from './IIdentityProvider';
+import { IIdentity } from './IIdentity';
+import { IdentityProviderResult } from './IdentityProviderResult';
+
+/**
+ * Represents an implementation of {@link IIdentityProvider}.
+*/
+export class IdentityProvider extends IIdentityProvider {
+    static readonly CookieName = '.cratis-identity';
+    
+    /**
+     * Gets the current identity by optionally specifying the details type.
+     * @returns The current identity as {@link IIdentity}.
+     */
+    static async getCurrent<TDetails = {}>(): Promise<IIdentity<TDetails>> {
+        const cookie = this.getCookie();
+        if (cookie.length == 2) {
+            const json = atob(cookie[1]);
+            const result = JSON.parse(json) as IdentityProviderResult;
+            return {
+                id: result.id,
+                name: result.name,
+                claims: result.claims,
+                details: result.details,
+                isSet: true,
+                refresh: IdentityProvider.refresh
+            } as IIdentity<TDetails>;
+        } else {
+            const identity = await this.refresh();
+            return identity;
+        }
+    }
+
+    /** @inheritdoc */
+    async getCurrent<TDetails = {}>(): Promise<IIdentity<TDetails>> {
+        return IdentityProvider.getCurrent<TDetails>();
+    }
+
+    static async refresh() {
+        IdentityProvider.clearCookie();
+        const response = await fetch('/.cratis/me');
+
+        const result = await response.json() as IdentityProviderResult;
+
+        return {
+            id: result.id,
+            name: result.name,
+            claims: result.claims,
+            details: result.details,
+            isSet: true,
+            refresh: IdentityProvider.refresh
+        };
+    }
+
+    private static getCookie() {
+        const decoded = decodeURIComponent(document.cookie);
+        const cookies = decoded.split(';');
+        const cookie = cookies.find(_ => _.trim().indexOf(`${IdentityProvider.CookieName}=`) == 0);
+        if (cookie) {
+            const keyValue = cookie.split('=');
+            return [keyValue[0].trim(), keyValue[1].trim()];
+        }
+        return [];
+    }
+
+    private static clearCookie() {
+        document.cookie = `${IdentityProvider.CookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    }
+}

--- a/Source/JavaScript/Applications/identity/IdentityProviderResult.tsx
+++ b/Source/JavaScript/Applications/identity/IdentityProviderResult.tsx
@@ -1,5 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export * from './IdentityProvider';
-export * from './useIdentity';
+export type IdentityProviderResult = {
+    id: string;
+    name: string;
+    claims: { [key: string]: string; };
+    details: any;
+};

--- a/Source/JavaScript/Applications/identity/index.ts
+++ b/Source/JavaScript/Applications/identity/index.ts
@@ -2,4 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './IdentityProvider';
-export * from './useIdentity';
+export * from './IdentityProviderResult';
+export * from './IIdentityProvider';
+export * from './IIdentity';

--- a/Source/JavaScript/Applications/index.ts
+++ b/Source/JavaScript/Applications/index.ts
@@ -2,12 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import * as commands from './commands';
+import * as identity from './identity';
 import * as queries from './queries';
 import * as validation from './validation';
+export * from './Globals';
+
 export {
     commands,
+    identity,
     queries,
     validation,
 
 };
-export * from './Globals';

--- a/Source/JavaScript/Applications/package.json
+++ b/Source/JavaScript/Applications/package.json
@@ -29,6 +29,11 @@
             "require": "./dist/commands/index.js",
             "types": "./dist/commands/index.d.ts"
         },
+        "./identity": {
+            "import": "./dist/identity/index.js",
+            "require": "./dist/identity/index.js",
+            "types": "./dist/identity/index.d.ts"
+        },
         "./queries": {
             "import": "./dist/queries/index.js",
             "require": "./dist/queries/index.js",


### PR DESCRIPTION
### Added

- Added a new `IdentityProvider` in the `@cratis/applications` package within the `identity` module that enables you to get the current identity in a non React app.
- Added a binding for the `IIdentityProvider` abstract class / interface for the `@cratis/applications.react.mvvm` package that binds to the identity provider. Allowing you to take a dependency to the `IIdentityProvider` in a view model or other types and use it without having access to the React `IdentityProviderContext`.
