### PR TITLE
Adding the possibility to specify identity details provider as options

### DIFF
--- a/Source/DotNET/Applications/ApplicationModelOptions.cs
+++ b/Source/DotNET/Applications/ApplicationModelOptions.cs
@@ -20,4 +20,9 @@ public class ApplicationModelOptions
     /// Gets or sets the options for the tenancy.
     /// </summary>
     public TenancyOptions Tenancy { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets what type of identity details provider to use. If none is specified it will use type discovery to try to find one.
+    /// </summary>
+    public Type? IdentityDetailsProvider { get; set; }
 }

--- a/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
@@ -27,13 +27,7 @@ public static class IdentityProviderServiceCollectionExtensions
             throw new MultipleIdentityDetailsProvidersFound(providerTypes);
         }
 
-        services.AddSingleton(
-            typeof(IProvideIdentityDetails),
-            providerTypes.Length == 1 ? providerTypes[0] : defaultImplementationType);
-
-        services.AddSingleton<IdentityProviderEndpoint>();
-
-        return services;
+        return services.AddIdentityProvider(providerTypes.Length == 1 ? providerTypes[0] : defaultImplementationType);
     }
 
     /// <summary>
@@ -43,9 +37,19 @@ public static class IdentityProviderServiceCollectionExtensions
     /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
     public static IServiceCollection AddIdentityProvider<TProvider>(this IServiceCollection services)
-        where TProvider : class, IProvideIdentityDetails
+        where TProvider : class, IProvideIdentityDetails =>
+        services.AddIdentityProvider(typeof(TProvider));
+
+    /// <summary>
+    /// Add a identity provider to the service collection.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="type">The <see cref="Type"/> of the <see cref="IProvideIdentityDetails"/> implementation to add.</param>
+    /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
+    public static IServiceCollection AddIdentityProvider(this IServiceCollection services, Type type)
     {
-        services.AddSingleton<TProvider>();
+        TypeIsNotAnIdentityDetailsProvider.ThrowIfNotAnIdentityDetailsProvider(type);
+        services.AddSingleton(typeof(IProvideIdentityDetails), type);
         services.AddSingleton<IdentityProviderEndpoint>();
 
         return services;

--- a/Source/DotNET/Applications/Identity/TypeIsNotAnIdentityDetailsProvider.cs
+++ b/Source/DotNET/Applications/Identity/TypeIsNotAnIdentityDetailsProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Applications.Identity;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Exception that gets thrown when multiple identity details providers are found.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of <see cref="TypeIsNotAnIdentityDetailsProvider"/>.
+/// </remarks>
+/// <param name="type">Violating type.</param>
+public class TypeIsNotAnIdentityDetailsProvider(Type type) :
+    Exception($"The type '{type.AssemblyQualifiedName}' is not an implementation of '{typeof(IProvideIdentityDetails).AssemblyQualifiedName}'")
+{
+    /// <summary>
+    /// Throw if the type is not an identity details provider.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <exception cref="TypeIsNotAnIdentityDetailsProvider">Thrown if the type does not implement <see cref="IProvideIdentityDetails"/>.</exception>
+    public static void ThrowIfNotAnIdentityDetailsProvider(Type type)
+    {
+        if (!type.IsAssignableTo(typeof(IProvideIdentityDetails)))
+        {
+            throw new TypeIsNotAnIdentityDetailsProvider(type);
+        }
+    }
+}


### PR DESCRIPTION
### Added

- It is now possible to specify the identity details provider on the `ApplicationModelOptions` if you're using the `UseCratisApplicationModel()` extensions for configuring rather than the individual ones.
