### PR TITLE
Fix/viewmodel-instantiation

### DIFF
--- a/Samples/eCommerce/Basic/Web/App.tsx
+++ b/Samples/eCommerce/Basic/Web/App.tsx
@@ -17,15 +17,17 @@ const Something = () => {
     );
 };
 
+const isDevelopment = process.env.NODE_ENV === 'development';
+
 export const App = () => {
     return (
-        <ApplicationModel microservice='e-commerce'>
+        <ApplicationModel microservice='e-commerce' development={isDevelopment}>
             <DialogComponents confirmation={ConfirmationDialog} busyIndicator={BusyIndicatorDialog}>
                 <MVVM>
                     <BrowserRouter>
                         <Routes>
                             <Route path='/' element={<Feature blah='Horse' />} />
-                            <Route path='/something' element={<Something/>} />
+                            <Route path='/something' element={<Something />} />
                         </Routes>
 
                         {/* <Catalog /> */}

--- a/Samples/eCommerce/Basic/Web/package.json
+++ b/Samples/eCommerce/Basic/Web/package.json
@@ -5,7 +5,9 @@
     "main": "index.js",
     "private": true,
     "scripts": {
-        "dev": "vite"
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "yarn build && vite preview"
     },
     "author": "",
     "license": "MIT",

--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -10,19 +10,23 @@ import { Bindings } from './Bindings';
 export interface ApplicationModelProps {
     children?: JSX.Element | JSX.Element[];
     microservice: string;
+    development?: boolean;
 }
 
 export interface ApplicationModelConfiguration {
     microservice: string;
+    development?: boolean
 }
 
 export const ApplicationModelContext = React.createContext<ApplicationModelConfiguration>({
-    microservice: Globals.microservice
+    microservice: Globals.microservice,
+    development: false
 });
 
 export const ApplicationModel = (props: ApplicationModelProps) => {
     const configuration: ApplicationModelConfiguration = {
-        microservice: props.microservice
+        microservice: props.microservice,
+        development: props.development ?? false
     };
 
     Bindings.initialize(configuration.microservice);


### PR DESCRIPTION
### Added

- Optional property for `<ApplicationModel/>` to indiciate whether or not we're running in development. Using `process.env.NODE_ENV === 'development'` can then be used to pass to this. Defaults to `false`.

### Fixed

- Fixed `withViewModel` to honor new `ApplicationModel` property and do cleanup depending on development or not. This assumes that development means it is in React **StrictMode** and will then clean up on second render rather than the first for production.
