### PR TITLE
Introducing onFailed() for CommandResults

### DIFF
--- a/Source/JavaScript/Applications/commands/CommandResult.ts
+++ b/Source/JavaScript/Applications/commands/CommandResult.ts
@@ -13,6 +13,11 @@ import { Constructor, JsonSerializer } from '@cratis/fundamentals';
 type OnSuccess = (<TResponse>(response: TResponse) => void) | (() => void);
 
 /**
+ * Delegate type for the onFailed callback.
+ */
+type OnFailed<TResponse> = ((commandResult: CommandResult<TResponse>) => void) | (() => void);
+
+/**
  * Delegate type for the onException callback.
  */
 type OnException = (messages: string[], stackTrace: string) => void;
@@ -119,6 +124,18 @@ export class CommandResult<TResponse = {}> implements ICommandResult<TResponse> 
     onSuccess(callback: OnSuccess): CommandResult<TResponse> {
         if (this.isSuccess) {
             callback(this.response as TResponse);
+        }
+        return this;
+    }
+
+    /**
+     * Set up a callback for when the command failed.
+     * @param {OnFailed} callback The callback to call when the command failed.
+     * @returns {CommandResult} The instance of the command result.
+     */
+    onFailed(callback: OnFailed<TResponse>): CommandResult<TResponse> {
+        if (!this.isSuccess) {
+            callback(this);
         }
         return this;
     }

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_has_exceptions.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_has_exceptions.ts
@@ -20,6 +20,8 @@ describe('when chaining callbacks and result has exceptions', () => {
     }, Object, false);
 
     let onSuccessCalled = false;
+    let onFailedCalled = false;
+    let receivedCommandResultOnFailed: CommandResult<{}>;
     let onUnauthorizedCalled = false;
     let onValidationFailureCalled = false;
     let onExceptionCalled = false;
@@ -28,6 +30,10 @@ describe('when chaining callbacks and result has exceptions', () => {
 
     result
         .onSuccess(() => onSuccessCalled = true)
+        .onFailed((commandResult) => {
+            onFailedCalled = true;
+            receivedCommandResultOnFailed = commandResult;
+        })
         .onUnauthorized(() => onUnauthorizedCalled = true)
         .onValidationFailure(() => onValidationFailureCalled = true)
         .onException((messages, stackTrace) => {
@@ -36,11 +42,13 @@ describe('when chaining callbacks and result has exceptions', () => {
             receivedStackTrace = stackTrace;
         });
 
-    it('should call the on success callback', () => onSuccessCalled.should.be.false);
+    it('should not call the on success callback', () => onSuccessCalled.should.be.false);
     it('should forward the exception messages to the callback', () => receivedMessages.should.equal(result.exceptionMessages));
     it('should forward the exception stack trace to the callback', () => receivedStackTrace.should.equal(result.exceptionStackTrace));
+    it('should call the on failed callback', () => onFailedCalled.should.be.true);
+    it('should forward the command result to the on failed callback', () => receivedCommandResultOnFailed.should.equal(result));
     it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
     it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
-    it('should not call the on exception callback', () => onExceptionCalled.should.be.true);
+    it('should call the on exception callback', () => onExceptionCalled.should.be.true);
 });
 

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_invalid.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_invalid.ts
@@ -22,6 +22,8 @@ describe('when chaining callbacks and result is invalid', () => {
     }, Object, false);
 
     let onSuccessCalled = false;
+    let onFailedCalled = false;
+    let receivedCommandResultOnFailed: CommandResult<{}>;
     let onUnauthorizedCalled = false;
     let onValidationFailureCalled = false;
     let onExceptionCalled = false;
@@ -29,6 +31,10 @@ describe('when chaining callbacks and result is invalid', () => {
 
     result
         .onSuccess(() => onSuccessCalled = true)
+        .onFailed((commandResult) => {
+            onFailedCalled = true;
+            receivedCommandResultOnFailed = commandResult;
+        })
         .onUnauthorized(() => onUnauthorizedCalled = true)
         .onValidationFailure(validationResults => {
             onValidationFailureCalled = true;
@@ -36,8 +42,10 @@ describe('when chaining callbacks and result is invalid', () => {
         })
         .onException(() => onExceptionCalled = true);
 
-    it('should call the on success callback', () => onSuccessCalled.should.be.false);
+    it('should not call the on success callback', () => onSuccessCalled.should.be.false);
     it('should forward the validation results to the callback', () => receivedValidationResults.should.equal(result.validationResults));
+    it('should call the on failed callback', () => onFailedCalled.should.be.true);
+    it('should forward the command result to the on failed callback', () => receivedCommandResultOnFailed.should.equal(result));
     it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
     it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.true);
     it('should not call the on exception callback', () => onExceptionCalled.should.be.false);

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_successful.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_successful.ts
@@ -17,6 +17,7 @@ describe('when chaining callbacks and result is successful', () => {
     }, Object, false);
 
     let onSuccessCalled = false;
+    let onFailedCalled = false;
     let onUnauthorizedCalled = false;
     let onValidationFailureCalled = false;
     let onExceptionCalled = false;
@@ -27,14 +28,15 @@ describe('when chaining callbacks and result is successful', () => {
             onSuccessCalled = true;
             receivedResponse = response;
         })
+        .onFailed(() => onFailedCalled = true)
         .onUnauthorized(() => onUnauthorizedCalled = true)
         .onValidationFailure(() => onValidationFailureCalled = true)
         .onException(() => onExceptionCalled = true);
 
     it('should call the on success callback', () => onSuccessCalled.should.be.true);
     it('should pass the response to the callback', () => receivedResponse.should.equal(result.response));
+    it('should not call the on failed callback', () => onFailedCalled.should.be.false);
     it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.false);
     it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
     it('should not call the on exception callback', () => onExceptionCalled.should.be.false);
 });
-

--- a/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_unauthorized.ts
+++ b/Source/JavaScript/Applications/commands/for_CommandResult/when_chaining_callbacks/and_result_is_unauthorized.ts
@@ -17,18 +17,26 @@ describe('when chaining callbacks and result is unauthorized', () => {
     }, Object, false);
 
     let onSuccessCalled = false;
+    let onFailedCalled = false;
+    let receivedCommandResultOnFailed: CommandResult<{}>;
     let onUnauthorizedCalled = false;
     let onValidationFailureCalled = false;
     let onExceptionCalled = false;
 
     result
         .onSuccess(() => onSuccessCalled = true)
+        .onFailed((commandResult) => {
+            onFailedCalled = true;
+            receivedCommandResultOnFailed = commandResult;
+        })
         .onUnauthorized(() => onUnauthorizedCalled = true)
         .onValidationFailure(() => onValidationFailureCalled = true)
         .onException(() => onExceptionCalled = true);
 
-    it('should call the on success callback', () => onSuccessCalled.should.be.false);
-    it('should not call the on unauthorized callback', () => onUnauthorizedCalled.should.be.true);
+    it('should not the on success callback', () => onSuccessCalled.should.be.false);
+    it('should call the on failed callback', () => onFailedCalled.should.be.true);
+    it('should forward the command result to the on failed callback', () => receivedCommandResultOnFailed.should.equal(result));
+    it('should call the on unauthorized callback', () => onUnauthorizedCalled.should.be.true);
     it('should not call the on validation failure callback', () => onValidationFailureCalled.should.be.false);
     it('should not call the on exception callback', () => onExceptionCalled.should.be.false);
 });


### PR DESCRIPTION
### Added

- Added `.onFailed()` for `CommandResult` in `@cratis/applications` to be able to chain a reaction to handle any failure.
