### PR TITLE
Removing nodeResolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
         "prettier": "3.3.3",
         "rollup": "4.25.0",
         "rollup-plugin-commonjs": "10.1.0",
-        "rollup-plugin-node-resolve": "5.2.0",
         "rollup-plugin-peer-deps-external": "2.2.4",
         "rollup-plugin-typescript2": "0.36.0",
         "sinon": "19.0.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import typescript2 from 'rollup-plugin-typescript2';
-import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 
@@ -36,10 +35,6 @@ export function rollup(cjsPath, esmPath, tsconfigPath, pkg) {
             'react-dom',
         ],
         plugins: [
-            nodeResolve({
-                extensions: ['.js', '.jsx', '.ts', '.tsx'],
-                moduleDirectories: ['node_modules']
-            }),
             peerDepsExternal(),
             commonjs({
                 include: /node_modules/,


### PR DESCRIPTION
### Fixed

- Removing Rollup plugin that caused wrong resolution of node modules.

