### PR TITLE
Making folders lower case for packages, as that seems to be the case in NuGet Packages folder

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
@@ -28,7 +28,7 @@
     <ItemGroup>
         <Content Include="$(OutputPath)/*.*" PackagePath="tasks/net8.0/" />
         <Content Include="$(NuGetPackageRoot)\handlebars.net\$(HandlebarsVersion)\lib\netstandard2.0\Handlebars.dll" PackagePath="tasks/net8.0/" />
-        <Content Include="$(NuGetPackageRoot)\Microsoft.Extensions.DependencyModel\$(MicrosoftExtensionsDependencyModelVersion)\lib\netstandard2.0\Microsoft.Extensions.DependencyModel.dll" PackagePath="tasks/net8.0/" />
-        <Content Include="$(NuGetPackageRoot)\System.Reflection.MetadataLoadContext\$(SystemReflectionMetadataLoadContextVersion)\lib\netstandard2.0\System.Reflection.MetadataLoadContext.dll" PackagePath="tasks/net8.0/" />
+        <Content Include="$(NuGetPackageRoot)\microsoft.extensions.dependencymGHodel\$(MicrosoftExtensionsDependencyModelVersion)\lib\netstandard2.0\Microsoft.Extensions.DependencyModel.dll" PackagePath="tasks/net8.0/" />
+        <Content Include="$(NuGetPackageRoot)\system.reflection.metadataloadcontext\$(SystemReflectionMetadataLoadContextVersion)\lib\netstandard2.0\System.Reflection.MetadataLoadContext.dll" PackagePath="tasks/net8.0/" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Fixing folder name to be lower cased for content packages from `.nuget/packages` folder into the `ProxyGenerator.Build` package.
