### PR TITLE
Adding the specific output for each framework to the package

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
@@ -33,13 +33,14 @@
         </EmbeddedResource>
     </ItemGroup>
 
-
     <!-- Include output from the ProxyGenerator -->
     <ItemGroup>
+        <Content Include="$(MSBuildThisFileDirectory)bin/Release/net8.0/**/*" PackagePath="tasks/net8.0" />
         <Content Include="$(NuGetPackageRoot)\handlebars.net\$(HandlebarsVersion)\lib\netstandard2.0\Handlebars.dll" PackagePath="tasks/net8.0/" />
         <Content Include="$(NuGetPackageRoot)\microsoft.extensions.dependencymodel\$(MicrosoftExtensionsDependencyModelVersion)\lib\netstandard2.0\Microsoft.Extensions.DependencyModel.dll" PackagePath="tasks/net8.0/" />
         <Content Include="$(NuGetPackageRoot)\system.reflection.metadataloadcontext\8.0.1\lib\net8.0\System.Reflection.MetadataLoadContext.dll" PackagePath="tasks/net8.0/" />
 
+        <Content Include="$(MSBuildThisFileDirectory)bin/Release/net9.0/**/*" PackagePath="tasks/net9.0" />
         <Content Include="$(NuGetPackageRoot)\handlebars.net\$(HandlebarsVersion)\lib\netstandard2.0\Handlebars.dll" PackagePath="tasks/net9.0/" />
         <Content Include="$(NuGetPackageRoot)\microsoft.extensions.dependencymodel\$(MicrosoftExtensionsDependencyModelVersion)\lib\netstandard2.0\Microsoft.Extensions.DependencyModel.dll" PackagePath="tasks/net9.0/" />
         <Content Include="$(NuGetPackageRoot)\system.reflection.metadataloadcontext\9.0.0\lib\net9.0\System.Reflection.MetadataLoadContext.dll" PackagePath="tasks/net9.0/" />


### PR DESCRIPTION
### Fixed

- Adding output for each framework to the **ProxyGenerator.Build** package. Hopefully fixing .NET 8 builds which got an error of not being able to find specific dependencies.
