### PR TITLE
Do not include index.ts files in the generated index.ts file as exports

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -89,6 +89,7 @@ public static class Generator
         {
             var exports = directory
                 .GetFiles("*.ts")
+                .Where(_ => _.Name != "index.ts")
                 .Select(_ => $"./{Path.GetFileNameWithoutExtension(_.Name)}")
                 .OrderBy(_ => _.Split('/')[^1]);
             var descriptor = new IndexDescriptor(exports);


### PR DESCRIPTION
### Fixed

- The generated `index.ts` files in some circumstances added an export for itself, this is now fixed.
