### PR TITLE
Using one version of Microsoft.Extensions.DependencyModel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <Orleans>9.0.1</Orleans>
     <HandlebarsVersion>2.1.6</HandlebarsVersion>
-    <MicrosoftExtensionsDependencyModelVersion Condition=" '$(TargetFramework)' == 'net8.0' ">8.0.2</MicrosoftExtensionsDependencyModelVersion>
-    <MicrosoftExtensionsDependencyModelVersion Condition=" '$(TargetFramework)' == 'net9.0' ">9.0.0</MicrosoftExtensionsDependencyModelVersion>
+    <MicrosoftExtensionsDependencyModelVersion>9.0.0</MicrosoftExtensionsDependencyModelVersion>
     <SystemReflectionMetadataLoadContextVersion Condition=" '$(TargetFramework)' == 'net8.0' ">8.0.1</SystemReflectionMetadataLoadContextVersion>
     <SystemReflectionMetadataLoadContextVersion Condition=" '$(TargetFramework)' == 'net9.0' ">9.0.0</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>


### PR DESCRIPTION
### Fixed

- Switching to using same version of `Microsoft.Extensions.DependencyModel` for .net 8 and 9. Seems to work.
