### PR TITLE
Adding DirectConnection as an option for MongoDB - defaulting to true

### DIFF
--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -6,6 +6,7 @@ using Castle.DynamicProxy;
 using Cratis.Applications.MongoDB.Resilience;
 using Cratis.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Configuration;
@@ -22,9 +23,10 @@ namespace Cratis.Applications.MongoDB;
 /// Initializes a new instance of the <see cref="MongoDBClientFactory"/> class.
 /// </remarks>
 /// <param name="serverResolver"><see cref="IMongoServerResolver"/> for resolving the server.</param>
+/// <param name="options"><see cref="IOptions{TOptions}"/> for getting the options.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
 [Singleton]
-public class MongoDBClientFactory(IMongoServerResolver serverResolver, ILogger<MongoDBClientFactory> logger) : IMongoDBClientFactory
+public class MongoDBClientFactory(IMongoServerResolver serverResolver, IOptions<MongoDBOptions> options, ILogger<MongoDBClientFactory> logger) : IMongoDBClientFactory
 {
     readonly ConcurrentDictionary<string, IMongoClient> _clients = new();
 
@@ -42,6 +44,7 @@ public class MongoDBClientFactory(IMongoServerResolver serverResolver, ILogger<M
 
     IMongoClient CreateImplementation(MongoClientSettings settings)
     {
+        settings.DirectConnection = options.Value.DirectConnection;
         settings.ClusterConfigurator = ClusterConfigurator;
         logger.CreateClient(settings.Server.ToString());
 #pragma warning disable CA2000 // Dispose objects before losing scope - we're returning the client

--- a/Source/DotNET/MongoDB/MongoDBOptions.cs
+++ b/Source/DotNET/MongoDB/MongoDBOptions.cs
@@ -21,4 +21,9 @@ public class MongoDBOptions
     /// </summary>
     [Required]
     public string Database { get; set; } = null!;
+
+    /// <summary>
+    /// Gets whether or use the direct connection option for MongoDB. Defaults to true.
+    /// </summary>
+    public bool DirectConnection { get; set; } = true;
 }


### PR DESCRIPTION
### Added

- The `MongoDBOptions` now has a `DirectConnection` property which is directly set on the settings in the `MongoDBClientFactory` from this. Defaults to true, which is typically what you want for local development for instance.
