### PR TITLE
Fixing serializer bug with casting from uint to int

### DIFF
--- a/Source/DotNET/MongoDB/ConceptSerializer.cs
+++ b/Source/DotNET/MongoDB/ConceptSerializer.cs
@@ -95,7 +95,7 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         {
             bsonWriter.WriteDouble((double)underlyingValue);
         }
-        else if (underlyingValueType == typeof(int) || underlyingValueType == typeof(uint))
+        else if (underlyingValueType == typeof(int))
         {
             bsonWriter.WriteInt32((int)underlyingValue);
         }


### PR DESCRIPTION
### Fixed

- Fixed a problem in the MongoDB Serializer where it was casting an `uint` to `int`.
