### PR TITLE
Separating versions of dependencies between .NET8 and .NET9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,18 +3,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <Orleans>9.0.1</Orleans>
     <HandlebarsVersion>2.1.6</HandlebarsVersion>
-    <MicrosoftExtensionsDependencyModelVersion>9.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <SystemReflectionMetadataLoadContextVersion Condition=" '$(TargetFramework)' == 'net8.0' ">8.0.1</SystemReflectionMetadataLoadContextVersion>
-    <SystemReflectionMetadataLoadContextVersion Condition=" '$(TargetFramework)' == 'net9.0' ">9.0.0</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="6.0.2" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
     <PackageVersion Include="Serilog" Version="4.1.0" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
@@ -26,13 +19,11 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
     <PackageVersion Include="handlebars.net" Version="$(HandlebarsVersion)" />
     <PackageVersion Include="castle.core" Version="5.1.1" />
     <PackageVersion Include="polly.core" Version="8.5.0" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="$(SystemReflectionMetadataLoadContextVersion)" />
     <!-- Orleans -->
     <PackageVersion Include="Microsoft.Orleans.SDK" Version="$(Orleans)" />
     <PackageVersion Include="Microsoft.Orleans.Runtime" Version="$(Orleans)" />
@@ -57,5 +48,23 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Fixing depencies for .NET 8 TargetFramework - differentiating between .NET8 and .NET9 to avoid problems.
