### PR TITLE
Adding actual disposal of MongoClient in the interceptor

### DIFF
--- a/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
@@ -9,11 +9,12 @@ namespace Cratis.Applications.MongoDB.Resilience;
 /// <summary>
 /// Represents an interceptor for <see cref="IMongoClient"/> Dispose method.
 /// </summary>
-public class MongoClientDisposeInterceptor : IInterceptor
+/// <param name="mongoClient"><see cref="IMongoClient"/> to intercept.</param>
+public class MongoClientDisposeInterceptor(IMongoClient mongoClient) : IInterceptor
 {
     /// <inheritdoc/>
     public void Intercept(IInvocation invocation)
     {
-        // DO NOTHING
+        mongoClient.Dispose();
     }
 }

--- a/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
@@ -27,7 +27,7 @@ public class MongoClientInterceptorSelector(
     {
         if (method.Name == nameof(IDisposable.Dispose))
         {
-            return [new MongoClientDisposeInterceptor()];
+            return [new MongoClientDisposeInterceptor(mongoClient)];
         }
 
         if (method.Name == nameof(IMongoClient.GetDatabase))


### PR DESCRIPTION
### Fixed

- Adding disposal of the inner `IMongoClient` used by proxy interceptors. This should keep the number of active connections to the database down.
