### PR TITLE
Don't dispose if the MongoClient has already been disposed

### DIFF
--- a/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
@@ -12,9 +12,15 @@ namespace Cratis.Applications.MongoDB.Resilience;
 /// <param name="mongoClient"><see cref="IMongoClient"/> to intercept.</param>
 public class MongoClientDisposeInterceptor(IMongoClient mongoClient) : IInterceptor
 {
+    bool _isDisposed;
+
     /// <inheritdoc/>
     public void Intercept(IInvocation invocation)
     {
-        mongoClient.Dispose();
+        if (!_isDisposed)
+        {
+            mongoClient.Dispose();
+            _isDisposed = true;
+        }
     }
 }


### PR DESCRIPTION
### Fixed

- Making sure not to call `.Dispose()` on the MongoClient if it has already been disposed.
