### PR TITLE
Fix/mongodb-connection-leakage

### DIFF
--- a/Source/DotNET/MongoDB/HostBuilderExtensions.cs
+++ b/Source/DotNET/MongoDB/HostBuilderExtensions.cs
@@ -92,7 +92,7 @@ public static class HostBuilderExtensions
         services.AddSingleton(typeof(IMongoServerResolver), mongoDBBuilder.ServerResolverType);
         services.AddSingleton(typeof(IMongoDatabaseNameResolver), mongoDBBuilder.DatabaseNameResolverType);
         services.AddSingleton<IMongoDBClientFactory, MongoDBClientFactory>();
-        services.AddTransient(sp =>
+        services.AddScoped(sp =>
         {
             // TODO: This will not work when multi tenant.
             _clientFactory ??= sp.GetRequiredService<IMongoDBClientFactory>();
@@ -100,14 +100,14 @@ public static class HostBuilderExtensions
             return _clientFactory.Create();
         });
 
-        services.AddTransient(sp =>
+        services.AddScoped(sp =>
         {
             var client = sp.GetRequiredService<IMongoClient>();
             var databaseNameResolver = sp.GetRequiredService<IMongoDatabaseNameResolver>();
             return client.GetDatabase(databaseNameResolver.Resolve());
         });
 
-        services.AddTransient(typeof(IMongoCollection<>), typeof(MongoCollectionAdapter<>));
+        services.AddScoped(typeof(IMongoCollection<>), typeof(MongoCollectionAdapter<>));
     }
 
     static MongoDBBuilder CreateMongoDBBuilder(Action<MongoDBBuilder>? configure)

--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -34,7 +34,9 @@ public class MongoDBClientFactory(IMongoServerResolver serverResolver, IOptions<
     public IMongoClient Create() => Create(serverResolver.Resolve());
 
     /// <inheritdoc/>
-    public IMongoClient Create(MongoClientSettings settings) => _clients.GetOrAdd(settings.Server.ToString(), (_, v) => v, CreateImplementation(settings));
+#pragma warning disable MA0106 // Avoid closure by using an overload with the 'factoryArgument' parameter
+    public IMongoClient Create(MongoClientSettings settings) => _clients.GetOrAdd(settings.Server.ToString(), (_) => CreateImplementation(settings));
+#pragma warning restore MA0106 // Avoid closure by using an overload with the 'factoryArgument' parameter
 
     /// <inheritdoc/>
     public IMongoClient Create(MongoUrl url) => Create(MongoClientSettings.FromUrl(url));

--- a/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientDisposeInterceptor.cs
@@ -9,18 +9,11 @@ namespace Cratis.Applications.MongoDB.Resilience;
 /// <summary>
 /// Represents an interceptor for <see cref="IMongoClient"/> Dispose method.
 /// </summary>
-/// <param name="mongoClient"><see cref="IMongoClient"/> to intercept.</param>
-public class MongoClientDisposeInterceptor(IMongoClient mongoClient) : IInterceptor
+public class MongoClientDisposeInterceptor : IInterceptor
 {
-    bool _isDisposed;
-
-    /// <inheritdoc/>
+     /// <inheritdoc/>
     public void Intercept(IInvocation invocation)
     {
-        if (!_isDisposed)
-        {
-            mongoClient.Dispose();
-            _isDisposed = true;
-        }
+        // Do nothing - we don't want to dispose the client as we want to keep a single instance across a running process
     }
 }

--- a/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoClientInterceptorSelector.cs
@@ -27,7 +27,7 @@ public class MongoClientInterceptorSelector(
     {
         if (method.Name == nameof(IDisposable.Dispose))
         {
-            return [new MongoClientDisposeInterceptor(mongoClient)];
+            return [new MongoClientDisposeInterceptor()];
         }
 
         if (method.Name == nameof(IMongoClient.GetDatabase))


### PR DESCRIPTION
### Fixed

- FIxing a MongoDB connection leakage. We were calling an internal `CreateImplementation()` method even when the client was already there. So for every time we needed a `IMongoClient` it returned the one in the process but created a new one as well, which was never disposed or untracked.
- Reverting the `Dispose()` call in the proxy interceptor as we want to keep one `MongoClient` per process and never dispose of it, as described in the MongoDB best practices.
- Scoping the `IMongoClient` and other services in the IoC, preventing us to have to resolve it multiple times in a scope, typically during a Web request.