### PR TITLE
Fix/dont-cancel-if-cancelled

### DIFF
--- a/Source/DotNET/Applications/Queries/ClientObservable.cs
+++ b/Source/DotNET/Applications/Queries/ClientObservable.cs
@@ -49,7 +49,8 @@ public class ClientObservable<T>(
         using var subscription = subject.Subscribe(Next, Error, Complete);
 
         // If application is stopping, complete the observable
-        hostApplicationLifetime.ApplicationStopping.Register(Complete);
+        using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, hostApplicationLifetime.ApplicationStopping);
+        linkedTokenSource.Token.Register(Complete);
 
         await webSocketConnectionHandler.HandleIncomingMessages(webSocket, cts.Token, logger);
         subject.OnCompleted();

--- a/Source/DotNET/Applications/Queries/ClientObservable.cs
+++ b/Source/DotNET/Applications/Queries/ClientObservable.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Subjects;
-using System.Runtime.ConstrainedExecution;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
### Fixed

- Switching to using a linked token source for linking the `ApplicationStopping` with the local token source for WebSocket based observables. This is cleaner and should avoid any registration leakage on the global `ApplicationStopping` token.
