### PR TITLE
If token has a cancellation request - don't try to cancel again

### DIFF
--- a/Source/DotNET/Applications/Queries/ClientObservable.cs
+++ b/Source/DotNET/Applications/Queries/ClientObservable.cs
@@ -39,7 +39,6 @@ public class ClientObservable<T>(
     /// <inheritdoc/>
     public async Task HandleConnection(ActionExecutingContext context)
     {
-        var cancelled = false;
         using var webSocket = await context.HttpContext.WebSockets.AcceptWebSocketAsync();
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult<object>();
@@ -91,14 +90,13 @@ public class ClientObservable<T>(
         }
         void Complete()
         {
-            if (cancelled)
+            if (cts.IsCancellationRequested)
             {
                 return;
             }
             logger.ObservableCompleted();
             cts.Cancel();
             tcs.SetResult();
-            cancelled = true;
         }
     }
 


### PR DESCRIPTION
### Fixed

- Fixing how we know if we're cancelling already in the WebSockets `ClientObservable`by leveraging the `CancellationToken`to know if we're cancelling.
