### PR TITLE
Fixed so that we stop the WebSocket if token is cancelled and also handle OperationCanceled exception

### DIFF
--- a/Source/DotNET/Applications/Queries/WebSocketConnectionHandler.cs
+++ b/Source/DotNET/Applications/Queries/WebSocketConnectionHandler.cs
@@ -27,6 +27,11 @@ public class WebSocketConnectionHandler(ILogger<WebSocketConnectionHandler> hand
             {
                 do
                 {
+                    if (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
                     received = null!;
                     received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), token);
                     logger.ObservableReceivedMessage();
@@ -50,6 +55,10 @@ public class WebSocketConnectionHandler(ILogger<WebSocketConnectionHandler> hand
         catch (WebSocketException ex)
         {
             logger.ObservableWebSocketErrorReceivingMessage(ex);
+        }
+        catch (OperationCanceledException)
+        {
+            logger.ObservableCloseConnection("Operation was cancelled");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
### Fixed

- Handling operation being cancelled for WebSockets more gracefully, we don't need to spew out a stack trace and exception details for the `OperationCanceledException`happening deep inside the WebSockets. This happens typically when we cancel the `CancellationToken`, which is by design.	
