### PR TITLE
Don't include unused imports when there are no properties

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/ObservableQuery.hbs
@@ -5,7 +5,11 @@
 /* eslint-disable sort-imports */
 // eslint-disable-next-line header/header
 {{#if IsEnumerable}}
+{{#if Properties.[0]}}
 import { ObservableQueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForObservableQuery, Paging } from '@cratis/applications/queries';
+{{else}}
+import { ObservableQueryFor, QueryResultWithState, Sorting, Paging } from '@cratis/applications/queries';
+{{/if}}
 import { useObservableQuery, useObservableQueryWithPaging, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 {{else}}
 import { ObservableQueryFor, QueryResultWithState } from '@cratis/applications/queries';

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Query.hbs
@@ -5,7 +5,11 @@
 /* eslint-disable sort-imports */
 // eslint-disable-next-line header/header
 {{#if IsEnumerable}}
+{{#if Properties.[0]}}
 import { QueryFor, QueryResultWithState, Sorting, SortingActions, SortingActionsForQuery, Paging } from '@cratis/applications/queries';
+{{else}}
+import { QueryFor, QueryResultWithState, Sorting, Paging } from '@cratis/applications/queries';
+{{/if}}
 import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage, SetPageSize } from '@cratis/applications.react/queries';
 {{else}}
 import { QueryFor, QueryResultWithState } from '@cratis/applications/queries';


### PR DESCRIPTION
### Fixed

- Query proxies generated by the ProxyGenerator will now not import `SortingActions` and `SortingActionsForQuery` if there are no properties that use it. Typically when you have a query that returns an enumerable of primitive types.
