### PR TITLE
Fix/fundamentals-loading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,13 +25,15 @@
             "cwd": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator",
             "program": "${workspaceFolder}/Source/DotNET/Tools/ProxyGenerator/bin/Debug/net9.0/Cratis.Applications.ProxyGenerator.dll",
             "args": [
-                "/Volumes/Code/KDI/Ocean/Source/Exercises/Main/bin/Debug/net9.0/Kongsberg.KSim.Ocean.Exercises.Main.dll",
-                "/Volumes/Code/KDI/Ocean/Source/Exercises/Web/Api",
+                "/Volumes/Code/Cratis/Samples/Library/Api/bin/Debug/net9.0/Api.dll",
+                "/Volumes/Code/Cratis/Samples/Library/Web/Api",
+                // "/Volumes/Code/KDI/Ocean/Source/Exercises/Main/bin/Debug/net9.0/Kongsberg.KSim.Ocean.Exercises.Main.dll",
+                // "/Volumes/Code/KDI/Ocean/Source/Exercises/Web/Api",
                 // "/Volumes/Code/Cratis/Chronicle/Source/Api/bin/Debug/net9.0/Cratis.Chronicle.Api.dll",
                 // "/Volumes/Code/Cratis/Chronicle/Source/Workbench/Api",
                 // "${workspaceFolder}/Samples/eCommerce/Basic/Main/bin/Debug/net8.0/Main.dll",
                 // "${workspaceFolder}/Samples/eCommerce/Basic/Web/API",
-                "5"
+                "1"
             ],
             "stopAtEntry": false,
             "env": {

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -134,11 +134,7 @@ public static class TypeExtensions
             var fullPath = Path.Combine(nugetCachePath, fundamentalsPackage.Path!, assetPaths[0]);
             if (File.Exists(fullPath))
             {
-                var directory = Path.GetDirectoryName(fullPath);
-                if (directory is not null)
-                {
-                    paths = [.. paths, directory!];
-                }
+                paths = [.. paths, fullPath];
             }
         }
 
@@ -628,12 +624,12 @@ public static class TypeExtensions
 
         try
         {
-            var fundamentals = _metadataLoadContext.LoadFromAssemblyName("Cratis.Fundamentals")!;
+            var fundamentals = _metadataLoadContext.LoadFromAssemblyName("Cratis.Fundamentals");
             _conceptType = fundamentals.GetType("Cratis.Concepts.ConceptAs`1")!;
         }
         catch
         {
-            Console.WriteLine("Could not load Cratis.Fundamentals, concepts will not be supported");
+            Console.WriteLine("  Could not load Cratis.Fundamentals, concepts will not be supported");
         }
 
         var aspNetCore = _metadataLoadContext.LoadFromAssemblyName("Microsoft.AspNetCore.Mvc.Core");


### PR DESCRIPTION
### Fixed

- Fixing the path for `Cratis.Fundamentals` for the assembly resolver used in ProxyGenerator. It needs to be the full path with the filename.
