### PR TITLE
Cleanup when cancellation token is cancelled

### DIFF
--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -199,6 +199,7 @@ public static class MongoCollectionExtensions
         var cancellationTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2000 // Dispose objects before losing scope
         var cancellationToken = cancellationTokenSource.Token;
+        cancellationToken.Register(Cleanup);
 
         _ = Task.Run(Watch);
         return subject;

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -199,9 +199,8 @@ public static class MongoCollectionExtensions
         var cancellationTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2000 // Dispose objects before losing scope
         var cancellationToken = cancellationTokenSource.Token;
-        cancellationToken.Register(Cleanup);
 
-        _ = Task.Run(Watch);
+        _ = Task.Run(Watch, cancellationToken);
         return subject;
 
         async Task Watch()

--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -84,6 +84,7 @@ public class MongoDBClientFactory(IMongoServerResolver serverResolver, IMeter<IM
         var scope = meter.BeginScope(serverKey);
 
         UpdateConnectionCount(serverKey, scope, 0);
+        UpdateConnectionsAddedToPool(serverKey, scope, 0);
         UpdateCheckedOutConnections(serverKey, scope, 0);
         UpdateCommandCount(serverKey, scope, 0);
 


### PR DESCRIPTION
### Fixed

- Making sure to clean up and stop when cancellation token is cancelled for the MongoCollectionExtensions watch capability..
