### PR TITLE
Doing explicit dispose of cursor and adding log messages

### DIFF
--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -225,7 +225,7 @@ public static class MongoCollectionExtensions
 
                 while (await cursor.MoveNextAsync(cancellationToken))
                 {
-                    logger.LogInformation("Change stream cursor moved next");
+                    logger.LogInformation($"Change stream cursor moved next - {cursor.GetHashCode()}");
                     if (cancellationToken.IsCancellationRequested || !watching)
                     {
                         break;

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -226,7 +226,7 @@ public static class MongoCollectionExtensions
                 while (await cursor.MoveNextAsync(cancellationToken))
                 {
                     logger.LogInformation("Change stream cursor moved next");
-                    if (cancellationToken.IsCancellationRequested)
+                    if (cancellationToken.IsCancellationRequested || !watching)
                     {
                         break;
                     }
@@ -235,7 +235,7 @@ public static class MongoCollectionExtensions
                     {
                         foreach (var changeDocument in cursor.Current)
                         {
-                            if (cancellationToken.IsCancellationRequested)
+                            if (cancellationToken.IsCancellationRequested || !watching)
                             {
                                 break;
                             }

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -199,8 +199,10 @@ public static class MongoCollectionExtensions
         var cancellationTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2000 // Dispose objects before losing scope
         var cancellationToken = cancellationTokenSource.Token;
+        cancellationToken.ThrowIfCancellationRequested();
 
-        _ = Task.Run(Watch, cancellationToken);
+        var watchTask = Task.CompletedTask;
+        watchTask = Task.Run(Watch, cancellationToken);
         return subject;
 
         async Task Watch()
@@ -242,6 +244,8 @@ public static class MongoCollectionExtensions
                         }
                     },
                     cancellationToken);
+
+                logger.IteratingChangeStreamCursorCompleted();
             }
             catch (ObjectDisposedException)
             {
@@ -257,6 +261,7 @@ public static class MongoCollectionExtensions
             }
             finally
             {
+                watchTask.Dispose();
                 cursor?.Dispose();
                 Cleanup();
             }

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -279,8 +279,7 @@ public static class MongoCollectionExtensions
                 //         }
                 //     },
                 //     cancellationToken);
-
-                // logger.IteratingChangeStreamCursorCompleted();
+                logger.IteratingChangeStreamCursorCompleted();
             }
             catch (ObjectDisposedException)
             {

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -222,30 +222,30 @@ public static class MongoCollectionExtensions
                 documents = query.ToList();
                 onNext(documents, subject);
 
-                await cursor.ForEachAsync(
-                    async changeDocument =>
-                    {
-                        try
-                        {
-                            documents = await HandleChange(
-                                queryContext,
-                                onNext,
-                                changeDocument,
-                                invalidateFindOnAddOrDelete,
-                                baseQuery,
-                                query,
-                                documents,
-                                subject,
-                                idProperty);
-                        }
-                        catch (Exception e)
-                        {
-                            logger.UnexpectedError(e);
-                        }
-                    },
-                    cancellationToken);
+                // await cursor.ForEachAsync(
+                //     async changeDocument =>
+                //     {
+                //         try
+                //         {
+                //             documents = await HandleChange(
+                //                 queryContext,
+                //                 onNext,
+                //                 changeDocument,
+                //                 invalidateFindOnAddOrDelete,
+                //                 baseQuery,
+                //                 query,
+                //                 documents,
+                //                 subject,
+                //                 idProperty);
+                //         }
+                //         catch (Exception e)
+                //         {
+                //             logger.UnexpectedError(e);
+                //         }
+                //     },
+                //     cancellationToken);
 
-                logger.IteratingChangeStreamCursorCompleted();
+                // logger.IteratingChangeStreamCursorCompleted();
             }
             catch (ObjectDisposedException)
             {

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -261,6 +261,7 @@ public static class MongoCollectionExtensions
             }
             finally
             {
+                logger.DisposingCursor();
                 watchTask.Dispose();
                 cursor?.Dispose();
                 Cleanup();

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -201,6 +201,7 @@ public static class MongoCollectionExtensions
         var cancellationToken = cancellationTokenSource.Token;
         cancellationToken.ThrowIfCancellationRequested();
 
+        var watching = true;
         var watchTask = Task.CompletedTask;
         watchTask = Task.Run(Watch, cancellationToken);
         return subject;
@@ -308,6 +309,7 @@ public static class MongoCollectionExtensions
             {
                 return;
             }
+            watching = false;
             logger.CleaningUp();
             cancellationTokenSource?.Cancel();
             cancellationTokenSource?.Dispose();

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -224,6 +224,7 @@ public static class MongoCollectionExtensions
 
                 while (await cursor.MoveNextAsync(cancellationToken))
                 {
+                    logger.LogInformation("Change stream cursor moved next");
                     if (cancellationToken.IsCancellationRequested)
                     {
                         break;

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -225,7 +225,7 @@ public static class MongoCollectionExtensions
 
                 while (await cursor.MoveNextAsync(cancellationToken))
                 {
-                    logger.LogInformation($"Change stream cursor moved next - {cursor.GetHashCode()}");
+                    logger.LogInformation($"Change stream cursor moved next - {cursor.GetHashCode()} - {typeof(TDocument).FullName}");
                     if (cancellationToken.IsCancellationRequested || !watching)
                     {
                         break;

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -222,6 +222,9 @@ public static class MongoCollectionExtensions
                 documents = query.ToList();
                 onNext(documents, subject);
 
+                var hasDocuments = await cursor.MoveNextAsync(cancellationToken);
+                Console.WriteLine(hasDocuments);
+
                 // await cursor.ForEachAsync(
                 //     async changeDocument =>
                 //     {

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -9,7 +9,7 @@ namespace MongoDB.Driver;
 
 internal static partial class MongoCollectionExtensionsLogMessages
 {
-    [LoggerMessage(LogLevel.Information, "Iterating change stream cursor completed")]
+    [LoggerMessage(LogLevel.Trace, "Iterating change stream cursor completed")]
     internal static partial void IteratingChangeStreamCursorCompleted(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 
     [LoggerMessage(LogLevel.Trace, "Object was disposed")]
@@ -17,6 +17,9 @@ internal static partial class MongoCollectionExtensionsLogMessages
 
     [LoggerMessage(LogLevel.Trace, "Operation was cancelled")]
     internal static partial void OperationCancelled(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
+
+    [LoggerMessage(LogLevel.Trace, "Disposing cursor")]
+    internal static partial void DisposingCursor(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 
     [LoggerMessage(LogLevel.Trace, "Cleaning up")]
     internal static partial void CleaningUp(this ILogger<MongoCollectionExtensions.MongoCollection> logger);

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -18,9 +18,6 @@ internal static partial class MongoCollectionExtensionsLogMessages
     [LoggerMessage(LogLevel.Trace, "Operation was cancelled")]
     internal static partial void OperationCancelled(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 
-    [LoggerMessage(LogLevel.Trace, "Disposing cursor")]
-    internal static partial void DisposingCursor(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
-
     [LoggerMessage(LogLevel.Trace, "Cleaning up")]
     internal static partial void CleaningUp(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -9,8 +9,14 @@ namespace MongoDB.Driver;
 
 internal static partial class MongoCollectionExtensionsLogMessages
 {
-    [LoggerMessage(LogLevel.Trace, "Cursor disposed")]
-    internal static partial void CursorDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
+    [LoggerMessage(LogLevel.Trace, "Object was disposed")]
+    internal static partial void ObjectDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
+
+    [LoggerMessage(LogLevel.Trace, "Operation was cancelled")]
+    internal static partial void OperationCancelled(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
+
+    [LoggerMessage(LogLevel.Trace, "Cleaning up")]
+    internal static partial void CleaningUp(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 
     [LoggerMessage(LogLevel.Warning, "Unexpected error occurred")]
     internal static partial void UnexpectedError(this ILogger<MongoCollectionExtensions.MongoCollection> logger, Exception ex);

--- a/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensionsLogging.cs
@@ -9,6 +9,9 @@ namespace MongoDB.Driver;
 
 internal static partial class MongoCollectionExtensionsLogMessages
 {
+    [LoggerMessage(LogLevel.Information, "Iterating change stream cursor completed")]
+    internal static partial void IteratingChangeStreamCursorCompleted(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
+
     [LoggerMessage(LogLevel.Trace, "Object was disposed")]
     internal static partial void ObjectDisposed(this ILogger<MongoCollectionExtensions.MongoCollection> logger);
 

--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -75,8 +75,7 @@ public class MongoDBClientFactory(IMongoServerResolver serverResolver, IMeter<IM
             Selector = new MongoClientInterceptorSelector(proxyGenerator, resiliencePipeline, client)
         };
 
-        // return proxyGenerator.CreateInterfaceProxyWithTarget<IMongoClient>(client, proxyGeneratorOptions);
-        return client;
+        return proxyGenerator.CreateInterfaceProxyWithTarget<IMongoClient>(client, proxyGeneratorOptions);
     }
 
     void ClusterConfigurator(MongoClientSettings settings, ClusterBuilder builder)

--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -75,7 +75,8 @@ public class MongoDBClientFactory(IMongoServerResolver serverResolver, IMeter<IM
             Selector = new MongoClientInterceptorSelector(proxyGenerator, resiliencePipeline, client)
         };
 
-        return proxyGenerator.CreateInterfaceProxyWithTarget<IMongoClient>(client, proxyGeneratorOptions);
+        // return proxyGenerator.CreateInterfaceProxyWithTarget<IMongoClient>(client, proxyGeneratorOptions);
+        return client;
     }
 
     void ClusterConfigurator(MongoClientSettings settings, ClusterBuilder builder)

--- a/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptor.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptor.cs
@@ -50,6 +50,11 @@ public class MongoCollectionInterceptor(
                 openConnectionSemaphore.Release(1);
                 tcs.SetCanceled();
             }
+            catch (OperationCanceledException)
+            {
+                openConnectionSemaphore.Release(1);
+                tcs.SetCanceled();
+            }
             catch (Exception ex)
             {
                 openConnectionSemaphore.Release(1);

--- a/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorForReturnValues.cs
+++ b/Source/DotNET/MongoDB/Resilience/MongoCollectionInterceptorForReturnValues.cs
@@ -66,6 +66,11 @@ public class MongoCollectionInterceptorForReturnValues(
                 openConnectionSemaphore.Release(1);
                 setCanceledMethod.Invoke(tcs, []);
             }
+            catch (OperationCanceledException)
+            {
+                openConnectionSemaphore.Release(1);
+                setCanceledMethod.Invoke(tcs, []);
+            }
             catch (Exception ex)
             {
                 openConnectionSemaphore.Release(1);


### PR DESCRIPTION
### Fixed

- Passing along the `CancellationToken` to the resilience pipeline for MongoDB that comes in as input to any of the intercepted methods.
- Added more trace logging for `MongoCollectionExtensions``
- Explicitly setting `CancellationToken` to throw on cancel.