### PR TITLE
Adding support for query string parameters for commands / queries

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/CommandExtensions.cs
@@ -61,7 +61,8 @@ public static class CommandExtensions
 
         imports = [.. imports.DistinctBy(_ => _.Type)];
 
-        var route = method.GetRoute();
+        var arguments = method.GetArgumentDescriptors();
+        var route = method.GetRoute(arguments);
 
         return new(
             method.DeclaringType!,
@@ -71,7 +72,7 @@ public static class CommandExtensions
             method.Name,
             properties,
             imports.OrderBy(_ => _.Module),
-            method.GetArgumentDescriptors(),
+            arguments,
             hasResponse,
             responseModel,
             [.. typesInvolved, .. additionalTypesInvolved]);

--- a/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
@@ -15,8 +15,9 @@ public static class MethodInfoExtensions
     /// Get the route for a method.
     /// </summary>
     /// <param name="method">Method to get for.</param>
+    /// <param name="arguments">Arguments for the method.</param>
     /// <returns>The full route.</returns>
-    public static string GetRoute(this MethodInfo method)
+    public static string GetRoute(this MethodInfo method, IEnumerable<RequestArgumentDescriptor> arguments)
     {
         var routeTemplates = new string[]
         {
@@ -33,6 +34,13 @@ public static class MethodInfoExtensions
         }
 
         if (!route.StartsWith('/')) route = $"/{route}";
+
+        var queryStringParameters = arguments.Where(argument => argument.IsQueryStringParameter).ToArray();
+        if (queryStringParameters.Length > 0)
+        {
+            var queryString = string.Join('&', queryStringParameters.Select(_ => $"{_.Name}={{{_.Name}}}"));
+            route = $"{route}?{queryString}";
+        }
         return route;
     }
 

--- a/Source/DotNET/Tools/ProxyGenerator/ParameterInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ParameterInfoExtensions.cs
@@ -20,7 +20,7 @@ public static class ParameterInfoExtensions
     {
         var type = parameterInfo.ParameterType.GetTargetType();
         var optional = parameterInfo.IsOptional() || parameterInfo.HasDefaultValue;
-        return new RequestArgumentDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, optional);
+        return new RequestArgumentDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, optional, parameterInfo.IsFromQueryArgument());
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public static class ParameterInfoExtensions
     }
 
     /// <summary>
-    /// Check if a a parameter is adorned with the FromRequestAttribute from Application Model, which means we need to investigate the internals for any request arguments.
+    /// Check if a parameter is adorned with the FromRequestAttribute from Application Model, which means we need to investigate the internals for any request arguments.
     /// </summary>
     /// <param name="parameter">Method to check.</param>
     /// <returns>True if it is a from request argument, false otherwise.</returns>
@@ -69,5 +69,16 @@ public static class ParameterInfoExtensions
     {
         var attributes = parameter.GetCustomAttributesData().Select(_ => _.AttributeType.Name);
         return attributes.Any(_ => _ == WellKnownTypes.FromRequestAttribute);
+    }
+
+    /// <summary>
+    /// Check if a parameter is adorned with the FromQueryAttribute, which means we need to treat it as a query string parameter and include it in the route template.
+    /// </summary>
+    /// <param name="parameter">Method to check.</param>
+    /// <returns>True if it is a from request argument, false otherwise.</returns>
+    public static bool IsFromQueryArgument(this ParameterInfo parameter)
+    {
+        var attributes = parameter.GetCustomAttributesData().Select(_ => _.AttributeType.Name);
+        return attributes.Any(_ => _ == WellKnownTypes.FromQueryAttribute);
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -32,6 +32,17 @@ public static class PropertyExtensions
     }
 
     /// <summary>
+    /// Check if a property is adorned with the FromQueryAttribute, which means we need to treat it as a query string parameter and include it in the route template.
+    /// </summary>
+    /// <param name="property">Method to check.</param>
+    /// <returns>True if it is a from request argument, false otherwise.</returns>
+    public static bool IsFromQueryArgument(this PropertyInfo property)
+    {
+        var attributes = property.GetCustomAttributesData().Select(_ => _.AttributeType.Name);
+        return attributes.Any(_ => _ == WellKnownTypes.FromQueryAttribute);
+    }
+
+    /// <summary>
     /// Convert a <see cref="PropertyInfo"/> to a <see cref="RequestArgumentDescriptor"/>.
     /// </summary>
     /// <param name="propertyInfo">Parameter to convert.</param>
@@ -40,7 +51,12 @@ public static class PropertyExtensions
     {
         var type = propertyInfo.PropertyType.GetTargetType();
         var optional = propertyInfo.IsOptional();
-        return new RequestArgumentDescriptor(propertyInfo.PropertyType, propertyInfo.Name!, type.Type, optional);
+        return new RequestArgumentDescriptor(
+            propertyInfo.PropertyType,
+            propertyInfo.Name!,
+            type.Type,
+            optional,
+            propertyInfo.IsFromQueryArgument());
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/QueryExtensions.cs
@@ -64,7 +64,7 @@ public static class QueryExtensions
 
         imports = [.. imports.DistinctBy(_ => _.Type)];
 
-        var route = method.GetRoute();
+        var route = method.GetRoute(arguments);
 
         return new(
             method.DeclaringType!,

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/RequestArgumentDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/RequestArgumentDescriptor.cs
@@ -10,8 +10,10 @@ namespace Cratis.Applications.ProxyGenerator.Templates;
 /// <param name="Name">Name of argument.</param>
 /// <param name="Type">Type of argument.</param>
 /// <param name="IsOptional">Whether or not the argument is nullable / optional.</param>
+/// <param name="IsQueryStringParameter">Whether or not the argument is a query string parameter.</param>
 public record RequestArgumentDescriptor(
     Type OriginalType,
     string Name,
     string Type,
-    bool IsOptional);
+    bool IsOptional,
+    bool IsQueryStringParameter = false);


### PR DESCRIPTION
### Fixed

- Adding support for Query String parameters on queries and commands. This was a complete oversight when rewriting the proxy generator from a Roslyn extension to an after build Reflection based solution.
