### PR TITLE
If response is null - provide a proper error message rather than exception

### DIFF
--- a/Source/DotNET/Applications/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/Applications/Queries/QueryActionFilter.cs
@@ -106,7 +106,7 @@ public class QueryActionFilter(
             else
             {
                 logger.NonClientObservableReturnValue(controllerActionDescriptor.ControllerName, controllerActionDescriptor.ActionName);
-                var response = queryProviders.Execute(callResult.Response!);
+                var response = callResult.Response is not null ? queryProviders.Execute(callResult.Response!) : new QueryProviderResult(0, default!);
                 var queryContext = queryContextManager.Current;
                 var queryResult = new QueryResult<object>
                 {
@@ -120,6 +120,11 @@ public class QueryActionFilter(
                     ExceptionStackTrace = callResult.ExceptionStackTrace ?? string.Empty,
                     Data = response.Data
                 };
+
+                if (response.Data is null && queryResult.IsSuccess)
+                {
+                    queryResult.ExceptionMessages = ["Null data returned"];
+                }
 
                 if (!queryResult.IsAuthorized)
                 {

--- a/Source/DotNET/Applications/Queries/QueryResult.cs
+++ b/Source/DotNET/Applications/Queries/QueryResult.cs
@@ -60,7 +60,7 @@ public class QueryResult<T>
     /// <summary>
     /// Gets any exception messages that might have occurred.
     /// </summary>
-    public IEnumerable<string> ExceptionMessages { get; init; } = [];
+    public IEnumerable<string> ExceptionMessages { get; set; } = [];
 
     /// <summary>
     /// Gets the stack trace if there was an exception.


### PR DESCRIPTION
### Fixed

- The `QueryActionFilter` will now treat a `null` response as an error and make it visibile in the `QueryResult` rather than crash and burn.
