### PR TITLE
Adding support for setting base API path for commands and queries

### DIFF
--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -10,12 +10,14 @@ export interface ApplicationModelProps {
     children?: JSX.Element | JSX.Element[];
     microservice: string;
     development?: boolean;
+    apiBasePath?: string;
 }
 
 export const ApplicationModel = (props: ApplicationModelProps) => {
     const configuration: ApplicationModelConfiguration = {
         microservice: props.microservice,
-        development: props.development ?? false
+        development: props.development ?? false,
+        apiBasePath: props.apiBasePath ?? ''
     };
 
     Bindings.initialize(configuration.microservice, configuration.apiBasePath);

--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -18,7 +18,7 @@ export const ApplicationModel = (props: ApplicationModelProps) => {
         development: props.development ?? false
     };
 
-    Bindings.initialize(configuration.microservice);
+    Bindings.initialize(configuration.microservice, configuration.apiBasePath);
 
     return (
         <ApplicationModelContext.Provider value={configuration}>

--- a/Source/JavaScript/Applications.React/ApplicationModelContext.ts
+++ b/Source/JavaScript/Applications.React/ApplicationModelContext.ts
@@ -7,9 +7,11 @@ import React from 'react';
 export interface ApplicationModelConfiguration {
     microservice: string;
     development?: boolean
+    apiBasePath?: string;
 }
 
 export const ApplicationModelContext = React.createContext<ApplicationModelConfiguration>({
     microservice: Globals.microservice,
-    development: false
+    development: false,
+    apiBasePath: ''
 });

--- a/Source/JavaScript/Applications.React/Bindings.ts
+++ b/Source/JavaScript/Applications.React/Bindings.ts
@@ -9,6 +9,6 @@ import { WellKnownBindings } from './WellKnownBindings';
 export class Bindings {
     static initialize(microservice: string, apiBasePath?: string) {
         container.registerSingleton(WellKnownBindings.microservice, microservice);
-        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath) });
+        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath ?? '') });
     }
 }

--- a/Source/JavaScript/Applications.React/Bindings.ts
+++ b/Source/JavaScript/Applications.React/Bindings.ts
@@ -7,8 +7,8 @@ import { Constructor } from '@cratis/fundamentals';
 import { WellKnownBindings } from './WellKnownBindings';
 
 export class Bindings {
-    static initialize(microservice: string) {
+    static initialize(microservice: string, apiBasePath?: string) {
         container.registerSingleton(WellKnownBindings.microservice, microservice);
-        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice) });
+        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath) });
     }
 }

--- a/Source/JavaScript/Applications.React/commands/useCommand.ts
+++ b/Source/JavaScript/Applications.React/commands/useCommand.ts
@@ -31,6 +31,7 @@ export function useCommand<TCommand extends Command, TCommandContent>(commandTyp
     command.current = useMemo(() => {
         const instance = new commandType();
         instance.setMicroservice(applicationModel.microservice);
+        instance.setApiBasePath(applicationModel.apiBasePath ?? '');
         if (initialValues) {
             instance.setInitialValues(initialValues);
         }

--- a/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
@@ -21,6 +21,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         instance.paging = currentPaging;
         instance.sorting = currentSorting;
         instance.setMicroservice(applicationModel.microservice);
+        instance.setApiBasePath(applicationModel.apiBasePath ?? '');
         return instance;
     }, [currentPaging, currentSorting]);
 

--- a/Source/JavaScript/Applications.React/queries/useQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useQuery.ts
@@ -29,6 +29,7 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
         instance.paging = paging;
         instance.sorting = sorting;
         instance.setMicroservice(applicationModel.microservice);
+        instance.setApiBasePath(applicationModel.apiBasePath ?? '');
         return instance;
     }, []);
 

--- a/Source/JavaScript/Applications/commands/ICommand.ts
+++ b/Source/JavaScript/Applications/commands/ICommand.ts
@@ -52,6 +52,12 @@ export interface ICommand<TCommandContent = object, TCommandResponse = object> {
     setMicroservice(microservice: string);
 
     /**
+     * Set the base path for the API to use for the query. This is used to prepend to the path of the command.
+     * @param apiBasePath Base path for the API
+     */
+    setApiBasePath(apiBasePath: string): void;
+
+    /**
      * Notify about a property that has had its value changed.
      * @param {string} property Name of property that changes.
      */

--- a/Source/JavaScript/Applications/index.ts
+++ b/Source/JavaScript/Applications/index.ts
@@ -5,6 +5,7 @@ import * as commands from './commands';
 import * as identity from './identity';
 import * as queries from './queries';
 import * as validation from './validation';
+export * from './joinPaths';
 export * from './deepEqual';
 export * from './Globals';
 

--- a/Source/JavaScript/Applications/joinPaths.ts
+++ b/Source/JavaScript/Applications/joinPaths.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export function joinPaths(...paths) {
+    return paths.map(p => p.replace(/^\/+|\/+$/g, '')).join('/');
+}

--- a/Source/JavaScript/Applications/queries/IQuery.ts
+++ b/Source/JavaScript/Applications/queries/IQuery.ts
@@ -33,4 +33,10 @@ export interface IQuery {
      * @param microservice Name of microservice
      */
     setMicroservice(microservice: string);
+
+    /**
+     * Set the base path for the API to use for the query. This is used to prepend to the path of the query.
+     * @param apiBasePath Base path for the API
+     */
+    setApiBasePath(apiBasePath: string): void;
 }

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -15,6 +15,7 @@ import { Sorting } from './Sorting';
 import { Paging } from './Paging';
 import { SortDirection } from './SortDirection';
 import { Globals } from '../Globals';
+import { joinPaths } from '../joinPaths';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -24,6 +25,7 @@ import { Globals } from '../Globals';
  */
 export abstract class ObservableQueryFor<TDataType, TArguments = object> implements IObservableQueryFor<TDataType, TArguments> {
     private _microservice: string;
+    private _apiBasePath: string;
     private _connection?: IObservableQueryConnection<TDataType>;
 
     abstract readonly route: string;
@@ -42,6 +44,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = object> impleme
         this.sorting = Sorting.none;
         this.paging = Paging.noPaging;
         this._microservice = Globals.microservice ?? '';
+        this._apiBasePath = '';
     }
 
     /**
@@ -54,6 +57,11 @@ export abstract class ObservableQueryFor<TDataType, TArguments = object> impleme
     /** @inheritdoc */
     setMicroservice(microservice: string) {
         this._microservice = microservice;
+    }
+
+    /** @inheritdoc */
+    setApiBasePath(apiBasePath: string): void {
+        this._apiBasePath = apiBasePath;
     }
 
     /** @inheritdoc */
@@ -79,6 +87,7 @@ export abstract class ObservableQueryFor<TDataType, TArguments = object> impleme
             this._connection = new NullObservableQueryConnection(this.defaultValue);
         } else {
             actualRoute = this.routeTemplate(args);
+            actualRoute = joinPaths(this._apiBasePath, actualRoute);
             this._connection = new ObservableQueryConnection<TDataType>(actualRoute, this._microservice);
         }
 

--- a/Source/JavaScript/Applications/queries/QueryFor.ts
+++ b/Source/JavaScript/Applications/queries/QueryFor.ts
@@ -10,6 +10,7 @@ import { Paging } from './Paging';
 import { Globals } from '../Globals';
 import { Sorting } from './Sorting';
 import { SortDirection } from './SortDirection';
+import { joinPaths } from '../joinPaths';
 
 /**
  * Represents an implementation of {@link IQueryFor}.
@@ -17,6 +18,7 @@ import { SortDirection } from './SortDirection';
  */
 export abstract class QueryFor<TDataType, TArguments = object> implements IQueryFor<TDataType, TArguments> {
     private _microservice: string;
+    private _apiBasePath: string;
     abstract readonly route: string;
     abstract readonly routeTemplate: Handlebars.TemplateDelegate;
     abstract get requiredRequestArguments(): string[];
@@ -35,11 +37,17 @@ export abstract class QueryFor<TDataType, TArguments = object> implements IQuery
         this.sorting = Sorting.none;
         this.paging = Paging.noPaging;
         this._microservice = Globals.microservice ?? '';
+        this._apiBasePath = '';
     }
 
     /** @inheritdoc */
     setMicroservice(microservice: string) {
         this._microservice = microservice;
+    }
+
+    /** @inheritdoc */
+    setApiBasePath(apiBasePath: string): void {
+        this._apiBasePath = apiBasePath;
     }
 
     /** @inheritdoc */
@@ -62,6 +70,7 @@ export abstract class QueryFor<TDataType, TArguments = object> implements IQuery
         this.abortController = new AbortController();
 
         actualRoute = this.routeTemplate(args);
+        actualRoute = joinPaths(this._apiBasePath, actualRoute);
 
         const headers = {
             'Accept': 'application/json',

--- a/Source/JavaScript/Applications/queries/QueryProvider.ts
+++ b/Source/JavaScript/Applications/queries/QueryProvider.ts
@@ -13,13 +13,15 @@ export class QueryProvider implements IQueryProvider {
     /**
      * Initializes a new instance of {@link QueryProvider}
      * @param _microservice Name of the microservice to provide queries for.
+     * @param _apiBasePath Base path for the API to use for the query.
      */
-    constructor(private readonly _microservice: string) { }
+    constructor(private readonly _microservice: string, private readonly _apiBasePath: string) { }
 
     /** @inheritdoc */
     get<T extends IQuery>(queryType: Constructor<T>): T {
         const query = new queryType();
         query.setMicroservice(this._microservice);
+        query.setApiBasePath(this._apiBasePath);
         return query;
     }
 }


### PR DESCRIPTION
### Added

- Extending `ICommand` and `IQuery` interfaces with a `setApiBasePath()` method and implementing this in all implementations.
- Commands and Queries honor the new Api Base Path and prepends this to the query.
- React `ApplicationModel` context now has a property `apiBasePath` for configuring React apps.
