### PR TITLE
Make microservice property optional

### DIFF
--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -8,14 +8,14 @@ import { ApplicationModelConfiguration, ApplicationModelContext } from './Applic
 
 export interface ApplicationModelProps {
     children?: JSX.Element | JSX.Element[];
-    microservice: string;
+    microservice?: string;
     development?: boolean;
     apiBasePath?: string;
 }
 
 export const ApplicationModel = (props: ApplicationModelProps) => {
     const configuration: ApplicationModelConfiguration = {
-        microservice: props.microservice,
+        microservice: props.microservice ?? '',
         development: props.development ?? false,
         apiBasePath: props.apiBasePath ?? ''
     };


### PR DESCRIPTION
### Fixed

- Making `microservice` property for `<ApplicationModel/>` context optional, as there is requirement for it to be set anywhere. This is just an oversight.