### PR TITLE
Intercepting resolve for tsyringe during viewModel creation to set microservice and apiBasePath for types that supports it

### DIFF
--- a/Source/JavaScript/Applications/ICanBeConfigured.ts
+++ b/Source/JavaScript/Applications/ICanBeConfigured.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents the concept of something that can be configured.
+ */
+export interface ICanBeConfigured {
+    /**
+     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
+     * @param microservice Name of microservice
+     */
+    setMicroservice(microservice: string);
+
+    /**
+     * Set the base path for the API to use for the query. This is used to prepend to the path to any fetch operation.
+     * @param apiBasePath Base path for the API
+     */
+    setApiBasePath(apiBasePath: string): void;
+}

--- a/Source/JavaScript/Applications/commands/ICommand.ts
+++ b/Source/JavaScript/Applications/commands/ICommand.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { ICanBeConfigured } from '../ICanBeConfigured';
 import { CommandResult } from './CommandResult';
 
 /**
@@ -11,7 +12,7 @@ export type PropertyChanged = (property: string) => void;
 /**
  * Defines the base of a command.
  */
-export interface ICommand<TCommandContent = object, TCommandResponse = object> {
+export interface ICommand<TCommandContent = object, TCommandResponse = object> extends ICanBeConfigured {
     /**
      * Gets the route information for the command.
      */
@@ -44,18 +45,6 @@ export interface ICommand<TCommandContent = object, TCommandResponse = object> {
      * Gets whether or not there are changes to any properties.
      */
     readonly hasChanges: boolean;
-
-    /**
-     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
-     * @param microservice Name of microservice
-     */
-    setMicroservice(microservice: string);
-
-    /**
-     * Set the base path for the API to use for the query. This is used to prepend to the path of the command.
-     * @param apiBasePath Base path for the API
-     */
-    setApiBasePath(apiBasePath: string): void;
 
     /**
      * Notify about a property that has had its value changed.

--- a/Source/JavaScript/Applications/index.ts
+++ b/Source/JavaScript/Applications/index.ts
@@ -8,6 +8,7 @@ import * as validation from './validation';
 export * from './joinPaths';
 export * from './deepEqual';
 export * from './Globals';
+export * from './ICanBeConfigured';
 
 export {
     commands,

--- a/Source/JavaScript/Applications/joinPaths.ts
+++ b/Source/JavaScript/Applications/joinPaths.ts
@@ -2,5 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export function joinPaths(...paths) {
-    return paths.map(p => p.replace(/^\/+|\/+$/g, '')).join('/');
+    const joined = paths.join('/');
+    return joined.replace('//', '/');
 }

--- a/Source/JavaScript/Applications/queries/IQuery.ts
+++ b/Source/JavaScript/Applications/queries/IQuery.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { ICanBeConfigured } from '../ICanBeConfigured';
 import { Paging } from './Paging';
 import { Sorting } from './Sorting';
 
 /**
  * Defines the commonalities between all query types.
  */
-export interface IQuery {
+export interface IQuery extends ICanBeConfigured {
     /**
      * Gets the sorting for the query.
      */
@@ -27,16 +28,4 @@ export interface IQuery {
      * Sets the paging for the query.
      */
     set paging(value: Paging);
-
-    /**
-     * Set the microservice to be used for the query. This is passed along to the server to identify the microservice.
-     * @param microservice Name of microservice
-     */
-    setMicroservice(microservice: string);
-
-    /**
-     * Set the base path for the API to use for the query. This is used to prepend to the path of the query.
-     * @param apiBasePath Base path for the API
-     */
-    setApiBasePath(apiBasePath: string): void;
 }


### PR DESCRIPTION
### Fixed

- Fixing `microservice` and `apiBasePath` that are used by queries and commands cross cuttingly when using `withViewModel()`. This allows us to take dependencies directly to commands and queries and these values be set correctly relative the application context.
