### PR TITLE
Use BsonClassMap for getting Id property for QueryContextAwareSet

### DIFF
--- a/Source/DotNET/MongoDB/MissingIdMapping.cs
+++ b/Source/DotNET/MongoDB/MissingIdMapping.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MongoDB.Driver;
+
+/// <summary>
+/// Exception that gets thrown when type is missing an Id property mapping.
+/// </summary>
+/// <param name="type">Type that is missing the Id property mapping.</param>
+public class MissingIdMapping(Type type) : Exception($"Missing Id mapping for type {type.FullName}");

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -175,8 +175,8 @@ public static class MongoCollectionExtensions
         var queryContextManager = Internals.ServiceProvider.GetRequiredService<IQueryContextManager>();
         var queryContext = queryContextManager.Current;
 
-        // TODO: No customizable Id property?
-        var idProperty = typeof(TDocument).GetProperty("Id", BindingFlags.Instance | BindingFlags.Public)!;
+        var classMap = BsonClassMap.LookupClassMap(typeof(TDocument));
+        var idProperty = typeof(TDocument).GetProperty(classMap.IdMemberMap?.MemberName ?? "Id", BindingFlags.Instance | BindingFlags.Public) ?? throw new MissingIdMapping(typeof(TDocument));
         var documents = new QueryContextAwareSet<TDocument>(queryContext, idProperty);
 
         var options = new ChangeStreamOptions

--- a/Source/DotNET/MongoDB/QueryContextAwareSet.cs
+++ b/Source/DotNET/MongoDB/QueryContextAwareSet.cs
@@ -49,6 +49,9 @@ internal sealed class QueryContextAwareSet<TDocument> : IEnumerable<TDocument>
     /// Initializes a new instance of the <see cref="QueryContextAwareSet{TDocument}"/> class.
     /// </summary>
     /// <param name="queryContext">The query context.</param>
+    /// <remarks>
+    /// Primarily used for testing.
+    /// </remarks>
     public QueryContextAwareSet(QueryContext queryContext) : this(queryContext, typeof(TDocument).GetProperty("Id", BindingFlags.Instance | BindingFlags.Public)!)
     {
     }


### PR DESCRIPTION
### Fixed

- MongoCollection Observe extension methods now uses the `BsonClassMap` to find the Id property, it defaults to the Id property if this does not exist for some reason
