### PR TITLE
FIxing the property for skip output deletion

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
@@ -17,7 +17,10 @@
         <Message Text="AssemblyName : $(AssemblyName)" Importance="high" />
         <Message Text="ProxyGenerator base directory : $(CratisProxyGeneratorAssemblyDirectory)" Importance="high" />
         <Message Text="Full path to assembly : $(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll" Importance="high" />
-        <SkipOutputDeletion Condition=" '$(CratisProxiesSkipOutputDeletion)' == 'true' " Value="--skip-output-deletion"></SkipOutputDeletion>
+        
+        <PropertyGroup>
+            <SkipOutputDeletion Condition=" '$(CratisProxiesSkipOutputDeletion)' == 'true' ">--skip-output-deletion</SkipOutputDeletion>
+        </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true" Command="dotnet $(CratisProxyGeneratorAssembly) $(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll $(CratisProxiesOutputPath) $(CratisProxiesSegmentsToSkip) $(SkipOutputDeletion)" WorkingDirectory="$(CratisProxyGeneratorAssemblyDirectory)" />
     </Target>


### PR DESCRIPTION
### Fixed

- Fixing an error in the ProxyGenerator targets file that had the wrong syntax for the new property for skipping deletion output.
