### PR TITLE
Fix/meter

### DIFF
--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.Metrics;
 using Cratis.Applications;
 using Cratis.Conversion;
 using Cratis.DependencyInjection;
@@ -80,6 +81,7 @@ public static class HostBuilderExtensions
         builder
             .ConfigureServices(services =>
             {
+                services.AddKeyedSingleton(Internals.MeterName, new Meter(Internals.MeterName));
                 services
                     .AddTypeDiscovery()
                     .AddSingleton<IDerivedTypes>(derivedTypes)

--- a/Source/DotNET/Applications/Internals.cs
+++ b/Source/DotNET/Applications/Internals.cs
@@ -10,6 +10,10 @@ namespace Cratis.Applications;
 /// </summary>
 internal static class Internals
 {
+    /// <summary>
+    /// Gets the name of the meter used by the Application Model.
+    /// </summary>
+    internal const string MeterName = "Cratis.Applications";
     static IServiceProvider? _serviceProvider;
     static ITypes? _types;
 

--- a/Source/DotNET/MongoDB/HostBuilderExtensions.cs
+++ b/Source/DotNET/MongoDB/HostBuilderExtensions.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.Metrics;
+using Cratis.Applications;
 using Cratis.Applications.MongoDB;
+using Cratis.Metrics;
 using Cratis.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -77,6 +80,12 @@ public static class HostBuilderExtensions
         {
             optionsBuilder.BindConfiguration(mongoDBConfigSectionPath);
         }
+
+        services.AddKeyedSingleton<IMeter<IMongoClient>>(Internals.MeterName, (sp, key) =>
+        {
+            var meter = sp.GetRequiredKeyedService<Meter>(key);
+            return new Meter<IMongoClient>(meter);
+        });
 
         services.AddHostedService<MongoDBInitializer>();
 

--- a/Source/DotNET/MongoDB/MongoDBClientFactory.cs
+++ b/Source/DotNET/MongoDB/MongoDBClientFactory.cs
@@ -6,6 +6,7 @@ using Castle.DynamicProxy;
 using Cratis.Applications.MongoDB.Resilience;
 using Cratis.DependencyInjection;
 using Cratis.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -28,7 +29,11 @@ namespace Cratis.Applications.MongoDB;
 /// <param name="options"><see cref="IOptions{TOptions}"/> for getting the options.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
 [Singleton]
-public class MongoDBClientFactory(IMongoServerResolver serverResolver, IMeter<IMongoClient> meter, IOptions<MongoDBOptions> options, ILogger<MongoDBClientFactory> logger) : IMongoDBClientFactory
+public class MongoDBClientFactory(
+    IMongoServerResolver serverResolver,
+    [FromKeyedServices(Internals.MeterName)] IMeter<IMongoClient> meter,
+    IOptions<MongoDBOptions> options,
+    ILogger<MongoDBClientFactory> logger) : IMongoDBClientFactory
 {
     readonly ConcurrentDictionary<string, IMongoClient> _clients = new();
     readonly ConcurrentDictionary<string, int> _connectedClientsCount = new();

--- a/Source/JavaScript/Applications.React.MVVM/withViewModel.tsx
+++ b/Source/JavaScript/Applications.React.MVVM/withViewModel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { container, DependencyContainer } from "tsyringe";
+import { container, DependencyContainer } from 'tsyringe';
 import { Constructor } from '@cratis/fundamentals';
 import { FunctionComponent, ReactElement, useContext, useEffect, useRef, useState } from 'react';
 import { Observer } from 'mobx-react';


### PR DESCRIPTION
### Fixed

- Adding missing binding for general `Meter` for use within ApplicationModel as a keyed service and a specific `IMeter<>` for `IMongoClient`. This was missing and actually relying on a non-keyed version which might be there or not, depending on the setup.
