### PR TITLE
Adding support for clearing a command

### DIFF
--- a/Source/JavaScript/Applications/commands/Command.ts
+++ b/Source/JavaScript/Applications/commands/Command.ts
@@ -92,6 +92,15 @@ export abstract class Command<TCommandContent = object, TCommandResponse = objec
     }
 
     /** @inheritdoc */
+    clear(): void {
+        this.properties.forEach(property => {
+            this[property] = undefined;
+        });
+        this._initialValues = {};
+        this._hasChanges = false;
+    }
+
+    /** @inheritdoc */
     setInitialValues(values: TCommandContent) {
         this.properties.forEach(property => {
             if (Object.prototype.hasOwnProperty.call(values, property)) {

--- a/Source/JavaScript/Applications/commands/ICommand.ts
+++ b/Source/JavaScript/Applications/commands/ICommand.ts
@@ -26,6 +26,12 @@ export interface ICommand<TCommandContent = object, TCommandResponse = object> e
     execute(): Promise<CommandResult<TCommandResponse>>;
 
     /**
+     * Clear the command properties and reset them to their default values. This will also clear the initial values.
+     * This is used when the command is not needed anymore and should be cleared.
+     */
+    clear(): void;
+
+    /**
      * Set the initial values for the command. This is used for tracking if there are changes to a command or not.
      * @param {*} values Values to set.
      */

--- a/Source/JavaScript/Applications/commands/for_Command/when_clearing_the_command.ts
+++ b/Source/JavaScript/Applications/commands/for_Command/when_clearing_the_command.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SomeCommand } from './SomeCommand';
+
+describe('when clearing the command', () => {
+    const command = new SomeCommand();
+    command.setInitialValues({
+        someProperty: ''
+    });
+    command.someProperty = '42';
+    command.propertyChanged('someProperty');
+    command.clear();
+
+    it('should not have any changes', () => command.hasChanges.should.be.false);
+    it('should clear the property', () => (command.someProperty === undefined).should.be.true);
+});


### PR DESCRIPTION
### Added

- Adding a `.clear()` method on TS/JS `Command`, convenient if one is using a single command instance and want to clear its content after a successful execution.
