### PR TITLE
Moving LogEnricher config to HostBuilder extension - making it available for all scenarios

### DIFF
--- a/Source/DotNET/Applications/Execution/CorrelationIdHostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/Execution/CorrelationIdHostBuilderExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Applications.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extension methods for <see cref="IHostBuilder"/> for adding the correlation Id log enricher.
+/// </summary>
+public static class CorrelationIdHostBuilderExtensions
+{
+    /// <summary>
+    /// Adds the correlation ID enricher to the logging configuration.
+    /// </summary>
+    /// <param name="builder">The host builder.</param>
+    /// <returns>The host builder for chaining.</returns>
+    public static IHostBuilder AddCorrelationIdLogEnricher(this IHostBuilder builder)
+    {
+        builder.ConfigureLogging(logging => logging.EnableEnrichment());
+        builder.ConfigureServices(services => services.AddLogEnricher<CorrelationIdLogEnricher>());
+        return builder;
+    }
+}

--- a/Source/DotNET/Applications/Execution/CorrelationIdWebApplicationExtensions.cs
+++ b/Source/DotNET/Applications/Execution/CorrelationIdWebApplicationExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Applications.Execution;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -19,8 +17,7 @@ public static class CorrelationIdWebApplicationExtensions
     /// <returns>The web application builder for chaining.</returns>
     public static WebApplicationBuilder AddCorrelationIdLogEnricher(this WebApplicationBuilder builder)
     {
-        builder.Logging.EnableEnrichment();
-        builder.Services.AddLogEnricher<CorrelationIdLogEnricher>();
+        builder.Host.AddCorrelationIdLogEnricher();
         return builder;
     }
 }

--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -91,6 +91,7 @@ public static class HostBuilderExtensions
         var derivedTypes = DerivedTypes.Instance;
 
         builder.UseDefaultServiceProvider(_ => _.ValidateOnBuild = false);
+        builder.AddCorrelationIdLogEnricher();
 
         builder
             .ConfigureServices(services =>

--- a/Source/DotNET/Applications/WebApplicationBuilderExtensions.cs
+++ b/Source/DotNET/Applications/WebApplicationBuilderExtensions.cs
@@ -23,7 +23,6 @@ public static class WebApplicationBuilderExtensions
     /// <returns><see cref="WebApplicationBuilder"/> for building continuation.</returns>
     public static WebApplicationBuilder UseCratisApplicationModel(this WebApplicationBuilder builder, string? configSectionPath = null)
     {
-        builder.AddCorrelationIdLogEnricher();
         builder.Host.UseCratisApplicationModel(configSectionPath);
         return builder;
     }
@@ -36,7 +35,6 @@ public static class WebApplicationBuilderExtensions
     /// <returns><see cref="WebApplicationBuilder"/> for building continuation.</returns>
     public static WebApplicationBuilder UseCratisApplicationModel(this WebApplicationBuilder builder, Action<ApplicationModelOptions> configureOptions)
     {
-        builder.AddCorrelationIdLogEnricher();
         builder.Host.UseCratisApplicationModel(configureOptions);
         return builder;
     }


### PR DESCRIPTION
### Added

- Added `.AddCorrelationIdLogEnricher()` extension method for `IHostBuilder`, making it possible to configure for scenarios where you don't have a `WebApplicationBuilder`. Also moved the default hookup for this to the `UseCratisApplicationModel()` extension for `IHostBuilder`.
