### PR TITLE
Making the validator be recursive through properties

### DIFF
--- a/Source/DotNET/Applications/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Applications/Commands/Filters/FluentValidationFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
 using Cratis.Applications.Validation;
 using FluentValidation;
 
@@ -15,23 +16,36 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
     /// <inheritdoc/>
     public async Task<CommandResult> OnExecution(CommandContext context)
     {
-        if (discoverableValidators.TryGet(context.Type, out var validator))
+        var commandResult = CommandResult.Success(context.CorrelationId);
+        commandResult.MergeWith(await Validate(context, context.Command));
+        return commandResult;
+    }
+
+    async Task<CommandResult> Validate(CommandContext context, object instance)
+    {
+        var commandResult = CommandResult.Success(context.CorrelationId);
+
+        var instanceType = instance.GetType();
+        if (discoverableValidators.TryGet(instanceType, out var validator))
         {
-            var validationContextType = typeof(ValidationContext<>).MakeGenericType(context.Type);
-            var validationContext = Activator.CreateInstance(validationContextType, context.Command) as IValidationContext;
+            var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
+            var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
             var validationResult = await validator.ValidateAsync(validationContext);
             if (!validationResult.IsValid)
             {
-                return new CommandResult
+                commandResult.MergeWith(new CommandResult
                 {
-                    CorrelationId = context.CorrelationId,
-                    IsAuthorized = true,
                     ValidationResults = validationResult.Errors.Select(_ =>
                         new ValidationResult(ValidationResultSeverity.Error, _.ErrorMessage, [_.PropertyName], null!)).ToArray()
-                };
+                });
+            }
+
+            foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                commandResult.MergeWith(await Validate(context, property.GetValue(instance)!));
             }
         }
 
-        return CommandResult.Success(context.CorrelationId);
+        return commandResult;
     }
 }

--- a/Source/DotNET/Applications/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Applications/Commands/Filters/FluentValidationFilter.cs
@@ -40,9 +40,12 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                 });
             }
 
-            foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            if (!instanceType.IsPrimitive)
             {
-                commandResult.MergeWith(await Validate(context, property.GetValue(instance)!));
+                foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    commandResult.MergeWith(await Validate(context, property.GetValue(instance)!));
+                }
             }
         }
 

--- a/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
+++ b/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
@@ -16,6 +16,7 @@ public class BaseDbContext(DbContextOptions options) : DbContext(options)
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyJsonConversion(Database.ProviderName);
+        modelBuilder.ApplyConceptAsConversion();
         base.OnModelCreating(modelBuilder);
     }
 }

--- a/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
+++ b/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Applications.EntityFrameworkCore.Concepts;
 using Cratis.Applications.EntityFrameworkCore.Json;
 using Microsoft.EntityFrameworkCore;
 

--- a/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Cratis.Applications.EntityFrameworkCore.Concepts;
+
+/// <summary>
+/// Provides extension methods for applying concept-based value conversions.
+/// </summary>
+public static class ConceptAsConversion
+{
+    /// <summary>
+    /// Applies value conversion for all properties that are of <see cref="ConceptAs{T}"/> type  in the specified <see cref="ModelBuilder"/>.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder to apply the concept-based conversion to.</param>
+    public static void ApplyConceptAsConversion(this ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var properties = entityType.ClrType.GetProperties()
+                .Where(p => p.PropertyType.IsConcept())
+                .ToList();
+
+            foreach (var property in properties)
+            {
+                var conceptValueType = property.PropertyType.GetConceptValueType();
+                var propertyBuilder = modelBuilder.Entity(entityType.Name).Property(property.Name);
+                var converterType = typeof(ConceptAsValueConverter<,>).MakeGenericType(property.PropertyType, conceptValueType);
+                var comparerType = typeof(ConceptAsValueComparer<,>).MakeGenericType(property.PropertyType, conceptValueType);
+                var converter = Activator.CreateInstance(converterType) as ValueConverter;
+                var comparer = Activator.CreateInstance(comparerType) as ValueComparer;
+
+                propertyBuilder.HasConversion(converter);
+                propertyBuilder.Metadata.SetValueConverter(converter);
+                propertyBuilder.Metadata.SetValueComparer(comparer);
+            }
+        }
+    }
+
+    sealed class ConceptAsValueConverter<TConcept, TPrimitive>() : ValueConverter<TConcept, TPrimitive>(
+        v => v.Value,
+        v => (TConcept)ConceptFactory.CreateConceptInstance(typeof(TConcept), v))
+        where TConcept : notnull, ConceptAs<TPrimitive>
+        where TPrimitive : notnull, IComparable;
+
+    sealed class ConceptAsValueComparer<TConcept, TPrimitive>() : ValueComparer<TConcept>(
+        (l, r) => l!.Equals(r),
+        v => v.GetHashCode())
+        where TConcept : notnull, ConceptAs<TPrimitive>
+        where TPrimitive : notnull, IComparable;
+}


### PR DESCRIPTION
### Added

- Added support for `ConceptAs<>` type conversions to Entity Framework.

### Fixed

- Fixing the command validation filter to run through properties recursively.