### PR TITLE
Adding Guid and DateTimeOffset column types

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/ColumnExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/ColumnExtensions.cs
@@ -28,4 +28,36 @@ public static class ColumnExtensions
             _ => cb.Column<int>("INTEGER", nullable: false)
                 .Annotation("Sqlite:Autoincrement", true)
         };
+
+    /// <summary>
+    /// Adds a Guid column with appropriate database-specific type.
+    /// </summary>
+    /// <param name="cb">Columns builder.</param>
+    /// <param name="mb">Migration builder.</param>
+    /// <param name="nullable">Whether the column should be nullable.</param>
+    /// <returns>Operation builder for the column.</returns>
+#pragma warning disable CA1720 // Identifier contains type name
+    public static OperationBuilder<AddColumnOperation> Guid(this ColumnsBuilder cb, MigrationBuilder mb, bool nullable = true) =>
+        mb.ActiveProvider switch
+        {
+            "Npgsql.EntityFrameworkCore.PostgreSQL" => cb.Column<Guid>("UUID", nullable: nullable),
+            "Microsoft.EntityFrameworkCore.SqlServer" => cb.Column<Guid>("UNIQUEIDENTIFIER", nullable: nullable),
+            _ => cb.Column<Guid>("TEXT", nullable: nullable)
+        };
+#pragma warning restore CA1720 // Identifier contains type name
+
+    /// <summary>
+    /// Adds a DateTimeOffset column with appropriate database-specific type.
+    /// </summary>
+    /// <param name="cb">Columns builder.</param>
+    /// <param name="mb">Migration builder.</param>
+    /// <param name="nullable">Whether the column should be nullable.</param>
+    /// <returns>Operation builder for the column.</returns>
+    public static OperationBuilder<AddColumnOperation> DateTimeOffset(this ColumnsBuilder cb, MigrationBuilder mb, bool nullable = true) =>
+        mb.ActiveProvider switch
+        {
+            "Npgsql.EntityFrameworkCore.PostgreSQL" => cb.Column<DateTimeOffset>("TIMESTAMPTZ", nullable: nullable),
+            "Microsoft.EntityFrameworkCore.SqlServer" => cb.Column<DateTimeOffset>("DATETIMEOFFSET", nullable: nullable),
+            _ => cb.Column<DateTimeOffset>("TEXT", nullable: nullable)
+        };
 }


### PR DESCRIPTION
### Added

- Adding `Guid` column type for use when defining a Db schema, typically for EF Core migrations.
- Adding `DateTimeOffset` column type for use when defining a Db schema, typically for EF Core migrations.
