### PR TITLE
Fixing proxy generator to recognize Tasks and collection types properly

### DIFF
--- a/Directory.Packages.NET8.props
+++ b/Directory.Packages.NET8.props
@@ -2,7 +2,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
         <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="9.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.9" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.9" />
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />
@@ -51,7 +53,5 @@
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.9" />
   </ItemGroup>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/TypeExtensionsModelBound.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/TypeExtensionsModelBound.cs
@@ -63,7 +63,8 @@ public static class TypeExtensionsModelBound
     {
         var returnType = method.ReturnType;
 
-        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
+        if (returnType.IsGenericType &&
+            returnType.GetGenericTypeDefinition().FullName == typeof(Task<>).FullName)
         {
             returnType = returnType.GetGenericArguments()[0];
         }
@@ -79,14 +80,14 @@ public static class TypeExtensionsModelBound
         }
 
         if (returnType.IsGenericType &&
-            returnType.GetGenericTypeDefinition().FullName == "System.Reactive.Subjects.ISubject`1" &&
+            returnType.IsSubject() &&
             returnType.GetGenericArguments()[0] == readModelType)
         {
             return true;
         }
 
         if (returnType.IsGenericType &&
-            returnType.GetGenericTypeDefinition().FullName == "System.Reactive.Subjects.ISubject`1" &&
+            returnType.IsSubject() &&
             IsCollectionOfType(returnType.GetGenericArguments()[0], readModelType))
         {
             return true;
@@ -119,15 +120,6 @@ public static class TypeExtensionsModelBound
             return true;
         }
 
-        if (type.IsGenericType)
-        {
-            var genericArguments = type.GetGenericArguments();
-            return
-                type.ImplementsOpenGeneric(typeof(IEnumerable<>)) &&
-                genericArguments.Length == 1 &&
-                genericArguments[0] == elementType;
-        }
-
-        return false;
+        return type.ImplementsEnumerable();
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -630,6 +630,14 @@ public static class TypeExtensions
             .Any(i => i.GetTypeInfo().IsGenericType && i.GetTypeInfo().GetGenericTypeDefinition().GetTypeInfo() == openGenericTypeInfo);
     }
 
+    /// <summary>
+    /// Check if a type implements IEnumerable.
+    /// </summary>
+    /// <param name="type"><see cref="Type"/> to check.</param>
+    /// <returns>True if type implements IEnumerable, false if not.</returns>
+    public static bool ImplementsEnumerable(this Type type) =>
+        type.ImplementsOpenGeneric(_genericEnumerableType) || (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEnumerableType);
+
     static void InitializeWellKnownTypes()
     {
         var assembly = _metadataLoadContext!.CoreAssembly!;


### PR DESCRIPTION
### Fixed

- For Model Bound queries, the Proxy Generator now recognizes the correct `Task<>` and `IEnumerable<>`  types from the context of the assembly it is working with.

