### PR TITLE
Fixing how we identify collections of type

### DIFF
--- a/Source/DotNET/Applications/Queries/ModelBound/ReadModelExtensions.cs
+++ b/Source/DotNET/Applications/Queries/ModelBound/ReadModelExtensions.cs
@@ -67,15 +67,8 @@ public static class ReadModelExtensions
             return true;
         }
 
-        if (type.IsGenericType)
-        {
-            var genericArguments = type.GetGenericArguments();
-            return
-                type.ImplementsOpenGeneric(typeof(IEnumerable<>)) &&
-                genericArguments.Length == 1 &&
-                genericArguments[0] == elementType;
-        }
-
-        return false;
+        return type
+            .IsAssignableTo(typeof(IEnumerable<>)
+            .MakeGenericType(elementType));
     }
 }


### PR DESCRIPTION
### Fixed

- Fixing how queries that are a collection (IEnumerable<>) of a read model gets identified. They were skipped.
