### PR TITLE
Introducing a way to get the current command context and hooked up for command pipelines

### DIFF
--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
@@ -11,6 +11,7 @@ public class a_command_pipeline : Specification
     protected ICommandFilters _commandFilters;
     protected ICommandHandlerProviders _commandHandlerProviders;
     protected ICommandResponseValueHandlers _commandResponseValueHandlers;
+    protected ICommandContextModifier _commandContextModifier;
     protected IServiceProvider _serviceProvider;
     protected CommandPipeline _commandPipeline;
 
@@ -23,6 +24,7 @@ public class a_command_pipeline : Specification
         _commandFilters.OnExecution(Arg.Any<CommandContext>()).Returns(CommandResult.Success(correlationId));
         _commandHandlerProviders = Substitute.For<ICommandHandlerProviders>();
         _commandResponseValueHandlers = Substitute.For<ICommandResponseValueHandlers>();
+        _commandContextModifier = Substitute.For<ICommandContextModifier>();
         _serviceProvider = Substitute.For<IServiceProvider>();
 
         _commandPipeline = new(
@@ -30,6 +32,7 @@ public class a_command_pipeline : Specification
             _commandFilters,
             _commandHandlerProviders,
             _commandResponseValueHandlers,
+            _commandContextModifier,
             _serviceProvider);
     }
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_an_exception_is_thrown_in_handler.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_an_exception_is_thrown_in_handler.cs
@@ -21,4 +21,5 @@ public class and_an_exception_is_thrown_in_handler : given.a_command_pipeline_an
     [Fact] void should_not_call_value_handlers() => _commandResponseValueHandlers.DidNotReceive().Handle(Arg.Any<CommandContext>(), Arg.Any<object>());
     [Fact] void should_be_unsuccessful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_return_exception_in_command_result() => _result.ExceptionMessages.First().ShouldEqual(_exception.Message);
+    [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
@@ -18,4 +18,5 @@ public class and_command_filters_are_reporting_not_successful : given.a_command_
 
     [Fact] void should_return_not_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_not_call_command_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());
+    [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value.cs
@@ -26,4 +26,5 @@ public class and_handler_returns_a_one_of_value : given.a_command_pipeline_and_a
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _oneOf.Value);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
+    [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value.cs
@@ -23,4 +23,5 @@ public class and_handler_returns_a_value : given.a_command_pipeline_and_a_handle
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _value);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
+    [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
@@ -27,4 +27,5 @@ public class and_there_is_a_handler_that_has_dependencies : given.a_command_pipe
 
     [Fact] void should_call_command_handler() => _commandHandler.Received(1).Handle(Arg.Any<CommandContext>());
     [Fact] void should_pass_dependencies_to_handler() => _dependencies.ShouldContainOnly(_expectedDependencies);
+    [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_no_handler.cs
+++ b/Source/DotNET/Applications.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_no_handler.cs
@@ -11,4 +11,5 @@ public class and_there_is_no_handler : given.a_command_pipeline
 
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_exceptions() => _result.HasExceptions.ShouldBeTrue();
+    [Fact] void should_not_set_current_command_context() => _commandContextModifier.DidNotReceive().SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Applications/Assembly.cs
+++ b/Source/DotNET/Applications/Assembly.cs
@@ -4,3 +4,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Cratis.Applications.MongoDB")]
+[assembly: InternalsVisibleTo("Cratis.Applications.Specs")]

--- a/Source/DotNET/Applications/Commands/CommandContextIsNotAvailable.cs
+++ b/Source/DotNET/Applications/Commands/CommandContextIsNotAvailable.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.Commands;
+
+/// <summary>
+/// Exception that is thrown when no command context is available in the current scope.
+/// </summary>
+public class CommandContextIsNotAvailable() : Exception("No command context is available in the current scope.");

--- a/Source/DotNET/Applications/Commands/CommandContextManager.cs
+++ b/Source/DotNET/Applications/Commands/CommandContextManager.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.Commands;
+
+/// <summary>
+/// Manages the current <see cref="CommandContext"/> in an async local manner.
+/// </summary>
+public class CommandContextManager : ICommandContextModifier, ICommandContextAccessor
+{
+    static readonly AsyncLocal<CommandContext?> _current = new();
+
+    /// <inheritdoc/>
+    public CommandContext Current => _current.Value ?? throw new InvalidOperationException("No command context is available in the current scope.");
+
+    /// <inheritdoc/>
+    public void SetCurrent(CommandContext context) => _current.Value = context;
+}

--- a/Source/DotNET/Applications/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Applications/Commands/CommandPipeline.cs
@@ -16,6 +16,7 @@ namespace Cratis.Applications.Commands;
 /// <param name="commandFilters">The <see cref="ICommandFilters"/> to use for filtering commands.</param>
 /// <param name="handlerProviders">The <see cref="ICommandHandlerProviders"/> to use for finding command handlers.</param>
 /// <param name="valueHandlers">The <see cref="ICommandResponseValueHandlers"/> to use for handling response values.</param>
+/// <param name="contextModifier">The <see cref="ICommandContextModifier"/> to use for setting the current command context.</param>
 /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use for resolving dependencies.</param>
 [Singleton]
 public class CommandPipeline(
@@ -23,6 +24,7 @@ public class CommandPipeline(
     ICommandFilters commandFilters,
     ICommandHandlerProviders handlerProviders,
     ICommandResponseValueHandlers valueHandlers,
+    ICommandContextModifier contextModifier,
     IServiceProvider serviceProvider) : ICommandPipeline
 {
     /// <inheritdoc/>
@@ -40,6 +42,7 @@ public class CommandPipeline(
 
             var dependencies = commandHandler.Dependencies.Select(serviceProvider.GetRequiredService);
             var commandContext = new CommandContext(correlationId, command.GetType(), command, dependencies);
+            contextModifier.SetCurrent(commandContext);
             result = await commandFilters.OnExecution(commandContext);
             if (!result.IsSuccess)
             {

--- a/Source/DotNET/Applications/Commands/CommandServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/Commands/CommandServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class CommandServiceCollectionExtensions
         services.AddSingleton<ICommandFilters, CommandFilters>();
         services.AddSingleton<ICommandHandlerProviders, CommandHandlerProviders>();
         services.AddSingleton<ICommandResponseValueHandlers, CommandResponseValueHandlers>();
+        services.AddTransient(sp => sp.GetRequiredService<ICommandContextAccessor>().Current);
         return services;
     }
 }

--- a/Source/DotNET/Applications/Commands/CommandServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/Commands/CommandServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Applications.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Extensions for adding Cratis command handling services to a service collection.
+/// </summary>
+public static class CommandServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Cratis command handling services to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddCratisCommands(this IServiceCollection services)
+    {
+        services.AddSingleton<CommandContextManager>();
+        services.AddSingleton<ICommandContextModifier>(sp => sp.GetRequiredService<CommandContextManager>());
+        services.AddSingleton<ICommandContextAccessor>(sp => sp.GetRequiredService<CommandContextManager>());
+        services.AddSingleton<ICommandPipeline, CommandPipeline>();
+        services.AddSingleton<ICommandFilters, CommandFilters>();
+        services.AddSingleton<ICommandHandlerProviders, CommandHandlerProviders>();
+        services.AddSingleton<ICommandResponseValueHandlers, CommandResponseValueHandlers>();
+        return services;
+    }
+}

--- a/Source/DotNET/Applications/Commands/ICommandContextAccessor.cs
+++ b/Source/DotNET/Applications/Commands/ICommandContextAccessor.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.Commands;
+
+/// <summary>
+/// Provides access to the current <see cref="CommandContext"/>.
+/// </summary>
+public interface ICommandContextAccessor
+{
+    /// <summary>
+    /// Gets the current <see cref="CommandContext"/>.
+    /// </summary>
+    CommandContext Current { get; }
+}

--- a/Source/DotNET/Applications/Commands/ICommandContextModifier.cs
+++ b/Source/DotNET/Applications/Commands/ICommandContextModifier.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.Commands;
+
+/// <summary>
+/// Defines a system that can modify the current <see cref="CommandContext"/>.
+/// </summary>
+public interface ICommandContextModifier
+{
+    /// <summary>
+    /// Sets the current <see cref="CommandContext"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="CommandContext"/> to set as current.</param>
+    internal void SetCurrent(CommandContext context);
+}

--- a/Source/DotNET/Applications/Commands/ICommandContextModifier.cs
+++ b/Source/DotNET/Applications/Commands/ICommandContextModifier.cs
@@ -12,5 +12,5 @@ public interface ICommandContextModifier
     /// Sets the current <see cref="CommandContext"/>.
     /// </summary>
     /// <param name="context">The <see cref="CommandContext"/> to set as current.</param>
-    internal void SetCurrent(CommandContext context);
+    void SetCurrent(CommandContext context);
 }

--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -97,6 +97,7 @@ public static class HostBuilderExtensions
             .ConfigureServices(services =>
             {
                 services.AddCratisApplicationModelMeter();
+                services.AddCratisCommands();
                 services
                     .AddTypeDiscovery()
                     .AddSingleton<IDerivedTypes>(derivedTypes)


### PR DESCRIPTION
### Added

- `ICommandContextAccessor` for getting access to the current `CommandContext`when doing work that is part of the command pipeline.
- For convenience; making it possible to take a dependency directly to `CommandContext` which will resolve through the new `ICommandContextAccessor`
