### PR TITLE
Making the TDbContext constraint a regular DbContext

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/DbContextExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/DbContextExtensions.cs
@@ -20,7 +20,7 @@ public static class DbContextExtensions
     /// <param name="optionsAction">An optional action to configure the DbContext options.</param>
     /// <returns>The updated service collection.</returns>
     public static IServiceCollection AddDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<DbContextOptionsBuilder>? optionsAction = default)
-        where TDbContext : BaseDbContext
+        where TDbContext : DbContext
     {
         services.AddDbContext<TDbContext>(options =>
         {


### PR DESCRIPTION
### Fixed

- Fixed the constraint for `AddDbContextWithConnectionString()` extension method to be just `DbContext` and not `BaseDbContext` which it should've been.
