### PR TITLE
Fix/secure-check

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,6 +101,8 @@
 
 - Follow the following guides:
    - [How to Write Specs](./instructions/specs.instructions.md)
+   - [How to Write C# Specs](./instructions/specs.csharp.instructions.md)
+   - [How to Write TypeScript Specs](./instructions/specs.typescript.instructions.md)
    - [How to Write Entity Framework Core Specs](./instructions/efcore.specs.instructions.md)
    - [Concepts](./instructions/concepts.instructions.md)
    - [Documentation](./instructions/documentation.instructions.md)

--- a/.github/instructions/specs.csharp.instructions.md
+++ b/.github/instructions/specs.csharp.instructions.md
@@ -1,0 +1,165 @@
+---
+applyTo: "**/for_*/**/*.cs, **/when_*/**/*.cs"
+---
+
+# 🧪 How to Write C# Specs
+
+Use the base instructions for writing specs can be found in [Specs Instructions](./specs.instructions.md) and
+then adapt with the C# specific conventions below.
+
+## Test Frameworks & Conventions
+
+- **Frameworks:**
+  - Uses [Xunit](https://xunit.net/) as test framework and execution.
+  - Uses [NSubstitute](https://nsubstitute.github.io/) for mocking.
+  - Uses [Cratis Specifications](https://github.com/Cratis/Specifications/blob/main/README.md) for BDD style specification by example testing.
+  - Use separate projects for specs, e.g. `Applications.Specs`.
+
+## Base class
+
+- At the root of inheritance, `Specification` must be the base class.
+
+## Test Class Pattern
+
+- Use BDD-style methods:
+  - `void Establish()` for setup.
+  - `void Because()` for the action under test.
+  - `[Fact] void should_<expected_behavior>()` for assertions.
+  - Keep them focused on a single behavior or aspect.
+
+**Example:**
+
+```csharp
+public class when_adding : Specification
+{
+    EventsToAppend events;
+    string @event;
+
+    void Establish()
+    {
+        events = [];
+        @event = "Forty Two";
+    }
+
+    void Because() => events.Add(@event);
+
+    [Fact] void should_hold_the_added_event() => events.First().ShouldEqual(@event);
+}
+```
+
+**Example with multiple outcomes:**
+
+```
+for_EventsCommandResponseValueHandler/
+├── given/
+│   └── an_events_command_response_value_handler.cs
+├── when_checking_can_handle/
+│   ├── with_valid_events_collection.cs
+│   ├── with_null_value.cs
+│   └── without_event_source_id.cs
+└── when_handling/
+    ├── empty_events_collection.cs
+    ├── single_event_collection.cs
+    └── multiple_events_collection.cs
+```
+
+Each test class inherits from `given.an_events_command_response_value_handler`:
+
+```csharp
+public class with_valid_events_collection : given.an_events_command_response_value_handler
+{
+    IEnumerable<object> _events;
+    bool _result;
+
+    void Establish()
+    {
+        _events = [new TestEvent("Test"), new AnotherTestEvent(42)];
+    }
+
+    void Because() => _result = _handler.CanHandle(_commandContext, _events);
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+}
+```
+
+- Establish method can also be async if it needs to perform tasks that are async.
+
+## Reusable Context
+
+- Namespace should include `given` in the name (e.g., `Infrastructure.ReadModels.for_EventsCommandResponseValueHandler.given`)
+- Members that are to be reused should be `protected`
+- Members are initialized using the `Establish` method, same as regular specs
+- Specs inherit from the context by doing `given.a_specific_context`, example: `public class when_performing_a_behavior : given.a_specific_context`
+- Remember the inheritance rule: `Specification` must be in the inheritance chain at the root
+- Shared variables should be `protected` fields, not properties and they should follow the `_camelCase` naming convention
+- **For behaviors with multiple outcomes:**
+  - The reusable context should be in the unit's `given/` folder (e.g., `for_<Unit>/given/`)
+  - All test files within behavior folders (e.g., `when_<behavior>/`) inherit from this shared context
+  - This allows consistent setup across all variations of the behavior
+- If a specific behavior needs additional setup, create behavior-specific contexts in `when_<behavior>/given/` folder
+
+## Async
+
+- Any of the methods (`Establish`, `Because`, `Cleanup`) can be async if needed.
+
+## Substitutes
+
+- Concrete classes can be substituted/mocked, not just interfaces or abstract classes.
+- When substituting concrete classes, ensure they have virtual methods or properties to allow mocking behavior.
+- Pass constructor parameters as needed when substituting concrete classes. For example, `Substitute.For<ConcreteClass>(param1, param2)`.
+
+## Test Utilities
+
+- Use `Substitute.For<T>()` for mocks.
+- Cratis Specifications has a set of assertion extension methods, use these
+  - `.ShouldEqual()`
+  - `.ShouldBeTrue()`
+  - `.ShouldBeFalse()`
+  - `.ShouldBeNull()`
+  - `.ShouldNotBeNull()`
+  - `.ShouldBeOfExactType<T>()`
+  - `.ShouldContain()`
+  - `.ShouldContainOnly()`
+  - `.ShouldNotContain()`
+  - `.ShouldBeEmpty()`
+  - `.ShouldNotBeEmpty()`
+  - `.ShouldBeInRange()`
+  - `.ShouldNotBeInRange()`
+  - `.ShouldBeGreaterThan()`
+  - `.ShouldBeGreaterThanOrEqual()`
+  - `.ShouldBeLessThan()`
+  - `.ShouldBeLessThanOrEqual()`
+- Use custom helpers from `XUnit.Integration` for integration/event-based assertions.
+
+## Using statements
+
+- Common usings are provided in `GlobalUsings.Specs.cs` (e.g., `using Xunit;`, `using NSubstitute;`), don't add any using statements already in this file.
+- Don't add using statement for namespace of the system under test.
+
+## Properties and Simple Members
+
+**Do NOT create specs for:**
+- Simple auto-properties (e.g., `public string Name { get; set; }`)
+- Properties that return constructor parameters (e.g., `public string TableName => tableName;`)
+- Properties that return field values (e.g., `public Key Key => key;`)
+- Properties that delegate to other objects without transformation (e.g., `public IEnumerable<Property> Properties => mapper.Properties;`)
+- Expression-bodied properties that return simple values (e.g., `public Type PropertyName => someValue;`)
+- Properties that perform simple null checks or basic validation without complex logic
+- Getters that return injected dependencies or configuration values
+
+**Examples of properties to IGNORE:**
+```csharp
+// ❌ Do NOT write specs for these
+public string TableName => tableName;                    // Returns constructor parameter
+public Key Key => key;                                   // Returns constructor parameter
+public IEnumerable<Property> Properties => mapper.Properties; // Simple delegation
+public bool IsValid => _value is not null;              // Simple validation
+public ILogger Logger { get; }                          // Injected dependency
+```
+
+**Only write specs for properties with complex business logic:**
+```csharp
+// ✅ These might need specs if they contain complex logic
+public decimal TotalCost => Items.Sum(i => i.Cost * i.Quantity * (1 + i.TaxRate));
+public bool CanProcess => ValidateComplexBusinessRules() && CheckExternalConditions();
+```

--- a/.github/instructions/specs.instructions.md
+++ b/.github/instructions/specs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/for_*/**/*.cs, **/when_*/**/*.cs"
+applyTo: "**/for_*/**/*.*, **/when_*/**/*.*"
 ---
 
 # 🧪 How to Write Specs
@@ -7,92 +7,16 @@ applyTo: "**/for_*/**/*.cs, **/when_*/**/*.cs"
 We call automated tests for specs or specifications based on Specification by Example related to BDD (Behavior Driven Development).
 Keep tests focused, isolated, and descriptive!
 
-## Test Frameworks & Conventions
-
-- **Frameworks:**
-  - Uses [Xunit](https://xunit.net/) as test framework and execution.
-  - Uses [NSubstitute](https://nsubstitute.github.io/) for mocking.
-  - Uses [Cratis Specifications](https://github.com/Cratis/Specifications/blob/main/README.md) for BDD style specification by example testing.
+## Structure
 
 - **File/Folder Structure:**
-  - Organize tests by feature/domain, e.g. `Events/Constraints/for_UniqueConstraintProvider/when_providing.cs`.
-  - Use separate projects for specs, e.g. `Applications.Specs`.
+  - Organize tests by feature/domain, e.g. `Events/Constraints/for_UniqueConstraintProvider/when_providing`.
   - Use descriptive folder and file names:
     - `for_<TypeUnderTest>/` for the unit under test
     - `when_<behavior>/` for behaviors with multiple outcomes
-    - `when_<behavior>.cs` for simple behaviors with single outcomes
-    - Example: `for_UnitOfWork/when_committing/and_it_has_events_and_append_returns_constraints_and_errors.cs`
-  - Tests are found in alongside the code being tested in folders starting with either `for_`, `when_` or `given_` (for reusable contexts).
-
-## Base class
-
-- At the root of inheritance, `Specification` must be the base class.
-
-## Test Class Pattern
-
-- Use BDD-style methods:
-  - `void Establish()` for setup.
-  - `void Because()` for the action under test.
-  - `[Fact] void should_<expected_behavior>()` for assertions.
-  - Keep them focused on a single behavior or aspect.
-
-**Example:**
-
-```csharp
-public class when_adding : Specification
-{
-    EventsToAppend events;
-    string @event;
-
-    void Establish()
-    {
-        events = [];
-        @event = "Forty Two";
-    }
-
-    void Because() => events.Add(@event);
-
-    [Fact] void should_hold_the_added_event() => events.First().ShouldEqual(@event);
-}
-```
-
-**Example with multiple outcomes:**
-
-```
-for_EventsCommandResponseValueHandler/
-├── given/
-│   └── an_events_command_response_value_handler.cs
-├── when_checking_can_handle/
-│   ├── with_valid_events_collection.cs
-│   ├── with_null_value.cs
-│   └── without_event_source_id.cs
-└── when_handling/
-    ├── empty_events_collection.cs
-    ├── single_event_collection.cs
-    └── multiple_events_collection.cs
-```
-
-Each test class inherits from `given.an_events_command_response_value_handler`:
-
-```csharp
-public class with_valid_events_collection : given.an_events_command_response_value_handler
-{
-    IEnumerable<object> _events;
-    bool _result;
-
-    void Establish()
-    {
-        _events = [new TestEvent("Test"), new AnotherTestEvent(42)];
-    }
-
-    void Because() => _result = _handler.CanHandle(_commandContext, _events);
-
-    [Fact] void should_return_true() => _result.ShouldBeTrue();
-}
-```
-
-- Establish method can also be async if it needs to perform tasks that are async.
-
+    - Single file `when_<behavior>` for simple behaviors with single outcomes
+    - Example: `for_UnitOfWork/when_committing/and_it_has_events_and_append_returns_constraints_and_errors`
+ 
 ## What to specify
 
 - Write specs that verify what is promised from the signature of methods, not based on its implementation - we want to catch problems with the implementation.
@@ -126,11 +50,11 @@ public class with_valid_events_collection : given.an_events_command_response_val
   - Create a folder named `when_<behavior>` (e.g., `when_checking_can_handle`, `when_handling`)
   - Within this folder, create separate test files for each specific outcome or aspect
   - Use descriptive names that clearly indicate the specific condition being tested:
-    - `with_valid_events_collection.cs`
-    - `with_null_value.cs`
-    - `without_event_source_id.cs`
-    - `empty_events_collection.cs`
-    - `multiple_events_collection.cs`
+    - `with_valid_events_collection`
+    - `with_null_value`
+    - `without_event_source_id`
+    - `empty_events_collection`
+    - `multiple_events_collection`
 - Do not limit naming to `and_*` - use any preposition or descriptor that makes the condition clear:
   - `and_*` for additional conditions (e.g., `and_it_has_events`, `and_validation_fails`)
   - `or_*` for alternative scenarios (e.g., `or_timeout_occurs`, `or_connection_fails`)
@@ -142,65 +66,17 @@ public class with_valid_events_collection : given.an_events_command_response_val
 - Keep a single specific outcome or aspect in each file - don't combine multiple scenarios
 - Each test file should inherit from the appropriate reusable context (usually `given.a_<unit_name>`)
 
-## Namespaces
-
-- The namespace should start with the same as the unit having specs for it.
-- Do not include `.Specs` in the namespace.
-
 ## Reusable Context
 
 - Context can be encapsulated into reusable contexts that can be leveraged between specs.
 - Create a `given` folder within the unit folder (e.g., `for_<Unit>/given/`)
-- Add reusable context classes with descriptive names starting with `a_` or `an_` (e.g., `a_events_command_response_value_handler.cs`)
-- Namespace should include `given` in the name (e.g., `Infrastructure.ReadModels.for_EventsCommandResponseValueHandler.given`)
-- Members that are to be reused should be `protected`
-- Members are initialized using the `Establish` method, same as regular specs
-- Specs inherit from the context by doing `given.a_specific_context`, example: `public class when_performing_a_behavior : given.a_specific_context`
-- Remember the inheritance rule: `Specification` must be in the inheritance chain at the root
-- Shared variables should be `protected` fields, not properties and they should follow the `_camelCase` naming convention
+- Add reusable context classes with descriptive names starting with `a_` or `an_` (e.g., `a_events_command_response_value_handler`)
+
 - **For behaviors with multiple outcomes:**
   - The reusable context should be in the unit's `given/` folder (e.g., `for_<Unit>/given/`)
   - All test files within behavior folders (e.g., `when_<behavior>/`) inherit from this shared context
   - This allows consistent setup across all variations of the behavior
 - If a specific behavior needs additional setup, create behavior-specific contexts in `when_<behavior>/given/` folder
-
-## Async
-
-- Any of the methods (`Establish`, `Because`, `Cleanup`) can be async if needed.
-
-## Substitutes
-
-- Concrete classes can be substituted/mocked, not just interfaces or abstract classes.
-- When substituting concrete classes, ensure they have virtual methods or properties to allow mocking behavior.
-- Pass constructor parameters as needed when substituting concrete classes. For example, `Substitute.For<ConcreteClass>(param1, param2)`.
-
-## Test Utilities
-
-- Use `Substitute.For<T>()` for mocks.
-- Cratis Specifications has a set of assertion extension methods, use these
-  - `.ShouldEqual()`
-  - `.ShouldBeTrue()`
-  - `.ShouldBeFalse()`
-  - `.ShouldBeNull()`
-  - `.ShouldNotBeNull()`
-  - `.ShouldBeOfExactType<T>()`
-  - `.ShouldContain()`
-  - `.ShouldContainOnly()`
-  - `.ShouldNotContain()`
-  - `.ShouldBeEmpty()`
-  - `.ShouldNotBeEmpty()`
-  - `.ShouldBeInRange()`
-  - `.ShouldNotBeInRange()`
-  - `.ShouldBeGreaterThan()`
-  - `.ShouldBeGreaterThanOrEqual()`
-  - `.ShouldBeLessThan()`
-  - `.ShouldBeLessThanOrEqual()`
-- Use custom helpers from `XUnit.Integration` for integration/event-based assertions.
-
-## Using statements
-
-- Common usings are provided in `GlobalUsings.Specs.cs` (e.g., `using Xunit;`, `using NSubstitute;`), don't add any using statements already in this file.
-- Don't add using statement for namespace of the system under test.
 
 ## Formatting
 
@@ -211,34 +87,8 @@ public class with_valid_events_collection : given.an_events_command_response_val
 
 **NEVER write specs for simple properties or getters** - Properties are not behaviors and should not be tested unless they contain complex business logic.
 
-**Do NOT create specs for:**
-- Simple auto-properties (e.g., `public string Name { get; set; }`)
-- Properties that return constructor parameters (e.g., `public string TableName => tableName;`)
-- Properties that return field values (e.g., `public Key Key => key;`)
-- Properties that delegate to other objects without transformation (e.g., `public IEnumerable<Property> Properties => mapper.Properties;`)
-- Expression-bodied properties that return simple values (e.g., `public Type PropertyName => someValue;`)
-- Properties that perform simple null checks or basic validation without complex logic
-- Getters that return injected dependencies or configuration values
-
-**Examples of properties to IGNORE:**
-```csharp
-// ❌ Do NOT write specs for these
-public string TableName => tableName;                    // Returns constructor parameter
-public Key Key => key;                                   // Returns constructor parameter
-public IEnumerable<Property> Properties => mapper.Properties; // Simple delegation
-public bool IsValid => _value is not null;              // Simple validation
-public ILogger Logger { get; }                          // Injected dependency
-```
-
-**Only write specs for properties with complex business logic:**
-```csharp
-// ✅ These might need specs if they contain complex logic
-public decimal TotalCost => Items.Sum(i => i.Cost * i.Quantity * (1 + i.TaxRate));
-public bool CanProcess => ValidateComplexBusinessRules() && CheckExternalConditions();
-```
-
 **Avoid file names starting with:**
-- `when_getting_*` (e.g., `when_getting_key.cs`, `when_getting_properties.cs`)
+- `when_getting_*` (e.g., `when_getting_key.*`, `when_getting_properties.*`)
 - `when_returning_*` for simple return values
 - Any spec that just verifies a property returns what was passed in the constructor
 

--- a/.github/instructions/specs.typescript.instructions.md
+++ b/.github/instructions/specs.typescript.instructions.md
@@ -1,0 +1,131 @@
+---
+applyTo: "**/for_*/**/*.ts, **/when_*/**/*.ts"
+---
+
+# 🧪 How to Write TypeScript Specs
+
+Use the base instructions for writing specs can be found in [Specs Instructions](./specs.instructions.md) and
+then adapt with the C# specific conventions below.
+
+## Test Frameworks & Conventions
+
+- **Frameworks:**
+  - Uses [Mocha](https://mochajs.org) as test framework and execution.
+  - Uses [SinonJS](https://sinonjs.org) for mocking.
+  - Uses [Chai](https://www.chaijs.com) for assertions.
+  - Tests are found in alongside the code being tested in folders starting with either `for_`, `when_` or `given_` (for reusable contexts).
+
+- **File/Folder Structure:**
+  - Organize tests by feature/domain, e.g. `Events/Constraints/for_UniqueConstraintProvider/when_providing.ts`.
+  - Use descriptive folder and file names:
+    - `for_<TypeUnderTest>/` for the unit under test
+    - `when_<behavior>/` for behaviors with multiple outcomes
+    - `when_<behavior>.ts` for simple behaviors with single outcomes
+    - Example: `for_UnitOfWork/when_committing/and_it_has_events_and_append_returns_constraints_and_errors.ts`
+
+## Test Class Pattern
+
+- Use BDD-style methods:
+  - `void Establish()` for setup.
+  - `void Because()` for the action under test.
+  - `[Fact] void should_<expected_behavior>()` for assertions.
+  - Keep them focused on a single behavior or aspect.
+
+**Example:**
+
+```typescript
+describe("when_adding", () => {
+    let events: EventsToAppend;
+    let event: string;
+
+    beforeEach(() => {
+        events = [];
+        event = "Forty Two";
+    
+        events.Add(event);
+    });
+
+    it("should_hold_the_added_event", () => {
+        events[0].should.equal(event);
+    });
+});
+```
+
+**Example with multiple outcomes:**
+
+```
+for_EventsCommandResponseValueHandler/
+├── given/
+│   └── an_events_command_response_value_handler.ts
+├── when_checking_can_handle/
+│   ├── with_valid_events_collection.ts
+│   ├── with_null_value.ts
+│   └── without_event_source_id.ts
+└── when_handling/
+    ├── empty_events_collection.ts
+    ├── single_event_collection.ts
+    └── multiple_events_collection.ts
+```
+
+Each test uses the `given` function that takes the type of the context to use:
+
+```typescript
+describe("with_valid_events_collection", given(an_events_command_response_value_handler, context => {
+    let events: object[];
+    let result: boolean;
+
+    beforeEach(() => {
+        events = [new TestEvent("Test"), new AnotherTestEvent(42)];
+    
+        result = context.handler.CanHandle(context.commandContext, events);
+    });
+
+    it("should_return_true", () => {
+        result.should.be.true;
+    });
+}));
+```
+
+The context would be defined as follows:
+
+```typescript
+export class an_events_command_response_value_handler {
+    protected handler: EventsCommandResponseValueHandler;
+    protected commandContext: CommandContext;
+
+    constructor() {
+        this.commandContext = /* setup command context */;
+        this.handler = new EventsCommandResponseValueHandler(/* dependencies */);
+    }
+}
+```
+
+## Reusable Context
+
+- Context can be encapsulated into reusable contexts that can be leveraged between specs.
+- Create a `given` folder within the unit folder (e.g., `for_<Unit>/given/`)
+- Add reusable context classes with descriptive names starting with `a_` or `an_` (e.g., `a_events_command_response_value_handler.cs`)
+
+## Async
+
+- Any of the methods (`Establish`, `Because`, `Cleanup`) can be async if needed.
+
+## Substitutes
+
+- Use sinon for creating substitutes/mocks.
+- Pass constructor parameters as needed when substituting concrete classes. For example, `sinon.createStubInstance(ConcreteClass, { param1, param2 })`.
+
+## Test Utilities
+
+- Use the fluent interface from Chai for assertions, examples:
+    - <value>.should.equal(<expected>);
+    - <value>.should.be.true;
+    - <value>.should.be.false;
+    - <value>.should.be.null;
+    - <value>.should.not.be.null;
+    - <value>.should.deep.equal(<expected>);
+    - <value>.should.be.instanceOf(<Type>);
+    - <value>.should.contain(<item>);
+    - <value>.should.containOnly(<items>);
+    - <value>.should.have.lengthOf(<number>);
+    - <function>.should.throw(<ErrorType>);

--- a/.github/instructions/specs.typescript.instructions.md
+++ b/.github/instructions/specs.typescript.instructions.md
@@ -70,9 +70,13 @@ for_EventsCommandResponseValueHandler/
     └── multiple_events_collection.ts
 ```
 
-Each test uses the `given` function that takes the type of the context to use:
+Each test uses the `given` function that takes the type of the context to use. **IMPORTANT**: Import the `given` function from the root of the package (e.g., `import { given } from '../../../given';` when in a `when_behavior/` folder):
 
 ```typescript
+import { an_events_command_response_value_handler } from '../given/an_events_command_response_value_handler';
+import { given } from '../../../given'; // Import the given function from the package root
+import { expect } from 'chai';
+
 describe("with_valid_events_collection", given(an_events_command_response_value_handler, context => {
     let events: object[];
     let result: boolean;
@@ -84,7 +88,7 @@ describe("with_valid_events_collection", given(an_events_command_response_value_
     });
 
     it("should_return_true", () => {
-        result.should.be.true;
+        expect(result).to.be.true;
     });
 }));
 ```
@@ -93,8 +97,8 @@ The context would be defined as follows:
 
 ```typescript
 export class an_events_command_response_value_handler {
-    protected handler: EventsCommandResponseValueHandler;
-    protected commandContext: CommandContext;
+    handler: EventsCommandResponseValueHandler; // Public for access in tests
+    commandContext: CommandContext; // Public for access in tests
 
     constructor() {
         this.commandContext = /* setup command context */;
@@ -107,11 +111,15 @@ export class an_events_command_response_value_handler {
 
 - Context can be encapsulated into reusable contexts that can be leveraged between specs.
 - Create a `given` folder within the unit folder (e.g., `for_<Unit>/given/`)
-- Add reusable context classes with descriptive names starting with `a_` or `an_` (e.g., `a_events_command_response_value_handler.cs`)
+- Add reusable context classes with descriptive names starting with `a_` or `an_` (e.g., `an_events_command_response_value_handler.ts`)
+- **IMPORTANT**: Import the `given` function from the package root: `import { given } from '../../given';` (adjust path as needed)
+- Make context properties public (not protected) so tests can access them via `context.propertyName`
+- Use the `given` function for tests that benefit from shared setup and state
+- Simple tests without complex setup don't need to use the reusable context
 
 ## Async
 
-- Any of the methods (`Establish`, `Because`, `Cleanup`) can be async if needed.
+- Any of the methods (`beforeEach`, `afterEach`) can be async if needed.
 
 ## Substitutes
 
@@ -120,15 +128,14 @@ export class an_events_command_response_value_handler {
 
 ## Test Utilities
 
-- Use the fluent interface from Chai for assertions, examples:
-    - <value>.should.equal(<expected>);
-    - <value>.should.be.true;
-    - <value>.should.be.false;
-    - <value>.should.be.null;
-    - <value>.should.not.be.null;
-    - <value>.should.deep.equal(<expected>);
-    - <value>.should.be.instanceOf(<Type>);
-    - <value>.should.contain(<item>);
-    - <value>.should.containOnly(<items>);
-    - <value>.should.have.lengthOf(<number>);
-    - <function>.should.throw(<ErrorType>);
+- Use the `expect` interface from Chai for better TypeScript support:
+    - `expect(value).to.equal(expected);`
+    - `expect(value).to.be.true;`
+    - `expect(value).to.be.false;`
+    - `expect(value).to.be.null;`
+    - `expect(value).to.not.be.null;`
+    - `expect(value).to.deep.equal(expected);`
+    - `expect(value).to.be.instanceOf(Type);`
+    - `expect(array).to.contain(item);`
+    - `expect(array).to.have.lengthOf(number);`
+    - `expect(function).to.throw(ErrorType);`

--- a/.github/instructions/specs.typescript.instructions.md
+++ b/.github/instructions/specs.typescript.instructions.md
@@ -13,6 +13,9 @@ then adapt with the C# specific conventions below.
   - Uses [Mocha](https://mochajs.org) as test framework and execution.
   - Uses [SinonJS](https://sinonjs.org) for mocking.
   - Uses [Chai](https://www.chaijs.com) for assertions.
+  - Uses Vitest for running tests. See [Vitest Documentation](https://vitest.dev/).
+  - Uses yarn as package manager.
+  - Tests can be run using `yarn test` from every package.
   - Tests are found in alongside the code being tested in folders starting with either `for_`, `when_` or `given_` (for reusable contexts).
 
 - **File/Folder Structure:**

--- a/Documentation/frontend/react/application-model.md
+++ b/Documentation/frontend/react/application-model.md
@@ -25,6 +25,7 @@ It has a set of configuration options you can pass it:
 | ------ | ---- | ------- |
 | microservice | String | Name of the microservice, which will add necessary HTTP headers on Commands and Queries |
 | development | Boolean | Whether or not we're running in development, defaults to false |
+| origin | String | Url for where the APIs are located, defaults to empty string and makes them relative to the documents location |
 | basePath | String | Base path for the application |
 | apiBasePath | String | Base for prepended to the Command and Query requests |
 

--- a/Source/JavaScript/Applications.React.MVVM/withViewModel.tsx
+++ b/Source/JavaScript/Applications.React.MVVM/withViewModel.tsx
@@ -124,6 +124,7 @@ export function withViewModel<TViewModel extends object, TProps extends object =
                     const query = instance as ICanBeConfigured;
                     query.setMicroservice(applicationContext.microservice);
                     query.setApiBasePath(applicationContext.apiBasePath ?? '');
+                    query.setOrigin(applicationContext.origin ?? '');
                 }
 
                 return instance;

--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -10,6 +10,7 @@ export interface ApplicationModelProps {
     children?: JSX.Element | JSX.Element[];
     microservice?: string;
     development?: boolean;
+    origin?: string;
     basePath?: string;
     apiBasePath?: string;
 }
@@ -18,6 +19,7 @@ export const ApplicationModel = (props: ApplicationModelProps) => {
     const configuration: ApplicationModelConfiguration = {
         microservice: props.microservice ?? '',
         development: props.development ?? false,
+        origin: props.origin ?? '',
         basePath: props.basePath ?? '',
         apiBasePath: props.apiBasePath ?? ''
     };

--- a/Source/JavaScript/Applications.React/ApplicationModel.tsx
+++ b/Source/JavaScript/Applications.React/ApplicationModel.tsx
@@ -24,7 +24,7 @@ export const ApplicationModel = (props: ApplicationModelProps) => {
         apiBasePath: props.apiBasePath ?? ''
     };
 
-    Bindings.initialize(configuration.microservice, configuration.apiBasePath);
+    Bindings.initialize(configuration.microservice, configuration.apiBasePath, configuration.origin);
 
     return (
         <ApplicationModelContext.Provider value={configuration}>

--- a/Source/JavaScript/Applications.React/ApplicationModelContext.ts
+++ b/Source/JavaScript/Applications.React/ApplicationModelContext.ts
@@ -7,6 +7,7 @@ import React from 'react';
 export interface ApplicationModelConfiguration {
     microservice: string;
     development?: boolean
+    origin?: string;
     basePath?: string;
     apiBasePath?: string;
 }
@@ -14,6 +15,7 @@ export interface ApplicationModelConfiguration {
 export const ApplicationModelContext = React.createContext<ApplicationModelConfiguration>({
     microservice: Globals.microservice,
     development: false,
+    origin: '',
     basePath: '',
     apiBasePath: ''
 });

--- a/Source/JavaScript/Applications.React/Bindings.ts
+++ b/Source/JavaScript/Applications.React/Bindings.ts
@@ -7,8 +7,8 @@ import { Constructor } from '@cratis/fundamentals';
 import { WellKnownBindings } from './WellKnownBindings';
 
 export class Bindings {
-    static initialize(microservice: string, apiBasePath?: string) {
+    static initialize(microservice: string, apiBasePath?: string, origin?: string): void {
         container.registerSingleton(WellKnownBindings.microservice, microservice);
-        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath ?? '') });
+        container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath ?? '', origin ?? '') });
     }
 }

--- a/Source/JavaScript/Applications.React/commands/useCommand.ts
+++ b/Source/JavaScript/Applications.React/commands/useCommand.ts
@@ -32,6 +32,7 @@ export function useCommand<TCommand extends Command, TCommandContent>(commandTyp
         const instance = new commandType();
         instance.setMicroservice(applicationModel.microservice);
         instance.setApiBasePath(applicationModel.apiBasePath ?? '');
+        instance.setOrigin(applicationModel.origin ?? '');
         if (initialValues) {
             instance.setInitialValues(initialValues);
         }

--- a/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useObservableQuery.ts
@@ -22,6 +22,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         instance.sorting = currentSorting;
         instance.setMicroservice(applicationModel.microservice);
         instance.setApiBasePath(applicationModel.apiBasePath ?? '');
+        instance.setOrigin(applicationModel.origin ?? '');
         return instance;
     }, [currentPaging, currentSorting]);
 

--- a/Source/JavaScript/Applications.React/queries/useQuery.ts
+++ b/Source/JavaScript/Applications.React/queries/useQuery.ts
@@ -30,6 +30,7 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
         instance.sorting = sorting;
         instance.setMicroservice(applicationModel.microservice);
         instance.setApiBasePath(applicationModel.apiBasePath ?? '');
+        instance.setOrigin(applicationModel.origin ?? '');
         return instance;
     }, []);
 

--- a/Source/JavaScript/Applications/ICanBeConfigured.ts
+++ b/Source/JavaScript/Applications/ICanBeConfigured.ts
@@ -16,4 +16,10 @@ export interface ICanBeConfigured {
      * @param apiBasePath Base path for the API
      */
     setApiBasePath(apiBasePath: string): void;
+
+    /**
+     * Set the origin to be used for the query. This is used to set the origin (scheme + host + port) for API calls.
+     * @param origin The origin to use.
+     */
+    setOrigin(origin: string): void;
 }

--- a/Source/JavaScript/Applications/UrlHelpers.ts
+++ b/Source/JavaScript/Applications/UrlHelpers.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Url } from 'url';
+
+export class UrlHelpers {
+    /**
+     * Creates a URL from the given origin, API base path, and route.
+     * @param origin The origin of the request. If not provided, it defaults to the current document's origin.
+     * @param apiBasePath The base path for the API.
+     * @param route The specific route for the request.
+     * @returns The constructed URL.
+    */
+    static createUrlFrom(origin: string, apiBasePath: string, route: string): URL {
+        if (!origin || origin.length === 0) {
+            origin = document?.location?.origin ?? '';
+        }
+
+        return new URL(route, `${origin}${apiBasePath}`);
+    }
+}

--- a/Source/JavaScript/Applications/UrlHelpers.ts
+++ b/Source/JavaScript/Applications/UrlHelpers.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Url } from 'url';
-
 export class UrlHelpers {
     /**
      * Creates a URL from the given origin, API base path, and route.

--- a/Source/JavaScript/Applications/commands/Command.ts
+++ b/Source/JavaScript/Applications/commands/Command.ts
@@ -7,7 +7,7 @@ import { CommandValidator } from './CommandValidator';
 import { Constructor, JsonSerializer } from '@cratis/fundamentals';
 import { Globals } from '../Globals';
 import { joinPaths } from '../joinPaths';
-import { UrlHelpers } from 'UrlHelpers';
+import { UrlHelpers } from '../UrlHelpers';
 
 type Callback = {
     callback: WeakRef<PropertyChanged>;

--- a/Source/JavaScript/Applications/commands/Command.ts
+++ b/Source/JavaScript/Applications/commands/Command.ts
@@ -39,6 +39,7 @@ export abstract class Command<TCommandContent = object, TCommandResponse = objec
     constructor(readonly _responseType: Constructor = Object, readonly _isResponseTypeEnumerable: boolean) {
         this._microservice = Globals.microservice ?? '';
         this._apiBasePath = '';
+        this._origin = '';
     }
 
     /** @inheritdoc */

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_base_path_ending_with_slash.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_base_path_ending_with_slash.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("with_base_path_ending_with_slash", () => {
+    let origin: string;
+    let apiBasePath: string;
+    let route: string;
+    let result: URL;
+
+    beforeEach(() => {
+        origin = 'https://example.com';
+        apiBasePath = '/api/v1/'; // base path ending with slash
+        route = 'users/123'; // relative route
+    
+        result = UrlHelpers.createUrlFrom(origin, apiBasePath, route);
+    });
+
+    it("should_create_correct_url", () => {
+        expect(result.href).to.equal('https://example.com/api/v1/users/123');
+    });
+
+    it("should_have_correct_origin", () => {
+        expect(result.origin).to.equal('https://example.com');
+    });
+
+    it("should_have_correct_pathname", () => {
+        expect(result.pathname).to.equal('/api/v1/users/123');
+    });
+});

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_empty_origin.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_empty_origin.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("with_empty_origin", () => {
+    let origin: string;
+    let apiBasePath: string;
+    let route: string;
+    let result: URL;
+    let originalDocument: Document | undefined;
+
+    beforeEach(() => {
+        // Mock document.location.origin
+        originalDocument = global.document;
+        global.document = {
+            location: {
+                origin: 'https://mocked-origin.com'
+            }
+        } as unknown as Document;
+
+        origin = '';
+        apiBasePath = '/api/v1';
+        route = '/users/123';
+    
+        result = UrlHelpers.createUrlFrom(origin, apiBasePath, route);
+    });
+
+    afterEach(() => {
+        if (originalDocument) {
+            global.document = originalDocument;
+        } else {
+            delete (global as { document?: Document }).document;
+        }
+    });
+
+    it("should_use_document_location_origin", () => {
+        expect(result.origin).to.equal('https://mocked-origin.com');
+    });
+
+    it("should_create_correct_url_with_document_origin", () => {
+        expect(result.href).to.equal('https://mocked-origin.com/users/123');
+    });
+});

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_null_or_undefined_origin.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_null_or_undefined_origin.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("with_null_or_undefined_origin", () => {
+    let apiBasePath: string;
+    let route: string;
+    let result: URL;
+    let originalDocument: Document | undefined;
+
+    beforeEach(() => {
+        // Mock document.location.origin
+        originalDocument = global.document;
+        global.document = {
+            location: {
+                origin: 'https://fallback-origin.com'
+            }
+        } as unknown as Document;
+
+        apiBasePath = '/api/v1';
+        route = '/users/123';
+    });
+
+    afterEach(() => {
+        if (originalDocument) {
+            global.document = originalDocument;
+        } else {
+            delete (global as { document?: Document }).document;
+        }
+    });
+
+    it("should_use_document_location_origin_when_null", () => {
+        result = UrlHelpers.createUrlFrom(null as unknown as string, apiBasePath, route);
+        expect(result.origin).to.equal('https://fallback-origin.com');
+    });
+
+    it("should_use_document_location_origin_when_undefined", () => {
+        result = UrlHelpers.createUrlFrom(undefined as unknown as string, apiBasePath, route);
+        expect(result.origin).to.equal('https://fallback-origin.com');
+    });
+
+    it("should_create_correct_url_with_document_origin_when_null", () => {
+        result = UrlHelpers.createUrlFrom(null as unknown as string, apiBasePath, route);
+        expect(result.href).to.equal('https://fallback-origin.com/users/123');
+    });
+
+    it("should_create_correct_url_with_document_origin_when_undefined", () => {
+        result = UrlHelpers.createUrlFrom(undefined as unknown as string, apiBasePath, route);
+        expect(result.href).to.equal('https://fallback-origin.com/users/123');
+    });
+});

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_relative_route.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_relative_route.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("with_relative_route", () => {
+    let origin: string;
+    let apiBasePath: string;
+    let route: string;
+    let result: URL;
+
+    beforeEach(() => {
+        origin = 'https://example.com';
+        apiBasePath = '/api/v1';
+        route = 'users/123'; // relative route without leading slash
+    
+        result = UrlHelpers.createUrlFrom(origin, apiBasePath, route);
+    });
+
+    it("should_create_correct_url_with_relative_route", () => {
+        expect(result.href).to.equal('https://example.com/api/users/123');
+    });
+
+    it("should_have_correct_origin", () => {
+        expect(result.origin).to.equal('https://example.com');
+    });
+
+    it("should_have_correct_pathname", () => {
+        expect(result.pathname).to.equal('/api/users/123');
+    });
+});

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_valid_parameters.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/with_valid_parameters.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("with_valid_parameters", () => {
+    let origin: string;
+    let apiBasePath: string;
+    let route: string;
+    let result: URL;
+
+    beforeEach(() => {
+        origin = 'https://example.com';
+        apiBasePath = '/api/v1';
+        route = '/users/123';
+    
+        result = UrlHelpers.createUrlFrom(origin, apiBasePath, route);
+    });
+
+    it("should_create_correct_url", () => {
+        expect(result.href).to.equal('https://example.com/users/123');
+    });
+
+    it("should_have_correct_origin", () => {
+        expect(result.origin).to.equal('https://example.com');
+    });
+
+    it("should_have_correct_pathname", () => {
+        expect(result.pathname).to.equal('/users/123');
+    });
+});

--- a/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/without_document_object.ts
+++ b/Source/JavaScript/Applications/for_UrlHelpers/when_creating_url_from/without_document_object.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { UrlHelpers } from '../../UrlHelpers';
+import { expect } from 'chai';
+
+describe("without_document_object", () => {
+    let origin: string;
+    let apiBasePath: string;
+    let route: string;
+    let originalDocument: Document | undefined;
+
+    beforeEach(() => {
+        // Mock document to be undefined
+        originalDocument = global.document;
+        (global as { document?: Document }).document = undefined;
+
+        origin = '';
+        apiBasePath = '/api/v1';
+        route = '/users/123';
+    });
+
+    afterEach(() => {
+        if (originalDocument) {
+            global.document = originalDocument;
+        } else {
+            delete (global as { document?: Document }).document;
+        }
+    });
+
+    it("should_throw_invalid_url_error", () => {
+        expect(() => UrlHelpers.createUrlFrom(origin, apiBasePath, route)).to.throw('Invalid URL');
+    });
+});

--- a/Source/JavaScript/Applications/given.ts
+++ b/Source/JavaScript/Applications/given.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { Suite } from 'mocha';
+
+export type ContextForSuite<TContext extends object> = (this: Suite, context: TContext) => void;
+
+export function given<TContext extends object>(contextType: Constructor<TContext>, callback: ContextForSuite<TContext>) {
+    return function (this: Suite) {
+        const context = new contextType(this);
+        callback.call(this, context);
+    };
+}

--- a/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Url } from 'url';
 import { Globals } from '../Globals';
 import { IObservableQueryConnection } from './IObservableQueryConnection';
 import { QueryResult } from './QueryResult';

--- a/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryConnection.ts
@@ -31,7 +31,7 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
 
     /** @inheritdoc */
     connect(dataReceived: DataReceived<TDataType>, queryArguments?: object) {
-        const secure = document.location.protocol.indexOf('https') === 0;
+        const secure = document?.location?.protocol?.indexOf('https') === 0;
         let url = `${secure ? 'wss' : 'ws'}://${document.location.host}${this._route}`;
         if (this._microservice?.length > 0) {
             url = `${url}?${Globals.microserviceWSQueryArgument}=${this._microservice}`;

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -16,7 +16,7 @@ import { Paging } from './Paging';
 import { SortDirection } from './SortDirection';
 import { Globals } from '../Globals';
 import { joinPaths } from '../joinPaths';
-import { UrlHelpers } from 'UrlHelpers';
+import { UrlHelpers } from '../UrlHelpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -16,7 +16,6 @@ import { Paging } from './Paging';
 import { SortDirection } from './SortDirection';
 import { Globals } from '../Globals';
 import { joinPaths } from '../joinPaths';
-import { URL } from 'url';
 import { UrlHelpers } from 'UrlHelpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -16,6 +16,8 @@ import { Paging } from './Paging';
 import { SortDirection } from './SortDirection';
 import { Globals } from '../Globals';
 import { joinPaths } from '../joinPaths';
+import { URL } from 'url';
+import { UrlHelpers } from 'UrlHelpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -26,6 +28,7 @@ import { joinPaths } from '../joinPaths';
 export abstract class ObservableQueryFor<TDataType, TParameters = object> implements IObservableQueryFor<TDataType, TParameters> {
     private _microservice: string;
     private _apiBasePath: string;
+    private _origin: string;
     private _connection?: IObservableQueryConnection<TDataType>;
 
     abstract readonly route: string;
@@ -45,6 +48,7 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
         this.paging = Paging.noPaging;
         this._microservice = Globals.microservice ?? '';
         this._apiBasePath = '';
+        this._origin = '';
     }
 
     /**
@@ -62,6 +66,11 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
     /** @inheritdoc */
     setApiBasePath(apiBasePath: string): void {
         this._apiBasePath = apiBasePath;
+    }
+
+    /** @inheritdoc */
+    setOrigin(origin: string): void {
+        this._origin = origin;
     }
 
     /** @inheritdoc */
@@ -83,12 +92,14 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
             connectionQueryArguments.sortDirection = (this.sorting.direction === SortDirection.descending) ? 'desc' : 'asc';
         }
 
+        
         if (!ValidateRequestArguments(this.constructor.name, this.requiredRequestParameters, args as object)) {
             this._connection = new NullObservableQueryConnection(this.defaultValue);
         } else {
             actualRoute = this.routeTemplate(args);
             actualRoute = joinPaths(this._apiBasePath, actualRoute);
-            this._connection = new ObservableQueryConnection<TDataType>(actualRoute, this._microservice);
+            const url = UrlHelpers.createUrlFrom(this._origin, this._apiBasePath, actualRoute);
+            this._connection = new ObservableQueryConnection<TDataType>(url, this._microservice);
         }
 
         const subscriber = new ObservableQuerySubscription(this._connection);

--- a/Source/JavaScript/Applications/queries/QueryFor.ts
+++ b/Source/JavaScript/Applications/queries/QueryFor.ts
@@ -11,7 +11,7 @@ import { Globals } from '../Globals';
 import { Sorting } from './Sorting';
 import { SortDirection } from './SortDirection';
 import { joinPaths } from '../joinPaths';
-import { UrlHelpers } from 'UrlHelpers';
+import { UrlHelpers } from '../UrlHelpers';
 
 /**
  * Represents an implementation of {@link IQueryFor}.

--- a/Source/JavaScript/Applications/queries/QueryProvider.ts
+++ b/Source/JavaScript/Applications/queries/QueryProvider.ts
@@ -22,6 +22,7 @@ export class QueryProvider implements IQueryProvider {
         const query = new queryType();
         query.setMicroservice(this._microservice);
         query.setApiBasePath(this._apiBasePath);
+        query.setOrigin(this._origin);
         return query;
     }
 }

--- a/Source/JavaScript/Applications/queries/QueryProvider.ts
+++ b/Source/JavaScript/Applications/queries/QueryProvider.ts
@@ -14,8 +14,12 @@ export class QueryProvider implements IQueryProvider {
      * Initializes a new instance of {@link QueryProvider}
      * @param _microservice Name of the microservice to provide queries for.
      * @param _apiBasePath Base path for the API to use for the query.
+     * @param _origin Origin to use for the query.
      */
-    constructor(private readonly _microservice: string, private readonly _apiBasePath: string) { }
+    constructor(
+        private readonly _microservice: string,
+        private readonly _apiBasePath: string,
+        private readonly _origin: string) { }
 
     /** @inheritdoc */
     get<T extends IQuery>(queryType: Constructor<T>): T {

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/TestQueries.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/TestQueries.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import Handlebars from 'handlebars';
+import { ObservableQueryFor } from '../../ObservableQueryFor';
+import { Constructor } from '@cratis/fundamentals';
+
+export class TestObservableQuery extends ObservableQueryFor<string, { id: string }> {
+    readonly route = '/api/test/{id}';
+    readonly routeTemplate = Handlebars.compile('/api/test/{{{id}}}');
+    readonly defaultValue = '';
+
+    get requiredRequestParameters(): string[] {
+        return ['id'];
+    }
+
+    constructor() {
+        super(String as Constructor, false);
+    }
+}
+
+export class TestEnumerableQuery extends ObservableQueryFor<string[], { category: string }> {
+    readonly route = '/api/items/{category}';
+    readonly routeTemplate = Handlebars.compile('/api/items/{{{category}}}');
+    readonly defaultValue: string[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return ['category'];
+    }
+
+    constructor() {
+        super(String as Constructor, true);
+    }
+}

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery, TestEnumerableQuery } from './TestQueries';
+
+export class an_observable_query_for {
+    protected query: TestObservableQuery;
+    protected enumerableQuery: TestEnumerableQuery;
+
+    constructor() {
+        this.query = new TestObservableQuery();
+        this.enumerableQuery = new TestEnumerableQuery();
+    }
+}

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/given/an_observable_query_for.ts
@@ -4,8 +4,8 @@
 import { TestObservableQuery, TestEnumerableQuery } from './TestQueries';
 
 export class an_observable_query_for {
-    protected query: TestObservableQuery;
-    protected enumerableQuery: TestEnumerableQuery;
+    query: TestObservableQuery;
+    enumerableQuery: TestEnumerableQuery;
 
     constructor() {
         this.query = new TestObservableQuery();

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from './given/TestQueries';
+import { Sorting } from '../Sorting';
+import { Paging } from '../Paging';
+import { Globals } from '../../Globals';
+import { expect } from 'chai';
+
+describe('when constructing', () => {
+    let query: TestObservableQuery;
+    let originalMicroservice: string | undefined;
+
+    beforeEach(() => {
+        originalMicroservice = Globals.microservice;
+        Globals.microservice = 'test-microservice';
+        query = new TestObservableQuery();
+    });
+
+    afterEach(() => {
+        if (originalMicroservice !== undefined) {
+            Globals.microservice = originalMicroservice;
+        }
+    });
+
+    it('should set sorting to none', () => expect(query.sorting).to.equal(Sorting.none));
+    it('should set paging to no paging', () => expect(query.paging).to.equal(Paging.noPaging));
+    it('should set model type to String', () => expect(query.modelType).to.equal(String));
+    it('should set enumerable to false', () => expect(query.enumerable).to.be.false);
+    it('should have default required request parameters', () => expect(query.requiredRequestParameters).to.deep.equal(['id']));
+    it('should have default route', () => expect(query.route).to.equal('/api/test/{id}'));
+    it('should have default value as empty string', () => expect(query.defaultValue).to.equal(''));
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing.ts
@@ -1,20 +1,19 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from './given/TestQueries';
+import { an_observable_query_for } from './given/an_observable_query_for';
+import { given } from '../../given';
 import { Sorting } from '../Sorting';
 import { Paging } from '../Paging';
 import { Globals } from '../../Globals';
 import { expect } from 'chai';
 
-describe('when constructing', () => {
-    let query: TestObservableQuery;
+describe('when constructing', given(an_observable_query_for, context => {
     let originalMicroservice: string | undefined;
 
     beforeEach(() => {
         originalMicroservice = Globals.microservice;
         Globals.microservice = 'test-microservice';
-        query = new TestObservableQuery();
     });
 
     afterEach(() => {
@@ -23,11 +22,11 @@ describe('when constructing', () => {
         }
     });
 
-    it('should set sorting to none', () => expect(query.sorting).to.equal(Sorting.none));
-    it('should set paging to no paging', () => expect(query.paging).to.equal(Paging.noPaging));
-    it('should set model type to String', () => expect(query.modelType).to.equal(String));
-    it('should set enumerable to false', () => expect(query.enumerable).to.be.false);
-    it('should have default required request parameters', () => expect(query.requiredRequestParameters).to.deep.equal(['id']));
-    it('should have default route', () => expect(query.route).to.equal('/api/test/{id}'));
-    it('should have default value as empty string', () => expect(query.defaultValue).to.equal(''));
-});
+    it('should set sorting to none', () => expect(context.query.sorting).to.equal(Sorting.none));
+    it('should set paging to no paging', () => expect(context.query.paging).to.equal(Paging.noPaging));
+    it('should set model type to String', () => expect(context.query.modelType).to.equal(String));
+    it('should set enumerable to false', () => expect(context.query.enumerable).to.be.false);
+    it('should have default required request parameters', () => expect(context.query.requiredRequestParameters).to.deep.equal(['id']));
+    it('should have default route', () => expect(context.query.route).to.equal('/api/test/{id}'));
+    it('should have default value as empty string', () => expect(context.query.defaultValue).to.equal(''));
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing_enumerable.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing_enumerable.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestEnumerableQuery } from './given/TestQueries';
+import { Sorting } from '../Sorting';
+import { Paging } from '../Paging';
+import { expect } from 'chai';
+
+describe('when constructing enumerable query', () => {
+    let query: TestEnumerableQuery;
+
+    beforeEach(() => {
+        query = new TestEnumerableQuery();
+    });
+
+    it('should set sorting to none', () => expect(query.sorting).to.equal(Sorting.none));
+    it('should set paging to no paging', () => expect(query.paging).to.equal(Paging.noPaging));
+    it('should set model type to String', () => expect(query.modelType).to.equal(String));
+    it('should set enumerable to true', () => expect(query.enumerable).to.be.true);
+    it('should have default required request parameters', () => expect(query.requiredRequestParameters).to.deep.equal(['category']));
+    it('should have default route', () => expect(query.route).to.equal('/api/items/{category}'));
+    it('should have default value as empty array', () => expect(query.defaultValue).to.deep.equal([]));
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing_enumerable.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_constructing_enumerable.ts
@@ -1,23 +1,18 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestEnumerableQuery } from './given/TestQueries';
+import { an_observable_query_for } from './given/an_observable_query_for';
+import { given } from '../../given';
 import { Sorting } from '../Sorting';
 import { Paging } from '../Paging';
 import { expect } from 'chai';
 
-describe('when constructing enumerable query', () => {
-    let query: TestEnumerableQuery;
-
-    beforeEach(() => {
-        query = new TestEnumerableQuery();
-    });
-
-    it('should set sorting to none', () => expect(query.sorting).to.equal(Sorting.none));
-    it('should set paging to no paging', () => expect(query.paging).to.equal(Paging.noPaging));
-    it('should set model type to String', () => expect(query.modelType).to.equal(String));
-    it('should set enumerable to true', () => expect(query.enumerable).to.be.true);
-    it('should have default required request parameters', () => expect(query.requiredRequestParameters).to.deep.equal(['category']));
-    it('should have default route', () => expect(query.route).to.equal('/api/items/{category}'));
-    it('should have default value as empty array', () => expect(query.defaultValue).to.deep.equal([]));
-});
+describe('when constructing enumerable query', given(an_observable_query_for, context => {
+    it('should set sorting to none', () => expect(context.enumerableQuery.sorting).to.equal(Sorting.none));
+    it('should set paging to no paging', () => expect(context.enumerableQuery.paging).to.equal(Paging.noPaging));
+    it('should set model type to String', () => expect(context.enumerableQuery.modelType).to.equal(String));
+    it('should set enumerable to true', () => expect(context.enumerableQuery.enumerable).to.be.true);
+    it('should have default required request parameters', () => expect(context.enumerableQuery.requiredRequestParameters).to.deep.equal(['category']));
+    it('should have default route', () => expect(context.enumerableQuery.route).to.equal('/api/items/{category}'));
+    it('should have default value as empty array', () => expect(context.enumerableQuery.defaultValue).to.deep.equal([]));
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_disposing.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_disposing.ts
@@ -1,29 +1,28 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from './given/TestQueries';
+import { an_observable_query_for } from './given/an_observable_query_for';
+import { given } from '../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-describe('when disposing', () => {
-    let query: TestObservableQuery;
+describe('when disposing', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
 
     beforeEach(() => {
-        query = new TestObservableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.query.setOrigin('https://example.com'); // Set origin to avoid document access
         callback = sinon.stub();
         
         // Create a subscription first
-        query.subscribe(callback, { id: 'test-id' });
+        context.query.subscribe(callback, { id: 'test-id' });
     });
 
     it('should not throw when disposing', () => {
-        expect(() => query.dispose()).to.not.throw();
+        expect(() => context.query.dispose()).to.not.throw();
     });
 
     it('should be safe to dispose multiple times', () => {
-        query.dispose();
-        expect(() => query.dispose()).to.not.throw();
+        context.query.dispose();
+        expect(() => context.query.dispose()).to.not.throw();
     });
-});
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_disposing.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_disposing.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from './given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+describe('when disposing', () => {
+    let query: TestObservableQuery;
+    let callback: sinon.SinonStub;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        callback = sinon.stub();
+        
+        // Create a subscription first
+        query.subscribe(callback, { id: 'test-id' });
+    });
+
+    it('should not throw when disposing', () => {
+        expect(() => query.dispose()).to.not.throw();
+    });
+
+    it('should be safe to dispose multiple times', () => {
+        query.dispose();
+        expect(() => query.dispose()).to.not.throw();
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_api_base_path.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_api_base_path.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from './given/TestQueries';
+import { expect } from 'chai';
+
+describe('when setting api base path', () => {
+    let query: TestObservableQuery;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+    });
+
+    it('should not throw when setting api base path', () => {
+        expect(() => query.setApiBasePath('/api/v1')).to.not.throw();
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_microservice.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_microservice.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from './given/TestQueries';
+import { expect } from 'chai';
+
+describe('when setting microservice', () => {
+    let query: TestObservableQuery;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+    });
+
+    it('should not throw when setting microservice', () => {
+        expect(() => query.setMicroservice('new-microservice')).to.not.throw();
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_origin.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_setting_origin.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from './given/TestQueries';
+import { expect } from 'chai';
+
+describe('when setting origin', () => {
+    let query: TestObservableQuery;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+    });
+
+    it('should not throw when setting origin', () => {
+        expect(() => query.setOrigin('https://example.com')).to.not.throw();
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_enumerable_query.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_enumerable_query.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestEnumerableQuery } from '../given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+
+describe('with enumerable query', () => {
+    let query: TestEnumerableQuery;
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string[]>;
+
+    beforeEach(() => {
+        query = new TestEnumerableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        callback = sinon.stub();
+        
+        subscription = query.subscribe(callback, { category: 'test-category' });
+    });
+
+    afterEach(() => {
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('should return a subscription', () => {
+        expect(subscription).to.not.be.undefined;
+    });
+
+    it('should not call callback immediately', () => {
+        expect(callback.called).to.be.false;
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_enumerable_query.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_enumerable_query.ts
@@ -1,22 +1,21 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestEnumerableQuery } from '../given/TestQueries';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
 
-describe('with enumerable query', () => {
-    let query: TestEnumerableQuery;
+describe('with enumerable query', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
     let subscription: ObservableQuerySubscription<string[]>;
 
     beforeEach(() => {
-        query = new TestEnumerableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.enumerableQuery.setOrigin('https://example.com'); // Set origin to avoid document access
         callback = sinon.stub();
         
-        subscription = query.subscribe(callback, { category: 'test-category' });
+        subscription = context.enumerableQuery.subscribe(callback, { category: 'test-category' });
     });
 
     afterEach(() => {
@@ -32,4 +31,4 @@ describe('with enumerable query', () => {
     it('should not call callback immediately', () => {
         expect(callback.called).to.be.false;
     });
-});
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_invalid_arguments.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_invalid_arguments.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from '../given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+
+describe('with invalid arguments', () => {
+    let query: TestObservableQuery;
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        callback = sinon.stub();
+        
+        // Subscribe with missing required arguments
+        subscription = query.subscribe(callback);
+    });
+
+    afterEach(() => {
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('should return a subscription', () => {
+        expect(subscription).to.not.be.undefined;
+    });
+
+    it('should call callback immediately with default value', () => {
+        expect(callback.called).to.be.true;
+        // The NullObservableQueryConnection returns QueryResult.empty with defaultValue
+        // but the data might be transformed, so let's check the actual structure
+        const result = callback.firstCall.args[0];
+        expect(result).to.not.be.undefined;
+        expect(result.isSuccess).to.be.true;
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_invalid_arguments.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_invalid_arguments.ts
@@ -1,23 +1,22 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from '../given/TestQueries';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
 
-describe('with invalid arguments', () => {
-    let query: TestObservableQuery;
+describe('with invalid arguments', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
     let subscription: ObservableQuerySubscription<string>;
 
     beforeEach(() => {
-        query = new TestObservableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.query.setOrigin('https://example.com'); // Set origin to avoid document access
         callback = sinon.stub();
         
         // Subscribe with missing required arguments
-        subscription = query.subscribe(callback);
+        subscription = context.query.subscribe(callback);
     });
 
     afterEach(() => {
@@ -38,4 +37,4 @@ describe('with invalid arguments', () => {
         expect(result).to.not.be.undefined;
         expect(result.isSuccess).to.be.true;
     });
-});
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_paging.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_paging.ts
@@ -1,24 +1,23 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from '../given/TestQueries';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
 import { Paging } from '../../Paging';
 
-describe('with paging', () => {
-    let query: TestObservableQuery;
+describe('with paging', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
     let subscription: ObservableQuerySubscription<string>;
 
     beforeEach(() => {
-        query = new TestObservableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
-        query.paging = new Paging(1, 10); // page 1, page size 10
+        context.query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.query.paging = new Paging(1, 10); // page 1, page size 10
         callback = sinon.stub();
         
-        subscription = query.subscribe(callback, { id: 'test-id' });
+        subscription = context.query.subscribe(callback, { id: 'test-id' });
     });
 
     afterEach(() => {
@@ -34,4 +33,4 @@ describe('with paging', () => {
     it('should not call callback immediately', () => {
         expect(callback.called).to.be.false;
     });
-});
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_paging.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_paging.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from '../given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { Paging } from '../../Paging';
+
+describe('with paging', () => {
+    let query: TestObservableQuery;
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        query.paging = new Paging(1, 10); // page 1, page size 10
+        callback = sinon.stub();
+        
+        subscription = query.subscribe(callback, { id: 'test-id' });
+    });
+
+    afterEach(() => {
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('should return a subscription', () => {
+        expect(subscription).to.not.be.undefined;
+    });
+
+    it('should not call callback immediately', () => {
+        expect(callback.called).to.be.false;
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_sorting.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_sorting.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from '../given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { Sorting } from '../../Sorting';
+import { SortDirection } from '../../SortDirection';
+
+describe('with sorting', () => {
+    let query: TestObservableQuery;
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        query.sorting = new Sorting('name', SortDirection.ascending);
+        callback = sinon.stub();
+        
+        subscription = query.subscribe(callback, { id: 'test-id' });
+    });
+
+    afterEach(() => {
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('should return a subscription', () => {
+        expect(subscription).to.not.be.undefined;
+    });
+
+    it('should not call callback immediately', () => {
+        expect(callback.called).to.be.false;
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_sorting.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_sorting.ts
@@ -1,25 +1,24 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from '../given/TestQueries';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
 import { Sorting } from '../../Sorting';
 import { SortDirection } from '../../SortDirection';
 
-describe('with sorting', () => {
-    let query: TestObservableQuery;
+describe('with sorting', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
     let subscription: ObservableQuerySubscription<string>;
 
     beforeEach(() => {
-        query = new TestObservableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
-        query.sorting = new Sorting('name', SortDirection.ascending);
+        context.query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.query.sorting = new Sorting('name', SortDirection.ascending);
         callback = sinon.stub();
         
-        subscription = query.subscribe(callback, { id: 'test-id' });
+        subscription = context.query.subscribe(callback, { id: 'test-id' });
     });
 
     afterEach(() => {
@@ -35,4 +34,4 @@ describe('with sorting', () => {
     it('should not call callback immediately', () => {
         expect(callback.called).to.be.false;
     });
-});
+}));

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_valid_arguments.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_valid_arguments.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { TestObservableQuery } from '../given/TestQueries';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+
+describe('with valid arguments', () => {
+    let query: TestObservableQuery;
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+
+    beforeEach(() => {
+        query = new TestObservableQuery();
+        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        callback = sinon.stub();
+        
+        // Subscribe with valid arguments
+        subscription = query.subscribe(callback, { id: 'test-id' });
+    });
+
+    afterEach(() => {
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+    });
+
+    it('should return a subscription', () => {
+        expect(subscription).to.not.be.undefined;
+    });
+
+    it('should not call callback immediately', () => {
+        expect(callback.called).to.be.false;
+    });
+});

--- a/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_valid_arguments.ts
+++ b/Source/JavaScript/Applications/queries/for_ObservableQueryFor/when_subscribing/with_valid_arguments.ts
@@ -1,23 +1,22 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { TestObservableQuery } from '../given/TestQueries';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
 
-describe('with valid arguments', () => {
-    let query: TestObservableQuery;
+describe('with valid arguments', given(an_observable_query_for, context => {
     let callback: sinon.SinonStub;
     let subscription: ObservableQuerySubscription<string>;
 
     beforeEach(() => {
-        query = new TestObservableQuery();
-        query.setOrigin('https://example.com'); // Set origin to avoid document access
+        context.query.setOrigin('https://example.com'); // Set origin to avoid document access
         callback = sinon.stub();
         
         // Subscribe with valid arguments
-        subscription = query.subscribe(callback, { id: 'test-id' });
+        subscription = context.query.subscribe(callback, { id: 'test-id' });
     });
 
     afterEach(() => {
@@ -33,4 +32,4 @@ describe('with valid arguments', () => {
     it('should not call callback immediately', () => {
         expect(callback.called).to.be.false;
     });
-});
+}));


### PR DESCRIPTION
### Added

- Adding a property on `<ApplicationModel/>` to configure the `origin` - which is where to find the APIs (e.g. http://localhost:5000).
- Adding functionality to Command, Query, ObservableQuery for setting the `origin` for APIs.
