### PR TITLE
Fixing handlebar template - it had requestParameter() instead of requestParameters()

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Command.hbs
@@ -60,7 +60,7 @@ export class {{Name}} extends Command<I{{Name}}> implements I{{Name}} {
     }
 {{/if}}
 
-    get requestParameter(): string[] {
+    get requestParameters(): string[] {
         return [
             {{#Parameters}}
             '{{camelcase Name}}',


### PR DESCRIPTION
### Fixed

- TypeScript generated commands now generate correctly for the `requestParamters` property.
