### PR TITLE
Fixing so that we get the Response value in the CommandResult going out

### DIFF
--- a/Source/DotNET/Applications/Commands/CommandEndpointsExtensions.cs
+++ b/Source/DotNET/Applications/Commands/CommandEndpointsExtensions.cs
@@ -64,7 +64,7 @@ public static class CommandEndpointsExtensions
                         commandResult = await commandPipeline.Execute(command);
                     }
                     response.SetResponseStatusCode(commandResult);
-                    await response.WriteAsJsonAsync(commandResult, jsonSerializerOptions, cancellationToken: context.RequestAborted);
+                    await response.WriteAsJsonAsync(commandResult, commandResult.GetType(), jsonSerializerOptions, cancellationToken: context.RequestAborted);
                 })
                 .WithTags(string.Join('.', location))
                 .WithName($"Execute{handler.CommandType.Name}")


### PR DESCRIPTION
### Fixed

- Explicitly telling the response serializer which `CommandResult` type to serialize to so that we get the `Response` property when there is a response value.
