### PR TITLE
Normalizing paths depending on target OS

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/PathHelpers.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PathHelpers.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Applications.ProxyGenerator;
+
+/// <summary>
+/// Provides helper methods for working with file paths.
+/// </summary>
+public static class PathHelpers
+{
+    /// <summary>
+    /// Normalize a path to use the correct directory separator for the current platform.
+    /// </summary>
+    /// <param name="path">Path to normalize.</param>
+    /// <returns>Normalized path.</returns>
+    public static string Normalize(string path)
+    {
+        var correctSeparator = Path.DirectorySeparatorChar;
+        var wrongSeparator = correctSeparator == '/' ? '\\' : '/';
+        path = path.Replace(wrongSeparator, correctSeparator);
+        return Path.GetFullPath(path);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Program.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Applications.ProxyGenerator;
+using static Cratis.Applications.ProxyGenerator.PathHelpers;
 
 Console.WriteLine("Cratis Proxy Generator\n");
 
@@ -11,8 +12,8 @@ if (args.Length < 2)
     Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>]");
     return 1;
 }
-var assemblyFile = Path.GetFullPath(args[0]);
-var outputPath = Path.GetFullPath(args[1]);
+var assemblyFile = Normalize(Path.GetFullPath(args[0]));
+var outputPath = Normalize(Path.GetFullPath(args[1]));
 var segmentsToSkip = args.Length > 2 ? int.Parse(args[2]) : 0;
 var skipOutputDeletion = args.Any(_ => _ == "--skip-output-deletion");
 var skipCommandNameInRoute = args.Any(_ => _ == "--skip-command-name-in-route");


### PR DESCRIPTION
### Fixed

- Fixing the ProxyGenerator to normalize paths coming in, this way it will have the correct slashes for the target operating system. This problem comes from the fact that the `.props` file is assuming **Unix** - which is fine, its easier to fix it in code rather than poluting the XML.
