### PR TITLE
Adding a trim of \ at the end for Windows for CratisProxiesOutputPath

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
@@ -12,8 +12,15 @@
     </PropertyGroup>
     
     <Target Name="CratisProxyGenerator" AfterTargets="AfterBuild"> 
+        <PropertyGroup>
+            <CratisProxiesOutputPath>
+                $([System.String]::Copy('$(CratisProxiesOutputPath)').TrimEnd('\'))
+            </CratisProxiesOutputPath>
+        </PropertyGroup>
+
         <Message Text="MSBuildProjectDirectory : $(MSBuildProjectDirectory)" Importance="high" />
         <Message Text="OutputPath : $(OutputPath)" Importance="high" />
+        <Message Text="ProxiesOutputPath : $(CratisProxiesOutputPath)" Importance="high" />
         <Message Text="AssemblyName : $(AssemblyName)" Importance="high" />
         <Message Text="ProxyGenerator base directory : $(CratisProxyGeneratorAssemblyDirectory)" Importance="high" />
         <Message Text="Full path to assembly : $(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll" Importance="high" />


### PR DESCRIPTION
### Fixed

- Fixes the `CratisProxiesOutputPath` if it has a `\` at the end for Windows. Windows will treat this as an escape character and keep the quote that sits there, making the rest of the command line arguments be in this one argument.
