### PR TITLE
Removing newlines in property

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Applications.ProxyGenerator.Build.targets
@@ -13,9 +13,7 @@
     
     <Target Name="CratisProxyGenerator" AfterTargets="AfterBuild"> 
         <PropertyGroup>
-            <CratisProxiesOutputPath>
-                $([System.String]::Copy('$(CratisProxiesOutputPath)').TrimEnd('\'))
-            </CratisProxiesOutputPath>
+            <CratisProxiesOutputPath>$([System.String]::Copy('$(CratisProxiesOutputPath)').TrimEnd('\'))</CratisProxiesOutputPath>
         </PropertyGroup>
 
         <Message Text="MSBuildProjectDirectory : $(MSBuildProjectDirectory)" Importance="high" />


### PR DESCRIPTION
### Fixed

- Removing newlines for the `CratisProxiesOutputPath` property in the ProxyGenerator Build .targets file. The newlines caused the proxy generator to fail.
