### PR TITLE
Refactor ModelBoundQueryPerformer and ModelBoundCommandHandler for ValueTask support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -137,6 +137,7 @@ dotnet_diagnostic.CA1852.severity = none
 dotnet_diagnostic.CA1859.severity = none
 dotnet_diagnostic.CA1861.severity = none
 dotnet_diagnostic.CA2000.severity = none
+dotnet_diagnostic.CA2012.severity = none
 dotnet_diagnostic.CA2201.severity = none
 dotnet_diagnostic.CA2211.severity = none
 dotnet_diagnostic.CA2252.severity = none

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.1.0" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.1.0" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.2.0" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.2.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
@@ -34,8 +34,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.223" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.224" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value_task.cs
+++ b/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value_task.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Applications.Commands.ModelBound.for_ModelBoundCommandHandler.when_handling;
+
+public class and_handler_returns_a_value_task : Specification
+{
+    record Command()
+    {
+        public Guid Expected = Guid.NewGuid();
+        public IEnumerable<object> Dependencies;
+
+        public ValueTask<Guid> Handle(int firstDependency, string secondDependency)
+        {
+            Dependencies = [firstDependency, secondDependency];
+            return ValueTask.FromResult(Expected);
+        }
+    }
+
+    ModelBoundCommandHandler _handler;
+    object _result;
+    CommandContext _context;
+    object[] _dependencies = [42, "The answer to life, the universe and everything"];
+
+    void Establish()
+    {
+        _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
+        _handler = new ModelBoundCommandHandler(
+            typeof(Command),
+            typeof(Command).GetMethod(nameof(Command.Handle))!);
+    }
+
+    async Task Because() => _result = await _handler.Handle(_context);
+
+    [Fact] void should_return_correct_type() => _result.ShouldBeOfExactType<Guid>();
+    [Fact] void should_return_expected_value() => _result.ShouldEqual(((Command)_context.Command).Expected);
+    [Fact] void should_pass_dependencies_to_handler() => ((Command)_context.Command).Dependencies.ShouldEqual(_dependencies);
+}

--- a/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_task_without_value.cs
+++ b/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_task_without_value.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Applications.Commands.ModelBound.for_ModelBoundCommandHandler.when_handling;
+
+public class and_handler_returns_async_task_without_value : Specification
+{
+    record Command()
+    {
+        public IEnumerable<object> Dependencies;
+        public async Task Handle(int firstDependency, string secondDependency)
+        {
+            Dependencies = [firstDependency, secondDependency];
+            await Task.Delay(1);
+        }
+    }
+
+    ModelBoundCommandHandler _handler;
+    object _result;
+    CommandContext _context;
+    object[] _dependencies = [42, "The answer to life, the universe and everything"];
+
+    void Establish()
+    {
+        _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
+        _handler = new ModelBoundCommandHandler(
+            typeof(Command),
+            typeof(Command).GetMethod(nameof(Command.Handle))!);
+    }
+
+    async Task Because() => _result = await _handler.Handle(_context);
+
+    [Fact] void should_return_null() => _result.ShouldBeNull();
+    [Fact] void should_pass_dependencies_to_handler() => ((Command)_context.Command).Dependencies.ShouldEqual(_dependencies);
+}

--- a/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_value_task.cs
+++ b/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_value_task.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Applications.Commands.ModelBound.for_ModelBoundCommandHandler.when_handling;
+
+public class and_handler_returns_async_value_task : Specification
+{
+    record Command()
+    {
+        public Guid Expected = Guid.NewGuid();
+        public IEnumerable<object> Dependencies;
+
+        public async ValueTask<Guid> Handle(int firstDependency, string secondDependency)
+        {
+            Dependencies = [firstDependency, secondDependency];
+            await Task.Delay(1);
+            return Expected;
+        }
+    }
+
+    ModelBoundCommandHandler _handler;
+    object _result;
+    CommandContext _context;
+    object[] _dependencies = [42, "The answer to life, the universe and everything"];
+
+    void Establish()
+    {
+        _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
+        _handler = new ModelBoundCommandHandler(
+            typeof(Command),
+            typeof(Command).GetMethod(nameof(Command.Handle))!);
+    }
+
+    async Task Because() => _result = await _handler.Handle(_context);
+
+    [Fact] void should_return_correct_type() => _result.ShouldBeOfExactType<Guid>();
+    [Fact] void should_return_expected_value() => _result.ShouldEqual(((Command)_context.Command).Expected);
+    [Fact] void should_pass_dependencies_to_handler() => ((Command)_context.Command).Dependencies.ShouldEqual(_dependencies);
+}

--- a/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_value_task_without_value.cs
+++ b/Source/DotNET/Applications.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_value_task_without_value.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Applications.Commands.ModelBound.for_ModelBoundCommandHandler.when_handling;
+
+public class and_handler_returns_value_task_without_value : Specification
+{
+    record Command()
+    {
+        public IEnumerable<object> Dependencies;
+        public ValueTask Handle(int firstDependency, string secondDependency)
+        {
+            Dependencies = [firstDependency, secondDependency];
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    ModelBoundCommandHandler _handler;
+    object _result;
+    CommandContext _context;
+    object[] _dependencies = [42, "The answer to life, the universe and everything"];
+
+    void Establish()
+    {
+        _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
+        _handler = new ModelBoundCommandHandler(
+            typeof(Command),
+            typeof(Command).GetMethod(nameof(Command.Handle))!);
+    }
+
+    async Task Because() => _result = await _handler.Handle(_context);
+
+    [Fact] void should_return_null() => _result.ShouldBeNull();
+    [Fact] void should_pass_dependencies_to_handler() => ((Command)_context.Command).Dependencies.ShouldEqual(_dependencies);
+}

--- a/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_async_task_return_type.cs
+++ b/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_async_task_return_type.cs
@@ -3,12 +3,15 @@
 
 namespace Cratis.Applications.Queries.ModelBound.for_ModelBoundQueryPerformer.when_performing;
 
-public class with_null_argument_for_non_nullable_parameter : given.a_model_bound_query_performer
+
+public class with_async_task_return_type : given.a_model_bound_query_performer
 {
     public record TestReadModel
     {
-        public static TestReadModel Query(int requiredInt, string requiredString)
+        public static async Task<TestReadModel> Query(int requiredInt, string requiredString)
         {
+            await Task.Delay(1);
+            await Task.CompletedTask;
             return new TestReadModel();
         }
     }

--- a/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_async_value_task_return_type.cs
+++ b/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_async_value_task_return_type.cs
@@ -3,11 +3,11 @@
 
 namespace Cratis.Applications.Queries.ModelBound.for_ModelBoundQueryPerformer.when_performing;
 
-public class with_async_task_return_type : given.a_model_bound_query_performer
+public class with_async_value_task_return_type : given.a_model_bound_query_performer
 {
     public record TestReadModel
     {
-        public static async Task<TestReadModel> Query(int requiredInt, string requiredString)
+        public static async ValueTask<TestReadModel> Query(int requiredInt, string requiredString)
         {
             await Task.Delay(1);
             await Task.CompletedTask;

--- a/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_non_async_task_return_type.cs
+++ b/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_non_async_task_return_type.cs
@@ -3,13 +3,13 @@
 
 namespace Cratis.Applications.Queries.ModelBound.for_ModelBoundQueryPerformer.when_performing;
 
-public class with_null_argument_for_non_nullable_parameter : given.a_model_bound_query_performer
+public class with_non_async_task_return_type : given.a_model_bound_query_performer
 {
     public record TestReadModel
     {
-        public static TestReadModel Query(int requiredInt, string requiredString)
+        public static Task<TestReadModel> Query(int requiredInt, string requiredString)
         {
-            return new TestReadModel();
+            return Task.FromResult(new TestReadModel());
         }
     }
 

--- a/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_value_task_return_type.cs
+++ b/Source/DotNET/Applications.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_performing/with_value_task_return_type.cs
@@ -3,15 +3,13 @@
 
 namespace Cratis.Applications.Queries.ModelBound.for_ModelBoundQueryPerformer.when_performing;
 
-public class with_async_task_return_type : given.a_model_bound_query_performer
+public class with_value_task_return_type : given.a_model_bound_query_performer
 {
     public record TestReadModel
     {
-        public static async Task<TestReadModel> Query(int requiredInt, string requiredString)
+        public static ValueTask<TestReadModel> Query(int requiredInt, string requiredString)
         {
-            await Task.Delay(1);
-            await Task.CompletedTask;
-            return new TestReadModel();
+            return ValueTask.FromResult(new TestReadModel());
         }
     }
 

--- a/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_exception_during_performance.cs
+++ b/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_exception_during_performance.cs
@@ -31,7 +31,7 @@ public class with_exception_during_performance : given.a_query_pipeline
         });
 
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
-        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromException<object?>(_exception));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromException<object?>(_exception));
     }
 
     async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);

--- a/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_null_query_data.cs
+++ b/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_null_query_data.cs
@@ -29,7 +29,7 @@ public class with_null_query_data : given.a_query_pipeline
         });
 
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
-        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromResult<object?>(null));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(null));
     }
 
     async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);

--- a/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_paged_query.cs
+++ b/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_paged_query.cs
@@ -33,7 +33,7 @@ public class with_paged_query : given.a_query_pipeline
         });
 
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
-        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromResult<object?>(_queryData));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_queryData));
         _queryRenderers.Render(_queryName, _queryData).Returns(_rendererResult);
     }
 

--- a/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_valid_query_and_successful_filters.cs
+++ b/Source/DotNET/Applications.Specs/Queries/for_QueryPipeline/when_performing/with_valid_query_and_successful_filters.cs
@@ -34,7 +34,7 @@ public class with_valid_query_and_successful_filters : given.a_query_pipeline
         });
 
         query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(_filterResult);
-        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromResult<object?>(_queryData));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_queryData));
         _queryRenderers.Render(_queryName, _queryData).Returns(_rendererResult);
     }
 

--- a/Source/DotNET/Applications/Commands/ICommandHandler.cs
+++ b/Source/DotNET/Applications/Commands/ICommandHandler.cs
@@ -31,5 +31,5 @@ public interface ICommandHandler
     /// </summary>
     /// <param name="commandContext">The context for the command being handled.</param>
     /// <returns>Response from handling the command.</returns>
-    Task<object?> Handle(CommandContext commandContext);
+    ValueTask<object?> Handle(CommandContext commandContext);
 }

--- a/Source/DotNET/Applications/Commands/ModelBound/ModelBoundCommandHandler.cs
+++ b/Source/DotNET/Applications/Commands/ModelBound/ModelBoundCommandHandler.cs
@@ -37,18 +37,11 @@ public class ModelBoundCommandHandler(Type commandType, MethodInfo handleMethod)
 
         if (result is Task task)
         {
-            if (handleMethod.ReturnType != typeof(Task))
-            {
-                var type = task.GetType();
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
-                {
-                    var property = type.GetProperty(nameof(Task<object>.Result));
-                    await task;
-                    return property?.GetValue(task);
-                }
-            }
             await task;
-            return null;
+
+            return task.GetType().GetProperty(nameof(Task<object>.Result)) is { } resultProperty
+                ? resultProperty.GetValue(task)
+                : null;
         }
 
         return result;

--- a/Source/DotNET/Applications/Queries/IQueryPerformer.cs
+++ b/Source/DotNET/Applications/Queries/IQueryPerformer.cs
@@ -56,5 +56,5 @@ public interface IQueryPerformer
     /// </summary>
     /// <param name="context">The context for the query to render.</param>
     /// <returns>The result of rendering the query.</returns>
-    Task<object?> Perform(QueryContext context);
+    ValueTask<object?> Perform(QueryContext context);
 }

--- a/Source/DotNET/Applications/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Applications/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -79,13 +79,10 @@ public class ModelBoundQueryPerformer : IQueryPerformer
         if (result is Task task)
         {
             await task;
-            var type = task.GetType();
-            if (type.GetProperty(nameof(Task<object>.Result)) is { } resultProperty)
-            {
-                return resultProperty.GetValue(task);
-            }
 
-            return null;
+            return task.GetType().GetProperty(nameof(Task<object>.Result)) is { } resultProperty
+                ? resultProperty.GetValue(task)
+                : null;
         }
 
         return result;

--- a/Source/DotNET/Applications/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Applications/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -78,17 +78,13 @@ public class ModelBoundQueryPerformer : IQueryPerformer
 
         if (result is Task task)
         {
-            if (_performMethod.ReturnType != typeof(Task))
-            {
-                var type = task.GetType();
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
-                {
-                    var property = type.GetProperty(nameof(Task<object>.Result));
-                    await task;
-                    return property?.GetValue(task);
-                }
-            }
             await task;
+            var type = task.GetType();
+            if (type.GetProperty(nameof(Task<object>.Result)) is { } resultProperty)
+            {
+                return resultProperty.GetValue(task);
+            }
+
             return null;
         }
 


### PR DESCRIPTION
### Changed

- Updated dependencies

### Fixed

- Correct handling of `Task` and `ValueTask` in model bound handlers