### PR TITLE
Skipping types that are types that are owned by other entities

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
@@ -21,6 +21,8 @@ public static class ConceptAsConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
+            if (entityType.IsOwned()) continue;
+
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyConceptAsConversion(databaseType);
         }

--- a/Source/DotNET/EntityFrameworkCore/GuidConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/GuidConversion.cs
@@ -21,6 +21,8 @@ public static class GuidConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes().Where(t => !t.ClrType.IsConcept()))
         {
+            if (entityType.IsOwned()) continue;
+
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyGuidConversion(databaseType);
         }

--- a/Source/DotNET/EntityFrameworkCore/Json/JsonConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/Json/JsonConversion.cs
@@ -33,6 +33,8 @@ public static class JsonConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
+            if (entityType.IsOwned()) continue;
+
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyJsonConversion(databaseType);
         }


### PR DESCRIPTION
### Fixed

- For EntityFramework converters we now skip types that are owned by other entities.
