### PR TITLE
Ignoring entity building if there are no properties to build for

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsConversion.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Concepts;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Cratis.Applications.EntityFrameworkCore.Concepts;
@@ -21,12 +22,21 @@ public static class ConceptAsConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-            if (entityType.IsOwned()) continue;
+            if (entityType.IsOwned() || !entityType.HasConceptProperties()) continue;
 
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyConceptAsConversion(databaseType);
         }
     }
+
+    /// <summary>
+    /// Checks if the entity has any properties of <see cref="ConceptAs{T}"/> type.
+    /// </summary>
+    /// <param name="entity">The entity type to check for concept properties.</param>
+    /// <returns>True if the entity has concept properties; otherwise, false.</returns>
+    public static bool HasConceptProperties(this IMutableEntityType entity) =>
+        entity.ClrType.GetProperties()
+            .Any(p => p.PropertyType.IsConcept());
 
     /// <summary>
     /// Applies value conversion for all properties that are of <see cref="ConceptAs{T}"/> type in the specified <see cref="EntityTypeBuilder"/>.

--- a/Source/DotNET/EntityFrameworkCore/GuidConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/GuidConversion.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Concepts;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Cratis.Applications.EntityFrameworkCore;
@@ -21,12 +22,21 @@ public static class GuidConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes().Where(t => !t.ClrType.IsConcept()))
         {
-            if (entityType.IsOwned()) continue;
+            if (entityType.IsOwned() || !entityType.HasGuidProperties()) continue;
 
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyGuidConversion(databaseType);
         }
     }
+
+    /// <summary>
+    /// Checks if the entity has any properties of type <see cref="Guid"/>.
+    /// </summary>
+    /// <param name="entity">The entity type to check for GUID properties.</param>
+    /// <returns>True if the entity has GUID properties; otherwise, false.</returns>
+    public static bool HasGuidProperties(this IMutableEntityType entity) =>
+        entity.ClrType.GetProperties()
+            .Any(p => p.PropertyType == typeof(Guid));
 
     /// <summary>
     /// Applies GUID conversion for all properties of type <see cref="Guid"/> in the specified <see cref="EntityTypeBuilder"/>.

--- a/Source/DotNET/EntityFrameworkCore/Json/JsonConversion.cs
+++ b/Source/DotNET/EntityFrameworkCore/Json/JsonConversion.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Cratis.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -33,12 +34,21 @@ public static class JsonConversion
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
-            if (entityType.IsOwned()) continue;
+            if (entityType.IsOwned() || !entityType.HasJsonProperties()) continue;
 
             var entityTypeBuilder = modelBuilder.Entity(entityType.Name);
             entityTypeBuilder.ApplyJsonConversion(databaseType);
         }
     }
+
+    /// <summary>
+    /// Checks if the entity has any JSON properties.
+    /// </summary>
+    /// <param name="entity">The entity type builder to check for JSON properties.</param>
+    /// <returns>True if the entity has JSON properties; otherwise, false.</returns>
+    public static bool HasJsonProperties(this IMutableEntityType entity) =>
+        entity.ClrType.GetProperties()
+            .Any(p => Attribute.IsDefined(p, typeof(JsonAttribute), inherit: true));
 
     /// <summary>
     /// Applies JSON conversion to properties of a specific entity through its builder.


### PR DESCRIPTION
### Fixed

- Don't define an entity if it does not have any properties that matches the converters we have (Guid, ConceptAs, Json) for Entity Framework. If we call `.Entity()` for an entity, it gets promoted as an entity - while we really don't want that for every type.
