### PR TITLE
Enable retry on failure for MS-SQL and PostgreSQL

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/DatabaseTypeExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/DatabaseTypeExtensions.cs
@@ -44,11 +44,11 @@ public static class DatabaseTypeExtensions
                 .ReplaceService<IMigrationsSqlGenerator, MigrationsSqlGeneratorForSqlite>(),
 
             DatabaseType.SqlServer => builder
-                .UseSqlServer(connectionString)
+                .UseSqlServer(connectionString, options => options.EnableRetryOnFailure())
                 .ReplaceService<IMigrationsSqlGenerator, MigrationsSqlGeneratorForSqlServer>(),
 
             DatabaseType.PostgreSql => builder
-                .UseNpgsql(connectionString)
+                .UseNpgsql(connectionString, options => options.EnableRetryOnFailure())
                 .ReplaceService<IMigrationsSqlGenerator, MigrationsSqlGeneratorForPostgreSQL>(),
 
             _ => throw new UnsupportedDatabaseType(connectionString)


### PR DESCRIPTION
### Fixed

- Adding missing `.EnableRetryOnFailure()` for MS-SQL and PostgreSQL when using the EF Core extension `.UseDatabaseFromConnectionString()`.
