### PR TITLE
Fix cookie name trimming

### DIFF
--- a/Source/JavaScript/Applications/identity/IdentityProvider.ts
+++ b/Source/JavaScript/Applications/identity/IdentityProvider.ts
@@ -70,8 +70,8 @@ export class IdentityProvider extends IIdentityProvider {
 
     private static getCookie() {
         const decoded = decodeURIComponent(document.cookie);
-        const cookies = decoded.split(';');
-        const cookie = cookies.find(_ => _.trim().indexOf(`${IdentityProvider.CookieName}=`) == 0);
+        const cookies = decoded.split(';').map(_ => _.trim());
+        const cookie = cookies.find(_ => _.indexOf(`${IdentityProvider.CookieName}=`) == 0);
         if (cookie) {
             const keyValue = cookie.split('=');
             return [keyValue[0].trim(), keyValue[1].trim()];


### PR DESCRIPTION
### Fixed

- Fixed the way the `.cratis.identity` cookie is identified. It was not trimming the strings properly and sometimes didn't find it.
