### PR TITLE
Adding HttpContextAccessor implicitly, since we're relying on it

### DIFF
--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -96,6 +96,7 @@ public static class HostBuilderExtensions
         builder
             .ConfigureServices(services =>
             {
+                services.AddHttpContextAccessor();
                 services.AddCratisApplicationModelMeter();
                 services.AddCratisCommands();
                 services


### PR DESCRIPTION
### Fixed

- Added missing call for adding the `IHttpContextAccessor` - we are now relying on it and we should explicltly add it to our setup. This is safe to add multiple times using the `.AddHttpContextAccessor()` extension method from ASP.NET Core.
