### PR TITLE
Adding missing correlationIdAccessor registration - this was in the Chronicle setup, which is an unhealthy assumption to take

### DIFF
--- a/Source/DotNET/Applications/HostBuilderExtensions.cs
+++ b/Source/DotNET/Applications/HostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.Metrics;
 using Cratis.Applications;
 using Cratis.Conversion;
 using Cratis.DependencyInjection;
+using Cratis.Execution;
 using Cratis.Serialization;
 using Cratis.Types;
 using Microsoft.Extensions.Configuration;
@@ -99,6 +100,7 @@ public static class HostBuilderExtensions
                 services.AddHttpContextAccessor();
                 services.AddCratisApplicationModelMeter();
                 services.AddCratisCommands();
+                services.AddSingleton<ICorrelationIdAccessor>(sp => new CorrelationIdAccessor());
                 services
                     .AddTypeDiscovery()
                     .AddSingleton<IDerivedTypes>(derivedTypes)


### PR DESCRIPTION
### Fixed

- Fixing an assumption that `ICorrelationIdAccessor` was registered with the IoC. In a stack with Chronicle, it would be - but not without. Explicitly registering it.
