### PR TITLE
Switching to using the same service provider as the rest of the running app for DbContext registrations

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
@@ -23,9 +23,11 @@ public static class DbContextServiceCollectionExtensions
     public static IServiceCollection AddDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<DbContextOptionsBuilder>? optionsAction = default)
         where TDbContext : DbContext
     {
-        services.AddDbContext<TDbContext>(options =>
+        services.AddDbContext<TDbContext>((serviceProvider, options) =>
         {
-            options.UseDatabaseFromConnectionString(connectionString);
+            options
+                .UseDatabaseFromConnectionString(connectionString)
+                .UseInternalServiceProvider(serviceProvider);
             optionsAction?.Invoke(options);
         });
         return services;

--- a/Source/DotNET/EntityFrameworkCore/ReadOnlyDbContextExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/ReadOnlyDbContextExtensions.cs
@@ -21,11 +21,12 @@ public static class ReadOnlyDbContextExtensions
     public static IServiceCollection AddReadOnlyDbContext<TContext>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = default)
         where TContext : DbContext
     {
-        services.AddDbContext<TContext>(options =>
+        services.AddDbContext<TContext>((serviceProvider, options) =>
         {
             options
                 .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
-                .AddInterceptors(new ReadOnlySaveChangesInterceptor());
+                .AddInterceptors(new ReadOnlySaveChangesInterceptor())
+                .UseInternalServiceProvider(serviceProvider);
             optionsAction?.Invoke(options);
         });
         return services;


### PR DESCRIPTION
### Fixed

- Fixing so that DbContexts are registered to be using the same `ServiceProvider` as the rest of the app, instead of its internal. This should fix a problem with the dependency `IEntityTypeRegistrar` not being picked up correctly in some scenarios.
