### PR TITLE
Resetting resolver state on close + dialog context dependency

### DIFF
--- a/Source/JavaScript/Applications.React/dialogs/useDialog.tsx
+++ b/Source/JavaScript/Applications.React/dialogs/useDialog.tsx
@@ -32,12 +32,13 @@ export function useDialog<TResponse = object, TProps = object>(
     const closeDialog = useCallback((result: DialogResult, value?: TResponse) => {
         setVisible(false);
         resolverRef.current?.([result, value]);
+        resolverRef.current = undefined;
     }, []);
 
     const dialogContextValue = useRef<DialogContextContent<TProps, TResponse>>(undefined!);
     dialogContextValue.current = useMemo(() => {
         return new DialogContextContent(dialogProps!, closeDialog);
-    }, [dialogProps]);
+    }, [dialogProps, closeDialog]);
 
     const DialogWrapper: FC<TProps> = (extraProps) => {
         return visible ? (


### PR DESCRIPTION
### Fixed

- React `useDialog()` hook now resets the current resolver ref that could prevent dialogs from showing up.
- Fixing a dependency in the React `useDialog()` for an internal `useMem()` that could cause staleness in state for the dialog.