### PR TITLE
Fixing OpenAPI dependency nightmare

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,8 +51,4 @@
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.11" />
     <PackageVersion Include="System.Text.Json" Version="9.0.11" />
   </ItemGroup>
-  <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
-  </ItemGroup>
 </Project>

--- a/Source/DotNET/Applications/Applications.csproj
+++ b/Source/DotNET/Applications/Applications.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Cratis.Fundamentals" />
         <PackageReference Include="FluentValidation" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/Source/DotNET/Applications/Commands/CommandEndpointsExtensions.cs
+++ b/Source/DotNET/Applications/Commands/CommandEndpointsExtensions.cs
@@ -68,8 +68,7 @@ public static class CommandEndpointsExtensions
                 })
                 .WithTags(string.Join('.', location))
                 .WithName($"Execute{handler.CommandType.Name}")
-                .WithSummary($"Execute {handler.CommandType.Name} command")
-                .WithOpenApi();
+                .WithSummary($"Execute {handler.CommandType.Name} command");
             }
         }
 

--- a/Source/DotNET/Applications/Queries/QueryEndpointsExtensions.cs
+++ b/Source/DotNET/Applications/Queries/QueryEndpointsExtensions.cs
@@ -79,8 +79,7 @@ public static class QueryEndpointsExtensions
                 })
                 .WithTags(string.Join('.', location))
                 .WithName($"Execute{performer.Name}")
-                .WithSummary($"Execute {performer.Name} query")
-                .WithOpenApi();
+                .WithSummary($"Execute {performer.Name} query");
             }
         }
 


### PR DESCRIPTION
### Fixed

- Removing explicit dependency to `Microsoft.AspNetCore.OpenApi` which then does not tie us down on the version for `Microsoft.OpenApi`.
