### PR TITLE
Making the property names consistent - camelCase

### DIFF
--- a/Source/DotNET/Applications.Specs/Validation/for_BaseValidator/when_validating_concept_as_property.cs
+++ b/Source/DotNET/Applications.Specs/Validation/for_BaseValidator/when_validating_concept_as_property.cs
@@ -29,7 +29,7 @@ public class when_validating_concept_as_property : Specification
     void Because() => _result = _validator.Validate(new TestCommand(new TestConcept(""), new TestConcept("not-an-email")));
 
     [Fact] void should_fail_validation() => _result.IsValid.ShouldBeFalse();
-    [Fact] void should_have_error_for_name_property() => _result.Errors.ShouldContain(error => error.PropertyName == "Name");
-    [Fact] void should_have_error_for_email_property() => _result.Errors.ShouldContain(error => error.PropertyName == "Email");
+    [Fact] void should_have_error_for_name_property() => _result.Errors.ShouldContain(error => error.PropertyName == "name");
+    [Fact] void should_have_error_for_email_property() => _result.Errors.ShouldContain(error => error.PropertyName == "email");
     [Fact] void should_not_have_error_with_value_in_property_name() => _result.Errors.ShouldNotContain(error => error.PropertyName.Contains("Value"));
 }

--- a/Source/DotNET/Applications/Validation/BaseValidator.cs
+++ b/Source/DotNET/Applications/Validation/BaseValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq.Expressions;
+using Cratis.Strings;
 using FluentValidation;
 
 namespace Cratis.Applications.Validation;
@@ -389,7 +390,7 @@ public class BaseValidator<T> : AbstractValidator<T>
     {
         if (expression.Body is MemberExpression memberExpression)
         {
-            return memberExpression.Member.Name;
+            return memberExpression.Member.Name.ToCamelCase();
         }
 
         throw new ArgumentException("Expression must be a member expression", nameof(expression));


### PR DESCRIPTION
### Fixed

- Property names during validation is now returned correctly as expected in the frontend; as camelCase.
