### PR TITLE
Fix/camel-case

### DIFF
--- a/Source/JavaScript/Applications/queries/IQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/IQueryFor.ts
@@ -22,7 +22,7 @@ export interface IQueryFor<TDataType, TArguments = object> extends IQuery {
     get parameters(): TArguments | undefined;
 
     /**
-     * Sets the current arguments for the query.git p
+     * Sets the current arguments for the query.
      */
     set parameters(value: TArguments);
 


### PR DESCRIPTION
### Fixed

- Fixing casing for the name of the property in the `PropertyDescriptor` when generating a command using the ProxyGenerator.
