### PR TITLE
Fixing lifecycle for the identity details provider

### DIFF
--- a/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
+++ b/Source/DotNET/Applications/Identity/IdentityProviderServiceCollectionExtensions.cs
@@ -49,7 +49,7 @@ public static class IdentityProviderServiceCollectionExtensions
     public static IServiceCollection AddIdentityProvider(this IServiceCollection services, Type type)
     {
         TypeIsNotAnIdentityDetailsProvider.ThrowIfNotAnIdentityDetailsProvider(type);
-        services.AddSingleton(typeof(IProvideIdentityDetails), type);
+        services.AddTransient(typeof(IProvideIdentityDetails), type);
         services.AddSingleton<IdentityProviderEndpoint>();
 
         return services;


### PR DESCRIPTION
### Fixed

- Fixing the lifecycle from singleton to transient for `IProvideIdentityDetails` registration. This should never have been singleton as the implementation could have dependencies that are context aware.
