### PR TITLE
Adding logic to avoid endpoint duplication when mapping commands and validation endpoints for controller based commands

### DIFF
--- a/Source/DotNET/Applications/Commands/ControllerCommandEndpointMapper.cs
+++ b/Source/DotNET/Applications/Commands/ControllerCommandEndpointMapper.cs
@@ -42,6 +42,12 @@ public class ControllerCommandEndpointMapper(
 
             if (commandType is null) continue;
 
+            var endpointName = $"Validate{action.ControllerName}{action.ActionName}";
+            if (endpoints.EndpointExists(endpointName))
+            {
+                continue;
+            }
+
             endpoints.Map(route, async context =>
             {
                 context.HandleCorrelationId(correlationIdAccessor, appModelOptions.CorrelationId);
@@ -63,7 +69,7 @@ public class ControllerCommandEndpointMapper(
             })
             .WithMetadata(new HttpMethodMetadata(_postHttpMethod))
             .WithTags(action.ControllerName)
-            .WithName($"Validate{action.ControllerName}{action.ActionName}")
+            .WithName(endpointName)
             .WithSummary($"Validate {action.ActionName} command without executing it");
         }
     }

--- a/Source/DotNET/Applications/EndpointRouteBuilderExtensions.cs
+++ b/Source/DotNET/Applications/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.AspNetCore.Routing;
+
+/// <summary>
+/// Provides extension methods for <see cref="IEndpointRouteBuilder"/>.
+/// </summary>
+public static class EndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Checks if an endpoint with the specified name already exists.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="endpointName">The name of the endpoint to check.</param>
+    /// <returns>True if the endpoint exists, false otherwise.</returns>
+    public static bool EndpointExists(this IEndpointRouteBuilder endpoints, string endpointName) =>
+        endpoints.DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .Any(e => e.Metadata.GetMetadata<EndpointNameMetadata>()?.EndpointName == endpointName);
+}


### PR DESCRIPTION
### Fixed

- Fixing registration of the minimal API based routes for both Commands and Queries and also the validate endpoints for controller based Commands. Routes with duplication in name will be ignored.
