### PR TITLE
Fix so that we get the correct query string

### DIFF
--- a/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Applications/queries/ObservableQueryFor.ts
@@ -134,7 +134,7 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
         const queryParams = UrlHelpers.buildQueryParams(unusedParameters, additionalParams);
         const queryString = queryParams.toString();
         if (queryString) {
-            actualRoute += '?' + queryString;
+            actualRoute += (actualRoute.includes('?') ? '&' : '?') + queryString;
         }
 
         const url = UrlHelpers.createUrlFrom(this._origin, this._apiBasePath, actualRoute);

--- a/Source/JavaScript/Applications/queries/QueryFor.ts
+++ b/Source/JavaScript/Applications/queries/QueryFor.ts
@@ -100,7 +100,7 @@ export abstract class QueryFor<TDataType, TParameters = object> implements IQuer
         const queryParams = UrlHelpers.buildQueryParams(unusedParameters, additionalParams);
         const queryString = queryParams.toString();
         if (queryString) {
-            actualRoute += '?' + queryString;
+            actualRoute += (actualRoute.includes('?') ? '&' : '?') + queryString;
         }
         
         const url = UrlHelpers.createUrlFrom(this._origin, this._apiBasePath, actualRoute);


### PR DESCRIPTION
### Fixed

- Fixing the generation of URLs when there were paging and query parameters. It added two `?` to the string. 
