### PR TITLE
Adding missing constructor for parameter descriptors

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator/ControllerBased/ParameterInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ControllerBased/ParameterInfoExtensions.cs
@@ -20,7 +20,13 @@ public static class ParameterInfoExtensions
     {
         var type = parameterInfo.ParameterType.GetTargetType();
         var optional = parameterInfo.IsOptional() || parameterInfo.HasDefaultValue;
-        return new RequestParameterDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, optional, parameterInfo.IsFromQueryArgument());
+        return new RequestParameterDescriptor(
+            parameterInfo.ParameterType,
+            parameterInfo.Name!,
+            type.Type,
+            type.Constructor,
+            optional,
+            parameterInfo.IsFromQueryArgument());
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/ControllerBased/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ControllerBased/PropertyExtensions.cs
@@ -47,6 +47,7 @@ public static class PropertyExtensions
             propertyInfo.PropertyType,
             propertyInfo.Name!,
             type.Type,
+            type.Constructor,
             optional,
             propertyInfo.IsFromQueryParameter());
     }

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
@@ -166,7 +166,7 @@ public static class QueryExtensions
         var optional = parameterInfo.IsOptional() || parameterInfo.HasDefaultValue;
 
         // All query parameters are considered query string parameters
-        return new RequestParameterDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, optional, true);
+        return new RequestParameterDescriptor(parameterInfo.ParameterType, parameterInfo.Name!, type.Type, type.Constructor, optional, true);
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/RequestParameterDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/RequestParameterDescriptor.cs
@@ -9,11 +9,13 @@ namespace Cratis.Applications.ProxyGenerator.Templates;
 /// <param name="OriginalType">The original type of the argument.</param>
 /// <param name="Name">Name of argument.</param>
 /// <param name="Type">Type of argument.</param>
+/// <param name="Constructor">The JavaScript constructor for the type.</param>
 /// <param name="IsOptional">Whether or not the argument is nullable / optional.</param>
 /// <param name="IsQueryStringParameter">Whether or not the argument is a query string parameter.</param>
 public record RequestParameterDescriptor(
     Type OriginalType,
     string Name,
     string Type,
+    string Constructor,
     bool IsOptional,
     bool IsQueryStringParameter = false);


### PR DESCRIPTION
### Fixed

- Fixing an oversight from previous version; missing the Constructor representing the type of a parameter in the `RequestParameterDescriptor` for query proxy generation.
