### PR TITLE
Fixing useQuery hook to also respond to changes done to args, sorting and paging passed into the hook

### DIFF
--- a/Source/JavaScript/Arc.React/queries/for_useQuery/FakeQueryWithRequiredParameters.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/FakeQueryWithRequiredParameters.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryFor } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+
+export interface FakeQueryWithRequiredParametersResult {
+    id: string;
+    name: string;
+}
+
+export interface FakeQueryWithRequiredParametersArguments {
+    userId: string;
+    category: string;
+}
+
+export class FakeQueryWithRequiredParameters extends QueryFor<FakeQueryWithRequiredParametersResult[]> {
+    readonly route = '/api/fake-query-with-required-parameters';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return ['userId', 'category'];
+    }
+
+    defaultValue: FakeQueryWithRequiredParametersResult[] = [];
+
+    constructor() {
+        super(Object, true);
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useQuery/when_required_argument_changes.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/when_required_argument_changes.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { useQuery } from '../useQuery';
+import { FakeQueryWithRequiredParameters, FakeQueryWithRequiredParametersArguments } from './FakeQueryWithRequiredParameters';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+
+describe('when required argument changes', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({ data: [], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, validationResults: [], exceptionMessages: [], exceptionStackTrace: '' })
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        React.createElement(ArcContext.Provider, { value: config }, children)
+    );
+
+    it('should execute query again when argument changes', async () => {
+        const { rerender } = renderHook(
+            ({ args }: { args: FakeQueryWithRequiredParametersArguments }) => useQuery(FakeQueryWithRequiredParameters, args),
+            {
+                wrapper,
+                initialProps: { args: { userId: 'user-1', category: 'cat-1' } }
+            }
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        fetchStub.resetHistory();
+
+        rerender({ args: { userId: 'user-2', category: 'cat-1' } });
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/for_useQuery/when_sorting_changes.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/when_sorting_changes.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { useQuery } from '../useQuery';
+import { FakeQuery } from './FakeQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { Sorting, SortDirection } from '@cratis/arc/queries';
+
+describe('when sorting changes', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({ data: [], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, validationResults: [], exceptionMessages: [], exceptionStackTrace: '' })
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        React.createElement(ArcContext.Provider, { value: config }, children)
+    );
+
+    it('should execute query again when sorting changes', async () => {
+        const { result } = renderHook(
+            () => useQuery(FakeQuery),
+            { wrapper }
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        fetchStub.resetHistory();
+
+        const [, , setSorting] = result.current;
+        await setSorting(new Sorting('name', SortDirection.ascending));
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/for_useQueryWithPaging/when_paging_changes.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQueryWithPaging/when_paging_changes.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { useQueryWithPaging } from '../useQuery';
+import { FakeQuery } from '../for_useQuery/FakeQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { Paging } from '@cratis/arc/queries';
+
+describe('when paging changes', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({ data: [], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, validationResults: [], exceptionMessages: [], exceptionStackTrace: '' })
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        React.createElement(ArcContext.Provider, { value: config }, children)
+    );
+
+    it('should execute query again when page changes', async () => {
+        const { result } = renderHook(
+            () => useQueryWithPaging(FakeQuery, new Paging(0, 10)),
+            { wrapper }
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        fetchStub.resetHistory();
+
+        const [, , , setPage] = result.current;
+        await setPage(1);
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/for_useQueryWithPaging/when_required_argument_changes.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQueryWithPaging/when_required_argument_changes.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { useQueryWithPaging } from '../useQuery';
+import { FakeQueryWithRequiredParameters, FakeQueryWithRequiredParametersArguments } from '../for_useQuery/FakeQueryWithRequiredParameters';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { Paging } from '@cratis/arc/queries';
+
+describe('when required argument changes', () => {
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({ data: [], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, validationResults: [], exceptionMessages: [], exceptionStackTrace: '' })
+        } as Response);
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        React.createElement(ArcContext.Provider, { value: config }, children)
+    );
+
+    it('should execute query again when argument changes', async () => {
+        const { rerender } = renderHook(
+            ({ args }: { args: FakeQueryWithRequiredParametersArguments }) => 
+                useQueryWithPaging(FakeQueryWithRequiredParameters, new Paging(0, 10), args),
+            {
+                wrapper,
+                initialProps: { args: { userId: 'user-1', category: 'cat-1' } }
+            }
+        );
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+
+        fetchStub.resetHistory();
+
+        rerender({ args: { userId: 'user-2', category: 'cat-1' } });
+
+        await waitFor(() => fetchStub.should.have.been.calledOnce);
+    });
+});


### PR DESCRIPTION
### Fixed

- Fixing the state tracking for the `useQuery()` hook to respond to changes from the args, sorting and paging passed to the hook, not only rely on calls to the different `set*` functions returned in the tuple.
