### PR TITLE
Moving configuration of DbContext from OnConfigure to registration

### DIFF
--- a/Documentation/backend/entity-framework/automatic-database-hookup.md
+++ b/Documentation/backend/entity-framework/automatic-database-hookup.md
@@ -8,17 +8,26 @@ Out of the box we support the following databases:
 
 There are different extension methods for adding `DbContext` types and also for resolving the correct database provider based on connection string.
 
+You can use the standard EF Core method with the Arc database detection extension:
+
 ```csharp
 services.AddDbContext<MyDbContext>(opt => opt.UseDatabaseFromConnectionString(".. your connection string.."));
 ```
 
 > Note: From the connection string it will do the correct `.UseSqlite()`, `.UseNpgsql()` or `.UseSqlServer()` call on the builder.
 
-There is also a short-hand version of this:
+However, **it is recommended** to use the Arc registration methods which use the pooled factory pattern for better performance and to support multiple database providers:
 
 ```csharp
 services.AddDbContextWithConnectionString<MyDbContext>(".. your connection string..", opt => /* do whatever configuration you want */);
 ```
+
+This method automatically:
+
+- Uses `AddPooledDbContextFactory` for improved performance
+- Applies all `BaseDbContext` configurations (interceptors, service replacements)
+- Registers both the factory and a scoped DbContext instance
+- Supports multiple database providers in the same application
 
 ## Multiple Database Providers
 

--- a/Documentation/backend/entity-framework/base-db-context.md
+++ b/Documentation/backend/entity-framework/base-db-context.md
@@ -4,6 +4,8 @@ The `BaseDbContext` provides a pre-configured Entity Framework Core context that
 
 ## Converters
 
+The `BaseDbContext` provides automatic converter application when used with the Arc registration methods (`AddDbContextWithConnectionString` or `AddReadOnlyDbContext`). These methods configure all necessary services and interceptors at registration time to support the pooled factory pattern.
+
 The `BaseDbContext` automatically applies converters to all `DbSet<>` types defined on the context and any types that are referenced by those entity types.
 
 ## How Converters Are Applied
@@ -50,3 +52,18 @@ services.AddDbContext<StoreDbContext>(opt => ...);
 ```
 
 Or leveraging the [automatic database hookup](./automatic-database-hookup.md) extensions provided by Cratis Arc.
+
+## Important: DbContext Pooling
+
+The `BaseDbContext` is designed to work with the pooled factory pattern used by the Arc registration methods. When using `AddDbContextWithConnectionString` or `AddReadOnlyDbContext`, all configuration (service replacements, interceptors, observation support) is applied at registration time.
+
+**Do not override `OnConfiguring`** in your derived DbContext classes when using pooled contexts, as EF Core does not allow modifying options in `OnConfiguring` when pooling is enabled. All configuration must be done during registration.
+
+If you need custom configuration, pass it through the optional `optionsAction` parameter:
+
+```csharp
+services.AddDbContextWithConnectionString<StoreDbContext>(
+    connectionString,
+    opt => opt.EnableSensitiveDataLogging() // Custom configuration here
+);
+```

--- a/Documentation/backend/entity-framework/observing.md
+++ b/Documentation/backend/entity-framework/observing.md
@@ -16,28 +16,27 @@ services.AddEntityFrameworkCoreObservation();
 
 This registers the necessary services for tracking entity changes and database-level notifications.
 
-If your DbContext inherits from `BaseDbContext`, observation support is automatically enabled when the services are registered. No additional configuration is needed.
+If your DbContext inherits from `BaseDbContext` and is registered using the Arc extension methods (`AddDbContextWithConnectionString` or `AddReadOnlyDbContext`), observation support is automatically enabled when the services are registered. No additional configuration is needed.
 
 ### Manual Configuration (Advanced)
 
-If you're not using `BaseDbContext`, you can manually add observation support:
+If you're not using `BaseDbContext` or the Arc registration methods, you can manually add observation support at registration time:
 
 ```csharp
-protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-{
-    optionsBuilder.AddObservation(serviceProvider);
-}
-```
-
-Or when configuring in dependency injection:
-
-```csharp
-services.AddDbContext<MyDbContext>((serviceProvider, options) =>
+services.AddPooledDbContextFactory<MyDbContext>((serviceProvider, options) =>
 {
     options.UseSqlServer(connectionString)
            .AddObservation(serviceProvider);
 });
+
+services.AddScoped(serviceProvider =>
+{
+    var factory = serviceProvider.GetRequiredService<IDbContextFactory<MyDbContext>>();
+    return factory.CreateDbContext();
+});
 ```
+
+> **Important**: When using pooled DbContext factories (`AddPooledDbContextFactory`), all configuration must be done at registration time. You cannot modify options in `OnConfiguring` when pooling is enabled.
 
 ## Usage
 

--- a/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
+++ b/Source/DotNET/EntityFrameworkCore/BaseDbContext.cs
@@ -4,11 +4,9 @@
 using Cratis.Arc.EntityFrameworkCore.Concepts;
 using Cratis.Arc.EntityFrameworkCore.Json;
 using Cratis.Arc.EntityFrameworkCore.Mapping;
-using Cratis.Arc.EntityFrameworkCore.Observe;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.EntityFrameworkCore;
@@ -19,23 +17,6 @@ namespace Cratis.Arc.EntityFrameworkCore;
 /// <param name="options">The options to be used by a <see cref="DbContext"/>.</param>
 public class BaseDbContext(DbContextOptions options) : DbContext(options)
 {
-    /// <inheritdoc/>
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder
-            .ReplaceService<IEvaluatableExpressionFilter, ConceptAsEvaluatableExpressionFilter>()
-            .ReplaceService<IModelCustomizer, ConceptAsModelCustomizer>()
-            .AddInterceptors(new ConceptAsQueryExpressionInterceptor(), new ConceptAsDbCommandInterceptor());
-
-        var serviceProvider = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()?.ApplicationServiceProvider;
-        if (serviceProvider?.GetService<IEntityChangeTracker>() is not null)
-        {
-            optionsBuilder.AddObservation(serviceProvider);
-        }
-
-        base.OnConfiguring(optionsBuilder);
-    }
-
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
### Fixed

- When doing pooled EntityFramework `DbContext` factories, `OnConfigure` is not allowed on `DbContext` implementations. Moved the registrations from `BaseDbContext` to be in the registrations extensions instead.
