### PR TITLE
Adding missing ServiceProvider on the options callbacks

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class DbContextServiceCollectionExtensions
     /// <param name="connectionString">The connection string to use for the DbContext.</param>
     /// <param name="optionsAction">An optional action to configure the DbContext options.</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<DbContextOptionsBuilder>? optionsAction = default)
+    public static IServiceCollection AddDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = default)
         where TDbContext : DbContext
     {
         services.AddPooledDbContextFactory<TDbContext>((serviceProvider, options) =>
@@ -43,7 +43,7 @@ public static class DbContextServiceCollectionExtensions
                 options.AddObservation(serviceProvider);
             }
 
-            optionsAction?.Invoke(options);
+            optionsAction?.Invoke(serviceProvider, options);
         });
 
         services.AddScoped(serviceProvider =>
@@ -63,7 +63,7 @@ public static class DbContextServiceCollectionExtensions
     /// <param name="optionsAction">An action to configure the DbContext options.</param>
     /// <param name="assemblies">The assemblies to scan for DbContext types.</param>
     /// <returns>The service collection, for chaining.</returns>
-    public static IServiceCollection AddReadModelDbContextsFromAssemblies(this IServiceCollection services, Action<DbContextOptionsBuilder> optionsAction, params Assembly[] assemblies)
+    public static IServiceCollection AddReadModelDbContextsFromAssemblies(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder> optionsAction, params Assembly[] assemblies)
     {
         var addDbContextMethod = typeof(ReadOnlyDbContextExtensions).GetMethod(nameof(ReadOnlyDbContextExtensions.AddReadOnlyDbContext), BindingFlags.Static | BindingFlags.Public)!;
 
@@ -84,7 +84,7 @@ public static class DbContextServiceCollectionExtensions
     /// <param name="assemblies">The assemblies to scan for DbContext types.</param>
     /// <returns>The service collection, for chaining.</returns>
     /// <exception cref="UnsupportedDatabaseType">Thrown if the connection string does not have a supported database type.</exception>
-    public static IServiceCollection AddReadModelDbContextsWithConnectionStringFromAssemblies(this IServiceCollection services, string connectionString, Action<DbContextOptionsBuilder> optionsAction, params Assembly[] assemblies)
+    public static IServiceCollection AddReadModelDbContextsWithConnectionStringFromAssemblies(this IServiceCollection services, string connectionString, Action<IServiceProvider, DbContextOptionsBuilder> optionsAction, params Assembly[] assemblies)
     {
         var addDbContextMethod = typeof(ReadOnlyDbContextExtensions).GetMethod(nameof(ReadOnlyDbContextExtensions.AddReadOnlyDbContextWithConnectionString), BindingFlags.Static | BindingFlags.Public)!;
 

--- a/Source/DotNET/EntityFrameworkCore/ReadOnlyDbContextExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/ReadOnlyDbContextExtensions.cs
@@ -24,7 +24,7 @@ public static class ReadOnlyDbContextExtensions
     /// <param name="services">The service collection to add the DbContext to.</param>
     /// <param name="optionsAction">An optional action to configure the DbContext options.</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddReadOnlyDbContext<TContext>(this IServiceCollection services, Action<DbContextOptionsBuilder>? optionsAction = default)
+    public static IServiceCollection AddReadOnlyDbContext<TContext>(this IServiceCollection services, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = default)
         where TContext : DbContext
     {
         services.AddPooledDbContextFactory<TContext>((serviceProvider, options) =>
@@ -43,7 +43,7 @@ public static class ReadOnlyDbContextExtensions
                 options.AddObservation(serviceProvider);
             }
 
-            optionsAction?.Invoke(options);
+            optionsAction?.Invoke(serviceProvider, options);
         });
 
         services.AddScoped(serviceProvider =>
@@ -64,13 +64,13 @@ public static class ReadOnlyDbContextExtensions
     /// <param name="connectionString">The connection string to use for the DbContext.</param>
     /// <param name="optionsAction">An optional action to configure the DbContext options.</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddReadOnlyDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<DbContextOptionsBuilder>? optionsAction = default)
+    public static IServiceCollection AddReadOnlyDbContextWithConnectionString<TDbContext>(this IServiceCollection services, string connectionString, Action<IServiceProvider, DbContextOptionsBuilder>? optionsAction = default)
         where TDbContext : BaseDbContext
     {
-        services.AddReadOnlyDbContext<TDbContext>(builder =>
+        services.AddReadOnlyDbContext<TDbContext>((serviceProvider, builder) =>
         {
             builder.UseDatabaseFromConnectionString(connectionString);
-            optionsAction?.Invoke(builder);
+            optionsAction?.Invoke(serviceProvider, builder);
         });
 
         return services;


### PR DESCRIPTION
### Fixed

- Adding missing `IServiceProvider` on the options callbacks for adding EntityFramework `DbContext` registrations.
