### PR TITLE
Removing ASP.NET Core Framework reference

### DIFF
--- a/Source/DotNET/Chronicle/Chronicle.csproj
+++ b/Source/DotNET/Chronicle/Chronicle.csproj
@@ -4,13 +4,8 @@
         <AssemblyName>Cratis.Arc.Chronicle</AssemblyName>
         <RootNamespace>Cratis.Arc.Chronicle</RootNamespace>
     </PropertyGroup>
-
     <ItemGroup>
         <InternalsVisibleTo Include="Cratis.Arc.Chronicle.Specs" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Arc.Core/Arc.Core.csproj" />

--- a/Source/DotNET/EntityFrameworkCore/EntityFrameworkCore.csproj
+++ b/Source/DotNET/EntityFrameworkCore/EntityFrameworkCore.csproj
@@ -5,9 +5,6 @@
         <NoWarn>$(NoWarn);NU5104</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    </ItemGroup>
-    <ItemGroup>
         <PackageReference Include="Cratis.Fundamentals" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />


### PR DESCRIPTION
### Fixed

- Removing framework reference for ASP.NET Core in EntityFrameworkCore and Chronicle packages - they're not needed.
