### PR TITLE
Moving ServiceProvider as a dependency on Command and Query pipelines to be passed in on execution - with the correctly scoped service provider

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
@@ -37,7 +37,6 @@ public class a_command_pipeline : Specification
             _commandHandlerProviders,
             _commandResponseValueHandlers,
             _commandContextModifier,
-            _commandContextValuesBuilder,
-            _serviceProvider);
+            _commandContextValuesBuilder);
     }
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_an_exception_is_thrown_in_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_an_exception_is_thrown_in_handler.cs
@@ -16,7 +16,7 @@ public class and_an_exception_is_thrown_in_handler : given.a_command_pipeline_an
         _commandHandler.Handle(Arg.Any<CommandContext>()).Throws(_exception);
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_not_call_value_handlers() => _commandResponseValueHandlers.DidNotReceive().Handle(Arg.Any<CommandContext>(), Arg.Any<object>());
     [Fact] void should_be_unsuccessful() => _result.IsSuccess.ShouldBeFalse();

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
@@ -14,7 +14,7 @@ public class and_command_filters_are_reporting_not_successful : given.a_command_
         _commandFilters.OnExecution(Arg.Any<CommandContext>()).Returns(CommandResult.Error(CorrelationId.New(), "Not successful"));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_return_not_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_not_call_command_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value.cs
@@ -23,7 +23,7 @@ public class and_handler_returns_a_one_of_value : given.a_command_pipeline_and_a
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _value).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _oneOf.Value);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value_without_value_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_value_without_value_handler.cs
@@ -19,7 +19,7 @@ public class and_handler_returns_a_one_of_value_without_value_handler : given.a_
         _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _value).Returns(false);
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_check_if_value_handlers_can_handle() => _commandResponseValueHandlers.Received(1).CanHandle(Arg.Any<CommandContext>(), _value);
     [Fact] void should_not_call_value_handlers() => _commandResponseValueHandlers.DidNotReceive().Handle(Arg.Any<CommandContext>(), _value);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_simple_value_as_response.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_simple_value_as_response.cs
@@ -20,7 +20,7 @@ public class and_handler_returns_a_one_of_with_simple_value_as_response : given.
         _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _value).Returns(false);
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_return_response_in_command_result() => _result.Response.ShouldEqual(_value);
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_simple_value_that_is_handled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_simple_value_that_is_handled.cs
@@ -24,7 +24,7 @@ public class and_handler_returns_a_one_of_with_simple_value_that_is_handled : gi
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _value).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _value);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_all_handled_values.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_all_handled_values.cs
@@ -26,7 +26,7 @@ public class and_handler_returns_a_one_of_with_tuple_containing_all_handled_valu
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), 3.14).Returns(CommandResult.Error(CorrelationId.New(), _secondErrorMessage));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_call_value_handlers_for_first_value() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), 42);
     [Fact] void should_call_value_handlers_for_second_value() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), 3.14);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_response_and_handled_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_response_and_handled_value.cs
@@ -25,7 +25,7 @@ public class and_handler_returns_a_one_of_with_tuple_containing_response_and_han
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), 3.14).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_call_value_handlers_for_handled_value() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), 3.14);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_responseValue)), 3.14);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_all_handled_values.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_all_handled_values.cs
@@ -25,7 +25,7 @@ public class and_handler_returns_a_triple_with_all_handled_values : given.a_comm
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Item3).Returns(CommandResult.Success(CorrelationId.New()));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact]
     void should_call_value_handlers_for_all_values()

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_one_unhandled_and_two_handled_values.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_one_unhandled_and_two_handled_values.cs
@@ -24,7 +24,7 @@ public class and_handler_returns_a_triple_with_one_unhandled_and_two_handled_val
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Item3).Returns(CommandResult.Success(CorrelationId.New()));
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact]
     void should_call_value_handlers_for_handled_values()

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_two_unhandled_values.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_two_unhandled_values.cs
@@ -17,7 +17,7 @@ public class and_handler_returns_a_triple_with_two_unhandled_values : given.a_co
         _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), Arg.Any<object>()).Returns(false);
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_be_unsuccessful() => _result.IsSuccess.ShouldBeFalse();
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_one_of_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_one_of_value.cs
@@ -24,7 +24,7 @@ public class and_handler_returns_a_tuple_with_response_and_one_of_value : given.
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Item2.Value).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item2.Value);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2.Value);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_value.cs
@@ -23,7 +23,7 @@ public class and_handler_returns_a_tuple_with_response_and_value : given.a_comma
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Item2).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item2);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_value_first_and_response_second.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_value_first_and_response_second.cs
@@ -23,7 +23,7 @@ public class and_handler_returns_a_tuple_with_value_first_and_response_second : 
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Item1).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item1);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item2)), _tuple.Item1);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value.cs
@@ -20,7 +20,7 @@ public class and_handler_returns_a_value : given.a_command_pipeline_and_a_handle
         _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _value).Returns(CommandResult.Error(CorrelationId.New(), _errorMessage));
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _value);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value_without_value_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_value_without_value_handler.cs
@@ -15,7 +15,7 @@ public class and_handler_returns_a_value_without_value_handler : given.a_command
         _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _value).Returns(false);
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_check_if_value_handlers_can_handle() => _commandResponseValueHandlers.Received(1).CanHandle(Arg.Any<CommandContext>(), _value);
     [Fact] void should_not_call_value_handlers() => _commandResponseValueHandlers.DidNotReceive().Handle(Arg.Any<CommandContext>(), _value);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_tuple_with_first_value_unhandled_and_second_value_handler_depends_on_first.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_tuple_with_first_value_unhandled_and_second_value_handler_depends_on_first.cs
@@ -36,7 +36,7 @@ public class and_handler_returns_tuple_with_first_value_unhandled_and_second_val
             });
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<Guid>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<Guid>;
 
     [Fact] void should_set_first_unhandled_value_as_response() => _result.Response.ShouldEqual(_tuple.Item1);
     [Fact] void should_call_handler_for_second_value() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item2);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
@@ -33,7 +33,7 @@ public class and_there_is_a_handler_that_has_dependencies : given.a_command_pipe
         });
     }
 
-    async Task Because() => _result = await _commandPipeline.Execute(_command);
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
 
     [Fact] void should_call_command_handler() => _commandHandler.Received(1).Handle(Arg.Any<CommandContext>());
     [Fact] void should_pass_dependencies_to_handler() => _dependencies.ShouldContainOnly(_expectedDependencies);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_no_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_no_handler.cs
@@ -7,7 +7,7 @@ public class and_there_is_no_handler : given.a_command_pipeline
 {
     CommandResult _result;
 
-    async Task Because() => _result = await _commandPipeline.Execute("something");
+    async Task Because() => _result = await _commandPipeline.Execute("something", _serviceProvider);
 
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_exceptions() => _result.HasExceptions.ShouldBeTrue();

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_authorization_fails.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_authorization_fails.cs
@@ -12,7 +12,7 @@ public class and_authorization_fails : given.a_command_pipeline_and_a_handler_fo
         _commandFilters.OnExecution(Arg.Any<CommandContext>()).Returns(Task.FromResult(CommandResult.Unauthorized(_correlationId)));
     }
 
-    async Task Because() => _result = await _commandPipeline.Validate(_command);
+    async Task Because() => _result = await _commandPipeline.Validate(_command, _serviceProvider);
 
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_is_valid.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_is_valid.cs
@@ -12,7 +12,7 @@ public class and_command_is_valid : given.a_command_pipeline_and_a_handler_for_c
         _commandFilters.OnExecution(Arg.Any<CommandContext>()).Returns(Task.FromResult(CommandResult.Success(_correlationId)));
     }
 
-    async Task Because() => _result = await _commandPipeline.Validate(_command);
+    async Task Because() => _result = await _commandPipeline.Validate(_command, _serviceProvider);
 
     [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_there_is_no_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_there_is_no_handler.cs
@@ -7,7 +7,7 @@ public class and_there_is_no_handler : given.a_command_pipeline
 {
     CommandResult _result;
 
-    async Task Because() => _result = await _commandPipeline.Validate("something");
+    async Task Because() => _result = await _commandPipeline.Validate("something", _serviceProvider);
 
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_exceptions() => _result.HasExceptions.ShouldBeTrue();

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_validation_fails.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_validation_fails.cs
@@ -20,7 +20,7 @@ public class and_validation_fails : given.a_command_pipeline_and_a_handler_for_c
         }));
     }
 
-    async Task Because() => _result = await _commandPipeline.Validate(_command);
+    async Task Because() => _result = await _commandPipeline.Validate(_command, _serviceProvider);
 
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/given/a_query_pipeline.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/given/a_query_pipeline.cs
@@ -36,7 +36,6 @@ public class a_query_pipeline : Specification
             _queryContextManager,
             query_filters,
             _queryPerformerProviders,
-            _queryRenderers,
-            _serviceProvider);
+            _queryRenderers);
     }
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_exception_during_performance.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_exception_during_performance.cs
@@ -34,11 +34,11 @@ public class with_exception_during_performance : given.a_query_pipeline
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromException<object?>(_exception));
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_unsuccessful_result() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_exception_message() => _result.ExceptionMessages.ShouldContain(_exception.Message);
     [Fact] void should_have_exception_stack_trace() => _result.ExceptionStackTrace.ShouldEqual(_exception.StackTrace ?? string.Empty);
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
-    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>());
+    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>());
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_failed_filters.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_failed_filters.cs
@@ -35,11 +35,11 @@ public class with_failed_filters : given.a_query_pipeline
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_filter_result() => _result.ShouldEqual(_filterResult);
     [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
     [Fact] void should_not_call_query_performer() => _queryPerformer.DidNotReceiveWithAnyArgs().Perform(Arg.Any<QueryContext>());
-    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>());
+    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>());
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_missing_performer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_missing_performer.cs
@@ -25,11 +25,11 @@ public class with_missing_performer : given.a_query_pipeline
         });
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_unsuccessful_result() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_exception_message_about_missing_performer() => _result.ExceptionMessages.ShouldContain($"No performer found for query {_queryName}");
     [Fact] void should_not_call_query_filters() => query_filters.DidNotReceiveWithAnyArgs().OnPerform(Arg.Any<QueryContext>());
     [Fact] void should_not_call_query_performer() => _queryPerformer.DidNotReceiveWithAnyArgs().Perform(Arg.Any<QueryContext>());
-    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>());
+    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>());
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_not_set_correlation_id.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_not_set_correlation_id.cs
@@ -39,10 +39,10 @@ public class with_not_set_correlation_id : given.a_query_pipeline
 
         query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(_filterResult);
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromResult<object?>(_queryData));
-        _queryRenderers.Render(_queryName, _queryData).Returns(_rendererResult);
+        _queryRenderers.Render(_queryName, _queryData, _serviceProvider).Returns(_rendererResult);
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_generate_new_correlation_id_for_context() => _capturedContext.CorrelationId.ShouldNotEqual(CorrelationId.NotSet);
     [Fact] void should_use_generated_correlation_id_consistently() => _capturedContext.CorrelationId.Value.ShouldNotEqual(Guid.Empty);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_null_query_data.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_null_query_data.cs
@@ -32,10 +32,10 @@ public class with_null_query_data : given.a_query_pipeline
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(null));
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
     [Fact] void should_have_correlation_id_from_filter_result() => _result.CorrelationId.ShouldEqual(_correlationId);
-    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>());
+    [Fact] void should_not_call_query_renderers() => _queryRenderers.DidNotReceiveWithAnyArgs().Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>());
     [Fact] void should_have_default_data() => _result.Data.ShouldBeNull();
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_null_renderer_result.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_null_renderer_result.cs
@@ -32,10 +32,10 @@ public class with_null_renderer_result : given.a_query_pipeline
 
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(Task.FromResult<object?>(_queryData));
-        _queryRenderers.Render(_queryName, _queryData).Returns((QueryRendererResult?)null);
+        _queryRenderers.Render(_queryName, _queryData, _serviceProvider).Returns((QueryRendererResult?)null);
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_unsuccessful_result() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_have_error_message_about_no_renderer_result() => _result.ExceptionMessages.ShouldContain("No renderer result");

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_paged_query.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_paged_query.cs
@@ -34,10 +34,10 @@ public class with_paged_query : given.a_query_pipeline
 
         query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_queryData));
-        _queryRenderers.Render(_queryName, _queryData).Returns(_rendererResult);
+        _queryRenderers.Render(_queryName, _queryData, _serviceProvider).Returns(_rendererResult);
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
     [Fact] void should_set_rendered_data_on_result() => _result.Data.ShouldEqual(_rendererResult.Data);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_valid_query_and_successful_filters.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_valid_query_and_successful_filters.cs
@@ -35,10 +35,10 @@ public class with_valid_query_and_successful_filters : given.a_query_pipeline
 
         query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(_filterResult);
         _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_queryData));
-        _queryRenderers.Render(_queryName, _queryData).Returns(_rendererResult);
+        _queryRenderers.Render(_queryName, _queryData, _serviceProvider).Returns(_rendererResult);
     }
 
-    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting);
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
 
     [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
     [Fact] void should_set_correlation_id_on_result() => _result.CorrelationId.ShouldEqual(_correlationId);

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
@@ -106,8 +106,8 @@ public static class CommandEndpointMapper
                 else
                 {
                     commandResult = validateOnly
-                        ? await commandPipeline.Validate(command)
-                        : await commandPipeline.Execute(command);
+                        ? await commandPipeline.Validate(command, context.RequestServices)
+                        : await commandPipeline.Execute(command, context.RequestServices);
                 }
 
                 context.SetStatusCode(commandResult.IsSuccess ? 200 : !commandResult.IsValid ? 400 : 500);

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -18,7 +18,6 @@ namespace Cratis.Arc.Commands;
 /// <param name="valueHandlers">The <see cref="ICommandResponseValueHandlers"/> to use for handling response values.</param>
 /// <param name="contextModifier">The <see cref="ICommandContextModifier"/> to use for setting the current command context.</param>
 /// <param name="contextValuesBuilder">The <see cref="ICommandContextValuesBuilder"/> to use for building command context values.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use for resolving dependencies.</param>
 [Singleton]
 public class CommandPipeline(
     ICorrelationIdAccessor correlationIdAccessor,
@@ -26,11 +25,10 @@ public class CommandPipeline(
     ICommandHandlerProviders handlerProviders,
     ICommandResponseValueHandlers valueHandlers,
     ICommandContextModifier contextModifier,
-    ICommandContextValuesBuilder contextValuesBuilder,
-    IServiceProvider serviceProvider) : ICommandPipeline
+    ICommandContextValuesBuilder contextValuesBuilder) : ICommandPipeline
 {
     /// <inheritdoc/>
-    public async Task<CommandResult> Execute(object command)
+    public async Task<CommandResult> Execute(object command, IServiceProvider serviceProvider)
     {
         var correlationId = GetCorrelationId();
         var result = CommandResult.Success(correlationId);
@@ -73,7 +71,7 @@ public class CommandPipeline(
     }
 
     /// <inheritdoc/>
-    public async Task<CommandResult> Validate(object command)
+    public async Task<CommandResult> Validate(object command, IServiceProvider serviceProvider)
     {
         var correlationId = GetCorrelationId();
         var result = CommandResult.Success(correlationId);

--- a/Source/DotNET/Arc.Core/Commands/ICommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandPipeline.cs
@@ -12,17 +12,19 @@ public interface ICommandPipeline
     /// Executes the given command.
     /// </summary>
     /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
     /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
-    Task<CommandResult> Execute(object command);
+    Task<CommandResult> Execute(object command, IServiceProvider serviceProvider);
 
     /// <summary>
     /// Validates the given command without executing it.
     /// </summary>
     /// <param name="command">The command to validate.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
     /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
     /// <remarks>
     /// This method runs authorization and validation filters but does not invoke the command handler.
     /// Use this for pre-flight validation before executing a command.
     /// </remarks>
-    Task<CommandResult> Validate(object command);
+    Task<CommandResult> Validate(object command, IServiceProvider serviceProvider);
 }

--- a/Source/DotNET/Arc.Core/Queries/IQueryPipeline.cs
+++ b/Source/DotNET/Arc.Core/Queries/IQueryPipeline.cs
@@ -15,6 +15,7 @@ public interface IQueryPipeline
     /// <param name="arguments">The arguments for the query.</param>
     /// <param name="paging">The paging to apply to the query.</param>
     /// <param name="sorting">The sorting to apply to the query.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve dependencies.</param>
     /// <returns>A <see cref="QueryResult"/> representing the result of executing the command.</returns>
-    Task<QueryResult> Perform(FullyQualifiedQueryName queryName, QueryArguments arguments, Paging paging, Sorting sorting);
+    Task<QueryResult> Perform(FullyQualifiedQueryName queryName, QueryArguments arguments, Paging paging, Sorting sorting, IServiceProvider serviceProvider);
 }

--- a/Source/DotNET/Arc.Core/Queries/IQueryRenderers.cs
+++ b/Source/DotNET/Arc.Core/Queries/IQueryRenderers.cs
@@ -13,6 +13,7 @@ public interface IQueryRenderers
     /// </summary>
     /// <param name="queryName">Name of the query.</param>
     /// <param name="query">Query to render.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve query renderer dependencies.</param>
     /// <returns>Result.</returns>
-    QueryRendererResult Render(FullyQualifiedQueryName queryName, object query);
+    QueryRendererResult Render(FullyQualifiedQueryName queryName, object query, IServiceProvider serviceProvider);
 }

--- a/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
@@ -74,7 +74,7 @@ public static class QueryEndpointMapper
                         var sorting = GetSortingInfo(context);
                         var arguments = GetQueryArguments(context, performer);
 
-                        var queryResult = await queryPipeline.Perform(performer.FullyQualifiedName, arguments, paging, sorting);
+                        var queryResult = await queryPipeline.Perform(performer.FullyQualifiedName, arguments, paging, sorting, context.RequestServices);
 
                         // Check if the result data is a streaming result (Subject or AsyncEnumerable)
                         if (queryResult.IsSuccess && observableQueryHandler.IsStreamingResult(queryResult.Data))

--- a/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
@@ -14,17 +14,15 @@ namespace Cratis.Arc.Queries;
 /// <param name="queryFilters">The query filters.</param>
 /// <param name="queryPerformerProviders">The query performer providers.</param>
 /// <param name="queryRenderers">The query renderers.</param>
-/// <param name="serviceProvider">Service provider for resolving dependencies.</param>
 public class QueryPipeline(
     ICorrelationIdAccessor correlationIdAccessor,
     IQueryContextManager queryContextManager,
     IQueryFilters queryFilters,
     IQueryPerformerProviders queryPerformerProviders,
-    IQueryRenderers queryRenderers,
-    IServiceProvider serviceProvider) : IQueryPipeline
+    IQueryRenderers queryRenderers) : IQueryPipeline
 {
     /// <inheritdoc/>
-    public async Task<QueryResult> Perform(FullyQualifiedQueryName queryName, QueryArguments arguments, Paging paging, Sorting sorting)
+    public async Task<QueryResult> Perform(FullyQualifiedQueryName queryName, QueryArguments arguments, Paging paging, Sorting sorting, IServiceProvider serviceProvider)
     {
         var correlationId = GetCorrelationId();
         var result = QueryResult.Success(correlationId);
@@ -49,7 +47,7 @@ public class QueryPipeline(
             {
                 return result;
             }
-            var rendererResult = queryRenderers.Render(queryName, data);
+            var rendererResult = queryRenderers.Render(queryName, data, serviceProvider);
             if (rendererResult is null)
             {
                 return QueryResult.Error(correlationId, "No renderer result");

--- a/Source/DotNET/Arc.Core/Queries/QueryRenderers.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryRenderers.cs
@@ -12,17 +12,15 @@ namespace Cratis.Arc.Queries;
 /// <param name="queryContextManager"><see cref="IQueryContextManager"/> for managing query contexts.</param>
 /// <param name="correlationIdAccessor"><see cref="ICorrelationIdAccessor"/> for getting the current correlation ID.</param>
 /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
-/// <param name="serviceProvider"><see cref="IServiceProvider"/> for getting instances of query providers.</param>
 public class QueryRenderers(
     IQueryContextManager queryContextManager,
     ICorrelationIdAccessor correlationIdAccessor,
-    ITypes types,
-    IServiceProvider serviceProvider) : IQueryRenderers
+    ITypes types) : IQueryRenderers
 {
     readonly IEnumerable<Type> _queryProviders = types.FindMultiple(typeof(IQueryRendererFor<>));
 
     /// <inheritdoc/>
-    public QueryRendererResult Render(FullyQualifiedQueryName queryName, object query)
+    public QueryRendererResult Render(FullyQualifiedQueryName queryName, object query, IServiceProvider serviceProvider)
     {
         var queryType = query.GetType();
         var queryProviderType = _queryProviders.FirstOrDefault(_ => queryType.IsAssignableTo(_.GetInterface(typeof(IQueryRendererFor<>).Name)!.GetGenericArguments()[0]));

--- a/Source/DotNET/Arc/CommandEndpointsExtensions.cs
+++ b/Source/DotNET/Arc/CommandEndpointsExtensions.cs
@@ -28,13 +28,11 @@ public static class CommandEndpointsExtensions
 
             // Map controller-based command validation endpoints
             var actionDescriptorProvider = app.ApplicationServices.GetRequiredService<IActionDescriptorCollectionProvider>();
-            var commandPipeline = app.ApplicationServices.GetRequiredService<ICommandPipeline>();
             var correlationIdAccessor = app.ApplicationServices.GetRequiredService<ICorrelationIdAccessor>();
             var arcOptions = app.ApplicationServices.GetRequiredService<IOptions<ArcOptions>>().Value;
 
             var controllerCommandMapper = new ControllerCommandEndpointMapper(
                 actionDescriptorProvider,
-                commandPipeline,
                 correlationIdAccessor,
                 arcOptions.JsonSerializerOptions,
                 mapper);

--- a/Source/DotNET/Arc/Commands/ControllerCommandEndpointMapper.cs
+++ b/Source/DotNET/Arc/Commands/ControllerCommandEndpointMapper.cs
@@ -15,13 +15,11 @@ namespace Cratis.Arc.Commands;
 /// Maps validation endpoints for controller-based commands.
 /// </summary>
 /// <param name="actionDescriptorCollectionProvider">Provider for discovering controller actions.</param>
-/// <param name="commandPipeline">The command pipeline for executing validation.</param>
 /// <param name="correlationIdAccessor">Accessor for correlation IDs.</param>
 /// <param name="jsonSerializerOptions">JSON serialization options.</param>
 /// <param name="endpointMapper">The endpoint mapper for checking existing endpoints.</param>
 public class ControllerCommandEndpointMapper(
     IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
-    ICommandPipeline commandPipeline,
     ICorrelationIdAccessor correlationIdAccessor,
     JsonSerializerOptions jsonSerializerOptions,
     IEndpointMapper endpointMapper)
@@ -52,6 +50,7 @@ public class ControllerCommandEndpointMapper(
             {
                 context.HandleCorrelationId(correlationIdAccessor, arcOptions.CorrelationId);
 
+                var commandPipeline = context.RequestServices.GetRequiredService<ICommandPipeline>();
                 var command = await context.Request.ReadFromJsonAsync(commandType, jsonSerializerOptions, cancellationToken: context.RequestAborted);
                 CommandResult commandResult;
 
@@ -61,7 +60,7 @@ public class ControllerCommandEndpointMapper(
                 }
                 else
                 {
-                    commandResult = await commandPipeline.Validate(command);
+                    commandResult = await commandPipeline.Validate(command, context.RequestServices);
                 }
 
                 context.Response.SetResponseStatusCode(commandResult);

--- a/Source/DotNET/Arc/Queries/QueryActionFilter.cs
+++ b/Source/DotNET/Arc/Queries/QueryActionFilter.cs
@@ -53,7 +53,8 @@ public class QueryActionFilter(
                 callResult.ExceptionMessages,
                 callResult.ExceptionStackTrace ?? string.Empty,
                 validationResults,
-                queryProviders);
+                queryProviders,
+                context.HttpContext.RequestServices);
 
             context.HttpContext.Response.SetResponseStatusCode(queryResult);
 
@@ -92,9 +93,10 @@ public class QueryActionFilter(
         IEnumerable<string> exceptionMessages,
         string exceptionStackTrace,
         IEnumerable<ValidationResult> validationResults,
-        IQueryRenderers queryProviders)
+        IQueryRenderers queryProviders,
+        IServiceProvider serviceProvider)
     {
-        var rendererResult = response is not null ? queryProviders.Render(queryName, response) : new QueryRendererResult(0, default!);
+        var rendererResult = response is not null ? queryProviders.Render(queryName, response, serviceProvider) : new QueryRendererResult(0, default!);
 
         var queryResult = new QueryResult
         {

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/given/a_command_pipeline_with_event_handlers.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/given/a_command_pipeline_with_event_handlers.cs
@@ -96,8 +96,7 @@ public class a_command_pipeline_with_event_handlers : Specification
             _commandHandlerProviders,
             _commandResponseValueHandlers,
             _commandContextModifier,
-            _commandContextValuesBuilder,
-            _serviceProvider);
+            _commandContextValuesBuilder);
     }
 
     protected record TestEvent(string Name);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/when_executing/and_handler_returns_tuple_with_event_first_and_response_second.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/when_executing/and_handler_returns_tuple_with_event_first_and_response_second.cs
@@ -19,7 +19,7 @@ public class and_handler_returns_tuple_with_event_first_and_response_second : gi
         _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_tuple);
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_append_event_to_event_log() => _eventLog.Received(1).Append(
         _command.EventSourceId,

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/when_executing/and_handler_returns_tuple_with_response_first_and_event_second.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/when_executing/and_handler_returns_tuple_with_response_first_and_event_second.cs
@@ -19,7 +19,7 @@ public class and_handler_returns_tuple_with_response_first_and_event_second : gi
         _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_tuple);
     }
 
-    async Task Because() => _result = (await _commandPipeline.Execute(_command)) as CommandResult<string>;
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
 
     [Fact] void should_append_event_to_event_log() => _eventLog.Received(1).Append(
         _command.EventSourceId,


### PR DESCRIPTION
### Fixed

- Fixing service scoping for Commands and Queries. Our pipelines are singleton, which meant they kept the `IServiceProvider` dependency as a singleton as well. Yielding random results. It now takes the correctly scoped `IServiceProvider` on execution.
