### PR TITLE
Fixing scoping for IProvideIdentityDetails through using the RequestServices of the context

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/given/an_identity_provider_result_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/given/an_identity_provider_result_handler.cs
@@ -12,6 +12,7 @@ public class an_identity_provider_result_handler : Specification
     protected IHttpRequestContextAccessor _httpRequestContextAccessor;
     protected IHttpRequestContext _httpRequestContext;
     protected IProvideIdentityDetails _identityProvider;
+    protected IServiceProvider _requestServices;
     protected IdentityProviderResultHandler _handler;
     protected ArcOptions _options = new();
 
@@ -22,10 +23,14 @@ public class an_identity_provider_result_handler : Specification
         _httpRequestContextAccessor.Current.Returns(_httpRequestContext);
 
         _identityProvider = Substitute.For<IProvideIdentityDetails>();
+        _requestServices = Substitute.For<IServiceProvider>();
+        _requestServices.GetService(typeof(IProvideIdentityDetails)).Returns(_identityProvider);
+        _httpRequestContext.RequestServices.Returns(_requestServices);
+
         var optionsWrapper = Substitute.For<IOptions<ArcOptions>>();
         optionsWrapper.Value.Returns(_options);
 
-        _handler = new(_httpRequestContextAccessor, _identityProvider, optionsWrapper);
+        _handler = new(_httpRequestContextAccessor, optionsWrapper);
     }
 
     protected ClaimsPrincipal CreateAuthenticatedUser()

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/when_generating_from_current_context/and_user_is_authenticated_and_authorized_identity_provider_is_resolved_from_request_services.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/when_generating_from_current_context/and_user_is_authenticated_and_authorized_identity_provider_is_resolved_from_request_services.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Identity.for_IdentityProviderResultHandler.when_generating_from_current_context;
+
+public class and_user_is_authenticated_and_authorized_identity_provider_is_resolved_from_request_services : given.an_authenticated_user
+{
+    IdentityProviderResult _result;
+
+    async Task Because() => _result = await _handler.GenerateFromCurrentContext();
+
+    [Fact] void should_resolve_identity_provider_from_request_services() => _requestServices.Received(1).GetService(typeof(IProvideIdentityDetails));
+    [Fact] void should_return_authenticated_result() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_return_authorized_result() => _result.IsAuthorized.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core/Identity/IdentityProviderResultHandler.cs
+++ b/Source/DotNET/Arc.Core/Identity/IdentityProviderResultHandler.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Cratis.Arc.Http;
 using Cratis.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Cratis.Arc.Identity;
@@ -13,12 +14,10 @@ namespace Cratis.Arc.Identity;
 /// Represents an implementation of <see cref="IIdentityProviderResultHandler"/>.
 /// </summary>
 /// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/>.</param>
-/// <param name="identityProvider">The <see cref="IProvideIdentityDetails"/>.</param>
 /// <param name="options">The <see cref="IOptions{ArcOptions}"/>.</param>
 [Singleton]
 public class IdentityProviderResultHandler(
     IHttpRequestContextAccessor httpRequestContextAccessor,
-    IProvideIdentityDetails identityProvider,
     IOptions<ArcOptions> options) : IIdentityProviderResultHandler
 {
     /// <summary>
@@ -53,6 +52,7 @@ public class IdentityProviderResultHandler(
             var claims = claimsPrincipal.Claims.Select(claim => new KeyValuePair<string, string>(claim.Type, claim.Value));
 
             var providerContext = new IdentityProviderContext(identityId, identityName, claims);
+            var identityProvider = context.RequestServices.GetRequiredService<IProvideIdentityDetails>();
             var result = await identityProvider.Provide(providerContext);
 
             if (result.IsUserAuthorized)


### PR DESCRIPTION
### Fixed

- Fixing how we resolve `IProvideIdentityDetails` by using the scoped **service provider** on the `IHttpRequestContext`. This guarantees the correct scoping of the service.
