### PR TITLE
Forgot to do export of stories

### DIFF
--- a/Source/JavaScript/Arc.React/index.ts
+++ b/Source/JavaScript/Arc.React/index.ts
@@ -5,6 +5,7 @@ import * as commands from './commands';
 import * as dialogs from './dialogs';
 import * as identity from './identity';
 import * as queries from './queries';
+import * as stories from './stories';
 
 export * from './Arc';
 export * from './ArcContext';
@@ -14,5 +15,6 @@ export {
     commands,
     dialogs,
     identity,
-    queries
+    queries,
+    stories
 };


### PR DESCRIPTION
### Fixed

- Adding missing `export` for `stories` in the root module.
