### PR TITLE
Add tests for TypeScript content combining with documentation handling

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_multiple_contents_having_documentation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeScriptContentCombiner/when_combining/with_multiple_contents_having_documentation.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeScriptContentCombiner.when_combining;
+
+public class with_multiple_contents_having_documentation : Specification
+{
+#pragma warning disable MA0136 // Raw String contains an implicit end of line character
+    const string FirstContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        import { field } from '@cratis/fundamentals';
+
+        /**
+         * The first type.
+         */
+        export class FirstType {
+        }
+        """;
+
+    const string SecondContent = """
+        /*---------------------------------------------------------------------------------------------
+         *  **DO NOT EDIT** - This file is an automatically generated file.
+         *--------------------------------------------------------------------------------------------*/
+
+        /* eslint-disable sort-imports */
+        import { field } from '@cratis/fundamentals';
+
+        /**
+         * The second type.
+         */
+        export class SecondType {
+        }
+        """;
+#pragma warning restore MA0136 // Raw String contains an implicit end of line character
+
+    string _result = null!;
+
+    void Because() => _result = TypeScriptContentCombiner.Combine([FirstContent, SecondContent]);
+
+    [Fact] void should_contain_header_once() => _result.Split("DO NOT EDIT").Length.ShouldEqual(2);
+    [Fact] void should_contain_only_one_eslint_disable() => _result.Split("/* eslint-disable sort-imports */").Length.ShouldEqual(2);
+    [Fact] void should_contain_only_one_import() => _result.Split("import { field } from '@cratis/fundamentals';").Length.ShouldEqual(2);
+    [Fact] void should_contain_first_type_documentation() => _result.ShouldContain("The first type.");
+    [Fact] void should_contain_second_type_documentation() => _result.ShouldContain("The second type.");
+    [Fact] void should_have_first_documentation_before_first_export() => _result.IndexOf("The first type.").ShouldBeLessThan(_result.IndexOf("export class FirstType"));
+    [Fact] void should_have_second_documentation_before_second_export() => _result.IndexOf("The second type.").ShouldBeLessThan(_result.IndexOf("export class SecondType"));
+    [Fact] void should_not_have_second_documentation_outside_jsdoc_block() => _result.ShouldNotContain("*/\n * The second type.");
+    [Fact] void should_not_have_first_documentation_outside_jsdoc_block() => _result.ShouldNotContain("*/\n * The first type.");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeScriptContentCombiner.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeScriptContentCombiner.cs
@@ -97,13 +97,37 @@ public static class TypeScriptContentCombiner
 
         var header = string.Join('\n', lines.Take(3));
 
+        // Walk backwards from the export to include any preceding JSDoc block in the body,
+        // so that per-type documentation is not mixed into the shared preamble section.
+        var bodyStartIndex = exportStartIndex;
+        var checkIndex = exportStartIndex - 1;
+
+        while (checkIndex >= 0 && string.IsNullOrWhiteSpace(lines[checkIndex]))
+        {
+            checkIndex--;
+        }
+
+        if (checkIndex >= 0 && lines[checkIndex].TrimStart().StartsWith("*/", StringComparison.Ordinal))
+        {
+            var scanIndex = checkIndex;
+            while (scanIndex >= 0 && !lines[scanIndex].TrimStart().StartsWith("/**", StringComparison.Ordinal))
+            {
+                scanIndex--;
+            }
+
+            if (scanIndex >= 0 && lines[scanIndex].TrimStart().StartsWith("/**", StringComparison.Ordinal))
+            {
+                bodyStartIndex = scanIndex;
+            }
+        }
+
         var preambleLines = lines
             .Skip(3)
-            .Take(exportStartIndex - 3)
+            .Take(bodyStartIndex - 3)
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .ToList();
 
-        var body = string.Join('\n', lines.Skip(exportStartIndex));
+        var body = string.Join('\n', lines.Skip(bodyStartIndex));
 
         return new ParsedContent(header, preambleLines, body);
     }


### PR DESCRIPTION
### Fixed

- Updated the `TypeScriptContentCombiner` to ensure that per-type documentation is preserved and not mixed into the shared preamble section.

