### PR TITLE
Upgrading Fundamentals

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Chronicle" Version="15.4.0" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.4.0" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.7.2" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.2" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.7.3" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.3" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />


### PR DESCRIPTION
### Fixed

- Upgrading Cratis Fundamentals for alignment on Humanizer version, which was causing issues.
