### PR TITLE
Disabling SA1200 for GlobalUsings that will be injected

### DIFF
--- a/Source/DotNET/Cratis/GlobalUsings.cs
+++ b/Source/DotNET/Cratis/GlobalUsings.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable IDE0005 // Using directive is unnecessary.
+#pragma warning disable SA1200 // Using directives should be placed correctly
+
 global using Cratis.Arc;
 global using Cratis.Arc.Authentication;
 global using Cratis.Arc.Authorization;


### PR DESCRIPTION
### Fixed

- Disabling SA1200 in the GlobalUsings.cs in the Cratis package - this is injected into applications and we want to not have this as warnings for consuming solutions.
