### PR TITLE
Fix MA0127, MA0042 and NJsonSchema build errors

### DIFF
--- a/Source/DotNET/Chronicle.Specs/EventTypesForSpecifications.cs
+++ b/Source/DotNET/Chronicle.Specs/EventTypesForSpecifications.cs
@@ -4,8 +4,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using Cratis.Chronicle.Events;
-using NJsonSchema;
-using NJsonSchema.Generation;
+using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Arc.Chronicle;
 
@@ -28,9 +27,7 @@ public class EventTypesForSpecifications : IEventTypes
 
         _eventTypes = types.ToDictionary(_ => _, _ => _.GetEventType());
         _clrTypesByEventType = _eventTypes.ToDictionary(_ => _.Value.Id, _ => _.Key);
-
-        var generator = new JsonSchemaGenerator(new SystemTextJsonSchemaGeneratorSettings());
-        _jsonSchemasByEventType = _eventTypes.ToDictionary(_ => _.Value.Id, _ => generator.Generate(_.Key));
+        _jsonSchemasByEventType = _eventTypes.ToDictionary(_ => _.Value.Id, _ => new JsonSchema());
 
         AllClrTypes = _clrTypesByEventType.Values.ToImmutableList();
     }

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -42,7 +42,7 @@ public static class MongoCollectionExtensions
     public static async Task<T?> FindByIdAsync<T, TId>(this IMongoCollection<T> collection, TId id)
     {
         var result = await collection.FindAsync(Builders<T>.Filter.Eq(new StringFieldDefinition<T, TId>("_id"), id));
-        return result.SingleOrDefault();
+        return await result.SingleOrDefaultAsync();
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/FileMetadataScanner.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/FileMetadataScanner.cs
@@ -113,7 +113,7 @@ public static class FileMetadataScanner
             .Where(f =>
             {
                 var ext = Path.GetExtension(f);
-                return (ext is ".ts" or ".tsx") && Path.GetFileName(f) != "index.ts";
+                return (string.Equals(ext, ".ts", StringComparison.Ordinal) || string.Equals(ext, ".tsx", StringComparison.Ordinal)) && Path.GetFileName(f) != "index.ts";
             })
             .ToList();
 


### PR DESCRIPTION
## Fixed

- Use `string.Equals` instead of `is` pattern in `FileMetadataScanner` to resolve MA0127 analyzer error
- Use `SingleOrDefaultAsync` instead of `SingleOrDefault` in `MongoCollectionExtensions.FindByIdAsync` to resolve MA0042 analyzer error
- Replace removed `NJsonSchema` dependency with `Cratis.Chronicle.Schemas.JsonSchema` in `EventTypesForSpecifications` to resolve CS0246 and CS0738 compiler errors