### PR TITLE
Fix ObservableQueryConnection, transport close() races, connection leak, and add Vite WebSocket proxy docs

### DIFF
--- a/Documentation/frontend/react/observable-query-multiplexing.md
+++ b/Documentation/frontend/react/observable-query-multiplexing.md
@@ -131,3 +131,4 @@ The cap only applies to SSE. WebSocket connections do not consume HTTP/1.1 conne
 - [Observable Query Hub](../../backend/queries/observable-query-hub.md) — Protocol reference, authorization semantics, and keep-alive configuration on the backend.
 - [Query Instance Caching](./query-instance-caching.md) — How query instances are deduplicated and last-known results cached across components.
 - [Queries](./queries.md) — General query hooks and usage patterns.
+- [Vite Configuration](./vite-configuration.md) — Required Vite proxy settings for WebSocket transport in development.

--- a/Documentation/frontend/react/toc.yml
+++ b/Documentation/frontend/react/toc.yml
@@ -18,6 +18,8 @@
   href: query-instance-caching.md
 - name: Conditional Queries
   href: conditional-queries.md
+- name: Vite Configuration
+  href: vite-configuration.md
 - name: Proxy Generation
   href: proxy-generation.md
 - name: Story Components

--- a/Documentation/frontend/react/vite-configuration.md
+++ b/Documentation/frontend/react/vite-configuration.md
@@ -1,0 +1,61 @@
+# Vite Configuration
+
+When you use Vite's built-in dev server to proxy API requests to a backend running on a different port, WebSocket connections require explicit opt-in.
+
+## WebSocket proxy for the observable query hub
+
+Vite's proxy is built on [http-proxy](https://github.com/http-party/node-http-proxy). By default it only proxies regular HTTP requests. To also forward the WebSocket upgrade handshake that the [observable query hub](./observable-query-multiplexing.md) requires, you must set `ws: true` on every proxy rule whose target serves WebSocket connections.
+
+The hub endpoint is `/.cratis/queries/ws`. Without `ws: true` on the `/.cratis` proxy rule, the browser issues a WebSocket upgrade to the Vite dev server, but Vite returns a plain HTTP response and the connection fails. Observable queries silently receive no data and repeatedly attempt to reconnect.
+
+### Correct configuration
+
+```ts
+// vite.config.ts
+export default defineConfig({
+    server: {
+        proxy: {
+            '/.cratis': {
+                target: 'http://localhost:5001',
+                ws: true,                          // required for WebSocket upgrade
+            },
+        },
+    },
+});
+```
+
+Compare with a common incorrect configuration that handles only HTTP:
+
+```ts
+// ❌ Missing ws: true — WebSocket connections fail silently
+'/.cratis': {
+    target: 'http://localhost:5001',
+},
+```
+
+### Why it is easy to miss
+
+Most proxy rules are added to forward `fetch` and `XHR` traffic. Those work without `ws: true` because they are ordinary HTTP requests. Observable queries are the only part of Arc that upgrade to a WebSocket, so the missing flag goes unnoticed until you observe that live data is never delivered to the frontend.
+
+Vite docs: [Server options — proxy](https://vite.dev/config/server-options.html#server-proxy).
+
+### Checking a full proxy block
+
+A typical Vite setup that exposes both the REST API and the observable query hub looks like this:
+
+```ts
+server: {
+    proxy: {
+        '/api': {
+            target: 'http://localhost:5001',
+            ws: true,        // required if any /api route also uses WebSocket
+        },
+        '/.cratis': {
+            target: 'http://localhost:5001',
+            ws: true,        // required for /.cratis/queries/ws
+        },
+    },
+},
+```
+
+Neither rule needs `changeOrigin: true` when the backend is on the same machine.

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.WebSockets;
+using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using Cratis.Arc.Http;
@@ -519,7 +520,7 @@ public class ObservableQueryDemultiplexer(
         Func<string, string, Task> onError,
         CancellationToken token)
     {
-        return subject.Subscribe(
+        var rxSubscription = subject.Subscribe(
             data =>
             {
                 if (token.IsCancellationRequested)
@@ -562,6 +563,16 @@ public class ObservableQueryDemultiplexer(
                 logger.SubscriptionError(queryId, error);
                 _ = onError(queryId, error.Message);
             });
+
+        // Disposing the Rx subscription only removes this observer from the subject — it does NOT
+        // signal completion to the subject, so the backing MongoDB change stream Watch() task would
+        // keep running and leak a connection indefinitely. Calling OnCompleted() here ensures that
+        // the change stream CancellationTokenSource in Observe() is cancelled immediately.
+        return Disposable.Create(() =>
+        {
+            rxSubscription.Dispose();
+            subject.OnCompleted();
+        });
     }
 
     async Task StreamAsyncEnumerable(

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryHubMessage.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryHubMessage.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace Cratis.Arc.Queries;
 
 /// <summary>
@@ -11,6 +13,7 @@ public class ObservableQueryHubMessage
     /// <summary>
     /// Gets or sets the type of message.
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<ObservableQueryHubMessageType>))]
     public ObservableQueryHubMessageType Type { get; set; }
 
     /// <summary>

--- a/Source/DotNET/Arc.Core/Queries/WebSocketMessage.cs
+++ b/Source/DotNET/Arc.Core/Queries/WebSocketMessage.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace Cratis.Arc.Queries;
 
 /// <summary>
@@ -11,6 +13,7 @@ public class WebSocketMessage
     /// <summary>
     /// Gets or sets the type of message.
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<WebSocketMessageType>))]
     public WebSocketMessageType Type { get; set; }
 
     /// <summary>

--- a/Source/DotNET/EntityFrameworkCore.Specs/Integration/TestWebSocketClient.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Integration/TestWebSocketClient.cs
@@ -224,8 +224,7 @@ public class TestWebSocketClient : IDisposable
                     {
                         var message = JsonSerializer.Deserialize<WebSocketDataMessage>(json, _jsonOptions);
 
-                        // Type 0 = Data (the enum is serialized as integer by Cratis.Json EnumConverterFactory)
-                        if (message?.Type == 0 && message.Data is not null)
+                        if (message?.Type == Cratis.Arc.Queries.WebSocketMessageType.Data && message.Data is not null)
                         {
                             // Parse the nested data structure using JsonElement
                             var dataElement = message.Data.Value;
@@ -267,7 +266,7 @@ public class TestWebSocketClient : IDisposable
     /// </summary>
     class WebSocketDataMessage
     {
-        public int? Type { get; set; }
+        public Cratis.Arc.Queries.WebSocketMessageType? Type { get; set; }
         public JsonElement? Data { get; set; }
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/arc-bootstrap.js
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/arc-bootstrap.js
@@ -16,6 +16,20 @@
         globalThis.__write_to_file('[ArcBootstrap] LOADING for the first time');
     }
 
+    // Console shim for environments where console is not natively available (e.g., ClearScript V8).
+    // Without this, bare console.log/error calls inside the module loader throw ReferenceError,
+    // which causes @cratis/fundamentals to be only partially cached — leaving exports like `field`
+    // missing, which in turn causes "TypeError: (0, fundamentals_1.field) is not a function".
+    if (!globalThis.console) {
+        globalThis.console = {
+            log: function() {},
+            warn: function() {},
+            error: function() {},
+            info: function() {},
+            debug: function() {}
+        };
+    }
+
     // Node.js process shim (required by some modules)
     if (!globalThis.process) {
         globalThis.process = {
@@ -572,4 +586,17 @@
         loadingModules: loadingModules,
         require: globalThis.require
     };
+
+    // Pre-load @cratis/fundamentals so the fully-populated module (including the `field`
+    // decorator export) is in the module cache before any generated TypeScript type code runs.
+    // TypeScript 6 emits separate require() calls for each import statement from the same
+    // module. The second call must hit a fully-populated cache entry — not a partial one that
+    // was interrupted by a missing console or other environment issue during the first load.
+    try {
+        loadModule('node_modules/@cratis/fundamentals/dist/cjs/index.js');
+    } catch (e) {
+        if (globalThis.__write_to_file) {
+            globalThis.__write_to_file('[ArcBootstrap] Failed to pre-load @cratis/fundamentals: ' + (e && e.message));
+        }
+    }
 })();

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_creating_instance.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_creating_instance.ts
@@ -6,7 +6,8 @@ import { render, act } from '@testing-library/react';
 import { useObservableQuery } from '../useObservableQuery';
 import { FakeObservableQuery } from './FakeObservableQuery';
 import { ArcContext, ArcConfiguration } from '../../ArcContext';
-import { QueryResult } from '@cratis/arc/queries';
+import { QueryResult, QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -42,9 +43,13 @@ describe('when creating instance', () => {
 
         render(
             React.createElement(
-                ArcContext.Provider,
-                { value: config },
-                React.createElement(TestComponent)
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
             )
         );
 
@@ -67,9 +72,13 @@ describe('when creating instance', () => {
 
         render(
             React.createElement(
-                ArcContext.Provider,
-                { value: config },
-                React.createElement(TestComponent)
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
             )
         );
 
@@ -95,3 +104,4 @@ describe('when creating instance', () => {
         capturedIsPerformingAfterResponse!.should.be.false;
     });
 });
+

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_initial_data_is_default_value.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_initial_data_is_default_value.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useObservableQuery } from '../useObservableQuery';
+import { FakeObservableQuery } from './FakeObservableQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when initial data is default value', () => {
+    let capturedData: unknown = undefined;
+    let renderCount = 0;
+
+    beforeEach(() => {
+        FakeObservableQuery.reset();
+        capturedData = undefined;
+        renderCount = 0;
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    it('should have data as empty array for enumerable query before first response', () => {
+        const TestComponent = () => {
+            const [result] = useObservableQuery(FakeObservableQuery);
+            renderCount++;
+
+            if (renderCount === 1) {
+                capturedData = result.data;
+            }
+
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        (capturedData as unknown[]).should.deep.equal([]);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/for_useQuery/when_initial_data_is_default_value.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useQuery/when_initial_data_is_default_value.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
+import { useQuery } from '../useQuery';
+import { FakeQuery } from './FakeQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { createFetchHelper } from '@cratis/arc/helpers/fetchHelper';
+import { QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when initial data is default value', () => {
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+    let capturedData: unknown = undefined;
+    let renderCount = 0;
+
+    beforeEach(() => {
+        fetchHelper = createFetchHelper();
+        const fetchStub = fetchHelper.stubFetch();
+        fetchStub.resolves({
+            json: async () => ({ data: [], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, validationResults: [], exceptionMessages: [], exceptionStackTrace: '', paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 } })
+        } as Response);
+        capturedData = undefined;
+        renderCount = 0;
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    it('should have data as empty array for enumerable query before first response', () => {
+        const TestComponent = () => {
+            const [result] = useQuery(FakeQuery);
+            renderCount++;
+
+            if (renderCount === 1) {
+                capturedData = result.data;
+            }
+
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        (capturedData as unknown[]).should.deep.equal([]);
+    });
+});

--- a/Source/JavaScript/Arc/queries/ObservableQueryConnection.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryConnection.ts
@@ -169,8 +169,9 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
             if (message.type === WebSocketMessageType.Pong) {
                 this.handlePong(message);
             } else if (message.type === WebSocketMessageType.Data || !message.type) {
-                // For backward compatibility, treat messages without a type as data messages
-                const data = message.data ?? message;
+                // For new-style messages (type === 'Data') the query result is wrapped in message.data.
+                // For legacy/backward-compatible messages (no type) the entire message IS the query result.
+                const data = message.type === WebSocketMessageType.Data ? message.data : message;
                 dataReceived(data as QueryResult<TDataType>);
             }
         } catch (error) {

--- a/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
@@ -153,7 +153,16 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
         this._policy.cancel();
         this._keepAlive.stop();
         this.clearConnectTimeout();
-        this._eventSource?.close();
+        if (this._eventSource) {
+            // Detach all handlers BEFORE closing so that the async onerror / onmessage
+            // events that fire after close() cannot observe the new _disconnected=false
+            // state set by an immediately following ensureConnected() call. Without this,
+            // a stale onerror triggers an unintended reconnect with exponential back-off.
+            this._eventSource.onopen = null;
+            this._eventSource.onmessage = null;
+            this._eventSource.onerror = null;
+            this._eventSource.close();
+        }
         this._eventSource = undefined;
         this._connectionId = undefined;
     }

--- a/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
@@ -175,7 +175,18 @@ export class WebSocketHubConnection {
         this._disconnected = true;
         this._keepAlive.stop();
         this._policy.cancel();
-        this._socket?.close();
+        if (this._socket) {
+            // Detach all handlers BEFORE closing so that the async onclose event cannot
+            // fire after a new subscription has reset _disconnected to false and opened a
+            // fresh socket. Without this, the stale onclose triggers an unintended
+            // reconnect via the back-off policy, causing a 1-10 second delay before the
+            // new page's queries receive their first data.
+            this._socket.onopen = null;
+            this._socket.onclose = null;
+            this._socket.onerror = null;
+            this._socket.onmessage = null;
+            this._socket.close();
+        }
         this._socket = undefined;
     }
 

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_websocket.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_websocket.ts
@@ -31,13 +31,13 @@ export class an_observable_query_connection_with_websocket {
             readyState: WebSocket.OPEN,
         };
 
-        const self = this;
+        const fakeWebSocket = this.fakeWebSocket;
         const FakeWebSocketClass = function (this: any) {
-            self.fakeWebSocket.onopen = null;
-            self.fakeWebSocket.onclose = null;
-            self.fakeWebSocket.onerror = null;
-            self.fakeWebSocket.onmessage = null;
-            return self.fakeWebSocket;
+            fakeWebSocket.onopen = null;
+            fakeWebSocket.onclose = null;
+            fakeWebSocket.onerror = null;
+            fakeWebSocket.onmessage = null;
+            return fakeWebSocket;
         };
         (globalThis as any)['WebSocket'] = FakeWebSocketClass;
 

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_websocket.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_websocket.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { ObservableQueryConnection } from '../../ObservableQueryConnection';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type FakeWebSocket = {
+    onopen: (() => void) | null;
+    onclose: (() => void) | null;
+    onerror: ((error: unknown) => void) | null;
+    onmessage: ((event: { data: string }) => void) | null;
+    close: sinon.SinonStub;
+    send: sinon.SinonStub;
+    readyState: number;
+};
+
+export class an_observable_query_connection_with_websocket {
+    connection: ObservableQueryConnection<unknown>;
+    fakeWebSocket!: FakeWebSocket;
+
+    constructor() {
+        this.fakeWebSocket = {
+            onopen: null,
+            onclose: null,
+            onerror: null,
+            onmessage: null,
+            close: sinon.stub(),
+            send: sinon.stub(),
+            readyState: WebSocket.OPEN,
+        };
+
+        const self = this;
+        const FakeWebSocketClass = function (this: any) {
+            self.fakeWebSocket.onopen = null;
+            self.fakeWebSocket.onclose = null;
+            self.fakeWebSocket.onerror = null;
+            self.fakeWebSocket.onmessage = null;
+            return self.fakeWebSocket;
+        };
+        (globalThis as any)['WebSocket'] = FakeWebSocketClass;
+
+        this.connection = new ObservableQueryConnection<unknown>(
+            new URL('https://example.com/api/test'),
+            'test-microservice'
+        );
+    }
+
+    simulateMessage(payload: object): void {
+        this.fakeWebSocket.onmessage?.({ data: JSON.stringify(payload) });
+    }
+
+    simulateOpen(): void {
+        this.fakeWebSocket.readyState = WebSocket.OPEN;
+        this.fakeWebSocket.onopen?.();
+    }
+}

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_data_message_with_type.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_data_message_with_type.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../given';
+import { an_observable_query_connection_with_websocket } from './given/an_observable_query_connection_with_websocket';
+import { QueryResult } from '../QueryResult';
+import { WebSocketMessageType } from '../WebSocketMessage';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('when receiving data message with Data type', given(an_observable_query_connection_with_websocket, context => {
+    const innerQueryResult = {
+        data: [{ id: '2', name: 'Item' }],
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+    };
+
+    let receivedData: QueryResult<unknown> | null = null;
+
+    beforeEach(() => {
+        receivedData = null;
+        context.connection.connect((data) => {
+            receivedData = data as QueryResult<unknown>;
+        });
+        context.simulateMessage({
+            type: WebSocketMessageType.Data,
+            data: innerQueryResult
+        });
+    });
+
+    it('should pass the inner data payload as the query result', () => {
+        receivedData!.should.not.be.null;
+    });
+
+    it('should have the correct data field', () => {
+        (receivedData as any)!.data.should.deep.equal(innerQueryResult.data);
+    });
+
+    it('should have the correct isSuccess field', () => {
+        (receivedData as any)!.isSuccess.should.equal(true);
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_legacy_data_message.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_legacy_data_message.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../given';
+import { an_observable_query_connection_with_websocket } from './given/an_observable_query_connection_with_websocket';
+import { QueryResult } from '../QueryResult';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('when receiving legacy data message without type field', given(an_observable_query_connection_with_websocket, context => {
+    const queryResult = {
+        data: [{ id: '1', name: 'Test' }],
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+    };
+
+    let receivedData: QueryResult<unknown> | null = null;
+
+    beforeEach(() => {
+        receivedData = null;
+        context.connection.connect((data) => {
+            receivedData = data as QueryResult<unknown>;
+        });
+        context.simulateMessage(queryResult);
+    });
+
+    it('should pass the entire message as the query result', () => {
+        receivedData!.should.not.be.null;
+    });
+
+    it('should have the correct data field', () => {
+        (receivedData as any)!.data.should.deep.equal(queryResult.data);
+    });
+
+    it('should have the correct isSuccess field', () => {
+        (receivedData as any)!.isSuccess.should.equal(true);
+    });
+
+    it('should have the correct paging field', () => {
+        (receivedData as any)!.paging.should.deep.equal(queryResult.paging);
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_unsubscribing/nulls_event_source_handlers_before_closing.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_unsubscribing/nulls_event_source_handlers_before_closing.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { a_server_sent_event_hub_connection } from '../given/a_server_sent_event_hub_connection';
+import { given } from '../../../given';
+import { HubMessageType } from '../../WebSocketHubConnection';
+
+describe('when unsubscribing the only query, nulls event source handlers before closing the event source', given(a_server_sent_event_hub_connection, context => {
+    let handlersWereNullWhenClosed: { onopen: boolean; onmessage: boolean; onerror: boolean };
+
+    beforeEach(async () => {
+        context.setup();
+        context.connection.subscribe('q1', { queryName: 'MyQuery' }, sinon.stub());
+        context.simulateOpen();
+        context.simulateMessage({ type: HubMessageType.Connected, payload: 'conn-abc' });
+
+        handlersWereNullWhenClosed = { onopen: false, onmessage: false, onerror: false };
+        context.fakeEventSource.close.callsFake(() => {
+            handlersWereNullWhenClosed.onopen = context.fakeEventSource.onopen === null;
+            handlersWereNullWhenClosed.onmessage = context.fakeEventSource.onmessage === null;
+            handlersWereNullWhenClosed.onerror = context.fakeEventSource.onerror === null;
+        });
+
+        context.connection.unsubscribe('q1');
+
+        // Allow the micro-task queue to drain so the async fetch completes.
+        await Promise.resolve();
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should have nulled onopen before calling eventSource.close()', () => handlersWereNullWhenClosed.onopen.should.be.true);
+    it('should have nulled onmessage before calling eventSource.close()', () => handlersWereNullWhenClosed.onmessage.should.be.true);
+    it('should have nulled onerror before calling eventSource.close()', () => handlersWereNullWhenClosed.onerror.should.be.true);
+}));

--- a/Source/JavaScript/Arc/queries/for_WebSocketHubConnection/when_unsubscribing/nulls_socket_handlers_before_closing.ts
+++ b/Source/JavaScript/Arc/queries/for_WebSocketHubConnection/when_unsubscribing/nulls_socket_handlers_before_closing.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { a_web_socket_hub_connection } from '../given/a_web_socket_hub_connection';
+import { given } from '../../../given';
+
+describe('when unsubscribing the only query, nulls socket handlers before closing the socket', given(a_web_socket_hub_connection, context => {
+    let handlersWereNullWhenClosed: { onopen: boolean; onclose: boolean; onerror: boolean; onmessage: boolean };
+
+    beforeEach(() => {
+        context.setup();
+        context.connection.subscribe('q1', { queryName: 'MyQuery' }, sinon.stub());
+        context.simulateOpen();
+
+        handlersWereNullWhenClosed = { onopen: false, onclose: false, onerror: false, onmessage: false };
+        context.fakeSocket.close.callsFake(() => {
+            handlersWereNullWhenClosed.onopen = context.fakeSocket.onopen === null;
+            handlersWereNullWhenClosed.onclose = context.fakeSocket.onclose === null;
+            handlersWereNullWhenClosed.onerror = context.fakeSocket.onerror === null;
+            handlersWereNullWhenClosed.onmessage = context.fakeSocket.onmessage === null;
+        });
+
+        context.connection.unsubscribe('q1');
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should have nulled onopen before calling socket.close()', () => handlersWereNullWhenClosed.onopen.should.be.true);
+    it('should have nulled onclose before calling socket.close()', () => handlersWereNullWhenClosed.onclose.should.be.true);
+    it('should have nulled onerror before calling socket.close()', () => handlersWereNullWhenClosed.onerror.should.be.true);
+    it('should have nulled onmessage before calling socket.close()', () => handlersWereNullWhenClosed.onmessage.should.be.true);
+}));


### PR DESCRIPTION
## Fixed

- `ObservableQueryConnection` now correctly unwraps typed `Data` messages from the wrapper envelope and continues to pass legacy untyped messages through as-is.
- `WebSocketHubConnection.close()` nulls all socket handlers before calling `socket.close()`, preventing a stale `onclose` event from triggering back-off reconnect on the new page's connection.
- `ServerSentEventHubConnection.close()` nulls all EventSource handlers before calling `eventSource.close()` — same race as the WebSocket transport.
- `ObservableQueryDemultiplexer.SubscribeToSubjectOfType<T>` wraps the Rx subscription in `Disposable.Create` so disposal calls both `rxSubscription.Dispose()` and `subject.OnCompleted()`, cancelling the backing `Watch()` task and releasing the database connection. Previously one connection leaked per observed query per navigation, eventually exhausting the pool (`MongoWaitQueueFullException`).
- `TestWebSocketClient` in the EFCore integration specs now deserializes the WebSocket message type as `WebSocketMessageType` enum instead of `int?`. The enum serialization format changed from integer to string in this PR; the test client was still matching on `== 0`, silently dropping all messages and causing all 7 `for_WebSocketObservableQueries` specs to fail.

## Added

- Vite configuration guide documenting that the `/.cratis` proxy rule requires `ws: true` for the observable query WebSocket hub.
- Specs for both typed and legacy WebSocket message shapes in `ObservableQueryConnection`.
- Specs asserting `useQuery` and `useObservableQuery` return an empty array as the initial data value.
- Spec asserting `WebSocketHubConnection` nulls all socket handlers before closing.
- Spec asserting `ServerSentEventHubConnection` nulls all EventSource handlers before closing.

## Changed

- `when_creating_instance` spec for `useObservableQuery` wraps the render tree in a `QueryInstanceCacheContext.Provider` as required by the current hook implementation.
- Observable Query Multiplexing docs link to the new Vite configuration page.