### PR TITLE
Add validation specs for nullable properties in commands

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/given/a_data_annotation_validation_filter.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/given/a_data_annotation_validation_filter.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.Filters.for_DataAnnotationValidationFilter.given;
+
+public class a_data_annotation_validation_filter : Specification
+{
+    protected DataAnnotationValidationFilter _filter;
+    protected CommandContext _context;
+    protected CorrelationId _correlationId;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _filter = new DataAnnotationValidationFilter();
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_nullable_property_without_required_attribute.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_nullable_property_without_required_attribute.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.Filters.for_DataAnnotationValidationFilter.when_validating;
+
+public class with_nullable_property_without_required_attribute : given.a_data_annotation_validation_filter
+{
+    CommandResult _result;
+
+    void Establish() =>
+        _context = new CommandContext(_correlationId, typeof(CommandWithNullableProperty), new CommandWithNullableProperty("Alice", null), [], new());
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_not_have_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+
+    record CommandWithNullableProperty(string Name, string? OptionalDescription);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_required_property_that_is_null.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_required_property_that_is_null.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Cratis.Arc.Commands.Filters.for_DataAnnotationValidationFilter.when_validating;
+
+public class with_required_property_that_is_null : given.a_data_annotation_validation_filter
+{
+    CommandResult _result;
+
+    void Establish() =>
+        _context = new CommandContext(_correlationId, typeof(CommandWithRequiredProperty), new CommandWithRequiredProperty(null!), [], new());
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_return_successful_result() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_have_one_validation_result() => _result.ValidationResults.Count().ShouldEqual(1);
+    [Fact] void should_have_validation_result_for_the_required_property() => _result.ValidationResults.First().Members.ShouldContain(nameof(CommandWithRequiredProperty.Name));
+
+    record CommandWithRequiredProperty([property: Required] string Name);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_valid_command.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_DataAnnotationValidationFilter/when_validating/with_valid_command.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.Filters.for_DataAnnotationValidationFilter.when_validating;
+
+public class with_valid_command : given.a_data_annotation_validation_filter
+{
+    CommandResult _result;
+
+    void Establish() =>
+        _context = new CommandContext(_correlationId, typeof(ValidCommand), new ValidCommand("Alice", 30), [], new());
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_not_have_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+
+    record ValidCommand(string Name, int Age);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_nullable_property_and_no_validator.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_nullable_property_and_no_validator.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_command_having_nullable_property_and_no_validator : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new CommandWithNullableProperty("ValidName", null);
+        _context = new CommandContext(_correlationId, typeof(CommandWithNullableProperty), command, [], new());
+
+        _discoverableValidators.TryGet(Arg.Any<Type>(), out Arg.Any<IValidator>()).Returns(false);
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_not_have_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+
+    record CommandWithNullableProperty(string Name, string? OptionalDescription);
+}


### PR DESCRIPTION
# Summary

Introduce specifications for validating nullable properties in commands using both FluentValidation and DataAnnotations.

## Added

- Specifications for nullable property validation behavior in DataAnnotationValidationFilter.
- Specifications for required property validation in DataAnnotationValidationFilter.
- Specifications for valid command scenarios in DataAnnotationValidationFilter.
- Specifications for nullable property validation behavior in FluentValidationFilter.

