### PR TITLE
Fix query infrastructure regressions breaking observable queries

### DIFF
--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.WebSockets;
-using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using Cratis.Arc.Http;
@@ -520,7 +519,7 @@ public class ObservableQueryDemultiplexer(
         Func<string, string, Task> onError,
         CancellationToken token)
     {
-        var rxSubscription = subject.Subscribe(
+        return subject.Subscribe(
             data =>
             {
                 if (token.IsCancellationRequested)
@@ -563,16 +562,6 @@ public class ObservableQueryDemultiplexer(
                 logger.SubscriptionError(queryId, error);
                 _ = onError(queryId, error.Message);
             });
-
-        // Disposing the Rx subscription only removes this observer from the subject — it does NOT
-        // signal completion to the subject, so the backing MongoDB change stream Watch() task would
-        // keep running and leak a connection indefinitely. Calling OnCompleted() here ensures that
-        // the change stream CancellationTokenSource in Observe() is cancelled immediately.
-        return Disposable.Create(() =>
-        {
-            rxSubscription.Dispose();
-            subject.OnCompleted();
-        });
     }
 
     async Task StreamAsyncEnumerable(

--- a/Source/JavaScript/Arc/queries/QueryResult.ts
+++ b/Source/JavaScript/Arc/queries/QueryResult.ts
@@ -130,7 +130,7 @@ export class QueryResult<TDataType = object> implements IQueryResult<TDataType> 
 
             this.data = data as TDataType;
         } else {
-            this.data = (enumerable ? [] : {}) as TDataType;
+            this.data = (enumerable ? [] : null) as TDataType;
         }
     }
 

--- a/Source/JavaScript/Arc/queries/QueryResultWithState.ts
+++ b/Source/JavaScript/Arc/queries/QueryResultWithState.ts
@@ -13,7 +13,7 @@ export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> 
 
     static empty<TDataType>(defaultValue: TDataType): QueryResultWithState<TDataType> {
         return new QueryResultWithState(
-            defaultValue ?? ([] as unknown as TDataType),
+            defaultValue,
             PagingInfo.noPaging,
             true,
             true,
@@ -27,7 +27,7 @@ export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> 
 
     static initial<TDataType>(defaultValue: TDataType): QueryResultWithState<TDataType> {
         return new QueryResultWithState(
-            defaultValue ?? ([] as unknown as TDataType),
+            defaultValue,
             PagingInfo.noPaging,
             true,
             true,
@@ -81,7 +81,7 @@ export class QueryResultWithState<TDataType> implements IQueryResult<TDataType> 
      */
     static fromQueryResult<TDataType>(queryResult: QueryResult<TDataType>, isPerforming: boolean) {
         return new QueryResultWithState<TDataType>(
-            queryResult.data ?? ([] as unknown as TDataType),
+            queryResult.data,
             queryResult.paging,
             queryResult.isSuccess,
             queryResult.isAuthorized,

--- a/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
@@ -12,17 +12,17 @@ import { QueryResult } from './QueryResult';
 
 /**
  * Message types matching the backend {@link ObservableQueryHubMessageType} enum.
- * Serialized as integers by the Cratis JSON configuration.
+ * Serialized as strings by the JsonStringEnumConverter on the server.
  */
 export enum HubMessageType {
-    Subscribe = 0,
-    Unsubscribe = 1,
-    QueryResult = 2,
-    Unauthorized = 3,
-    Error = 4,
-    Ping = 5,
-    Pong = 6,
-    Connected = 7,
+    Subscribe = 'Subscribe',
+    Unsubscribe = 'Unsubscribe',
+    QueryResult = 'QueryResult',
+    Unauthorized = 'Unauthorized',
+    Error = 'Error',
+    Ping = 'Ping',
+    Pong = 'Pong',
+    Connected = 'Connected',
 }
 
 /**

--- a/Source/JavaScript/Arc/queries/for_QueryResult/when_asking_has_data/and_it_is_null_for_non_enumerable.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResult/when_asking_has_data/and_it_is_null_for_non_enumerable.ts
@@ -23,7 +23,6 @@ describe('when asking has data and it is null for non-enumerable query', () => {
         data: null
     }, Object, false);
 
-    it('should consider to have data since empty object is truthy', () => queryResult.hasData.should.be.true);
-    it('should have data that is not null', () => (queryResult.data !== null).should.be.true);
-    it('should have data that is an empty object', () => queryResult.data.should.deep.equal({}));
+    it('should not have data since null data means no data', () => queryResult.hasData.should.be.false);
+    it('should have data that is null', () => (queryResult.data === null).should.be.true);
 });

--- a/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_empty/with_null_default_value.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_empty/with_null_default_value.ts
@@ -6,8 +6,7 @@ import { QueryResultWithState } from '../../QueryResultWithState';
 describe('when creating empty with null default value', () => {
     const result = QueryResultWithState.empty<string[]>(null as unknown as string[]);
 
-    it('should have data that is not undefined', () => (result.data !== undefined).should.be.true);
-    it('should have data that is not null', () => (result.data !== null).should.be.true);
+    it('should have null data since null defaultValue is passed through', () => (result.data === null).should.be.true);
     it('should not have data', () => result.hasData.should.be.false);
     it('should not be performing', () => result.isPerforming.should.be.false);
 });

--- a/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_empty/with_undefined_default_value.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_empty/with_undefined_default_value.ts
@@ -6,8 +6,7 @@ import { QueryResultWithState } from '../../QueryResultWithState';
 describe('when creating empty with undefined default value', () => {
     const result = QueryResultWithState.empty<string[]>(undefined as unknown as string[]);
 
-    it('should have data that is not undefined', () => (result.data !== undefined).should.be.true);
-    it('should have data that is not null', () => (result.data !== null).should.be.true);
+    it('should have undefined data since undefined defaultValue is passed through', () => (result.data === undefined).should.be.true);
     it('should not have data', () => result.hasData.should.be.false);
     it('should not be performing', () => result.isPerforming.should.be.false);
 });

--- a/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_initial/with_null_default_value.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_initial/with_null_default_value.ts
@@ -6,8 +6,7 @@ import { QueryResultWithState } from '../../QueryResultWithState';
 describe('when creating initial with null default value', () => {
     const result = QueryResultWithState.initial<string[]>(null as unknown as string[]);
 
-    it('should have data that is not undefined', () => (result.data !== undefined).should.be.true);
-    it('should have data that is not null', () => (result.data !== null).should.be.true);
+    it('should have null data since null defaultValue is passed through', () => (result.data === null).should.be.true);
     it('should not have data', () => result.hasData.should.be.false);
     it('should be performing', () => result.isPerforming.should.be.true);
 });

--- a/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_initial/with_undefined_default_value.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResultWithState/when_creating_initial/with_undefined_default_value.ts
@@ -6,8 +6,7 @@ import { QueryResultWithState } from '../../QueryResultWithState';
 describe('when creating initial with undefined default value', () => {
     const result = QueryResultWithState.initial<string[]>(undefined as unknown as string[]);
 
-    it('should have data that is not undefined', () => (result.data !== undefined).should.be.true);
-    it('should have data that is not null', () => (result.data !== null).should.be.true);
+    it('should have undefined data since undefined defaultValue is passed through', () => (result.data === undefined).should.be.true);
     it('should not have data', () => result.hasData.should.be.false);
     it('should be performing', () => result.isPerforming.should.be.true);
 });


### PR DESCRIPTION
## Fixed

- Fix subscriber disconnect completing shared observable subjects in the hub demultiplexer — after the first client disconnected, all subsequent hub subscriptions failed with `Sequence contains no elements`
- Fix `HubMessageType` TypeScript enum using integer values instead of strings, causing all inbound hub message type comparisons to fail silently
- Fix `QueryResult` and `QueryResultWithState` replacing `null`/`undefined` data with empty objects/arrays, causing `hasData` to return `true` when there was no data