### PR TITLE
Silence logging in SQL Server spec given contexts

### DIFF
--- a/Source/DotNET/EntityFrameworkCore.SqlServer.Specs/Observe/for_DbSetObserveExtensions/given/a_sql_server_observe_context.cs
+++ b/Source/DotNET/EntityFrameworkCore.SqlServer.Specs/Observe/for_DbSetObserveExtensions/given/a_sql_server_observe_context.cs
@@ -46,8 +46,7 @@ public class a_sql_server_observe_context(SqlServerFixture fixture) : Specificat
         // Set up service collection
         var services = new ServiceCollection();
         services.AddLogging(builder => builder
-            .SetMinimumLevel(LogLevel.Warning)
-            .AddConsole());
+            .SetMinimumLevel(LogLevel.None));
         services.AddEntityFrameworkCoreObservation();
 
         // Use a mocked QueryContextManager that returns the _queryContext field

--- a/Source/DotNET/EntityFrameworkCore.SqlServer.Specs/Observe/for_DbSetObserveExtensions/given/a_sql_server_schema_observe_context.cs
+++ b/Source/DotNET/EntityFrameworkCore.SqlServer.Specs/Observe/for_DbSetObserveExtensions/given/a_sql_server_schema_observe_context.cs
@@ -43,8 +43,7 @@ public class a_sql_server_schema_observe_context(SqlServerFixture fixture) : Spe
 
         var services = new ServiceCollection();
         services.AddLogging(builder => builder
-            .SetMinimumLevel(LogLevel.Warning)
-            .AddConsole());
+            .SetMinimumLevel(LogLevel.None));
         services.AddEntityFrameworkCoreObservation();
 
         _queryContextManager = Substitute.For<IQueryContextManager>();


### PR DESCRIPTION
## Changed

- Set log level to `None` in SQL Server spec given contexts to suppress all console output during spec runs, including teardown connection errors caused by the Testcontainer stopping while a re-subscription task is still in flight