### PR TITLE
Add specs verifying single-item collection for observable queries

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/ObservableControllerQueries.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/ObservableControllerQueries.cs
@@ -34,6 +34,13 @@ public class ObservableControllerQueriesController(ObservableControllerQueriesSt
     public ISubject<ObservableControllerQueryItem> ObserveSingle() => _state.SingleItemSubject;
 
     /// <summary>
+    /// Gets a collection containing a single item as an observable stream.
+    /// </summary>
+    /// <returns>Observable collection with one item.</returns>
+    [HttpGet("observe/single-item-collection")]
+    public ISubject<IEnumerable<ObservableControllerQueryItem>> ObserveSingleItemCollection() => _state.SingleItemCollectionSubject;
+
+    /// <summary>
     /// Gets a single item by ID as an observable stream.
     /// </summary>
     /// <param name="id">The item ID.</param>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/ObservableControllerQueriesState.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/ObservableControllerQueriesState.cs
@@ -20,6 +20,10 @@ public class ObservableControllerQueriesState
         new ObservableControllerQueryItem { Id = new Guid(0x10000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66), Name = "Single Controller Item", Value = 42 }
     );
 
+    public BehaviorSubject<IEnumerable<ObservableControllerQueryItem>> SingleItemCollectionSubject { get; } = new([
+        new ObservableControllerQueryItem { Id = new Guid(0x10000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77), Name = "Sole Controller Item", Value = 99 }
+    ]);
+
     public Dictionary<string, BehaviorSubject<IEnumerable<ObservableControllerQueryItem>>> CategorySubjects { get; } = [];
 
     public void Reset()
@@ -32,6 +36,10 @@ public class ObservableControllerQueriesState
 
         SingleItemSubject.OnNext(
             new ObservableControllerQueryItem { Id = new Guid(0x10000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66), Name = "Single Controller Item", Value = 42 });
+
+        SingleItemCollectionSubject.OnNext([
+            new ObservableControllerQueryItem { Id = new Guid(0x10000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77), Name = "Sole Controller Item", Value = 99 }
+        ]);
 
         CategorySubjects.Clear();
     }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/when_observing_controller_single_item_collection.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ControllerBased/when_observing_controller_single_item_collection.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ObservableQueries.ControllerBased;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+
+public class when_observing_controller_single_item_collection : given.a_scenario_web_application
+{
+    ObservableQueryExecutionContext<IEnumerable<ObservableControllerQueryItem>>? _executionResult;
+
+    void Establish() => LoadControllerQueryProxy<ObservableControllerQueriesController>("ObserveSingleItemCollection");
+
+    async Task Because()
+    {
+        _executionResult = await Bridge.PerformObservableQueryViaProxyAsync<IEnumerable<ObservableControllerQueryItem>>("ObserveSingleItemCollection");
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_authorized() => _executionResult.Result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _executionResult.Result.IsValid.ShouldBeTrue();
+    [Fact] void should_have_data() => _executionResult.Result.Data.ShouldNotBeNull();
+    [Fact] void should_have_data_as_collection() => _executionResult.LatestData.ShouldNotBeNull();
+    [Fact] void should_have_one_item() => _executionResult.LatestData.Count().ShouldEqual(1);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ModelBound/ObservableReadModels.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ModelBound/ObservableReadModels.cs
@@ -52,6 +52,15 @@ public class ObservableReadModel
     }
 
     /// <summary>
+    /// Gets a collection containing a single item as an observable stream.
+    /// </summary>
+    /// <returns>Observable collection with one read model.</returns>
+    public static ISubject<IEnumerable<ObservableReadModel>> ObserveSingleItemCollection() =>
+        new BehaviorSubject<IEnumerable<ObservableReadModel>>([
+            new ObservableReadModel { Id = new Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77), Name = "Sole Observable Item", Value = 99 }
+        ]);
+
+    /// <summary>
     /// Gets a single item by ID as an observable stream.
     /// </summary>
     /// <param name="id">The ID to find.</param>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ModelBound/when_observing_single_item_collection.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ObservableQueries/ModelBound/when_observing_single_item_collection.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ObservableQueries.ModelBound;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+
+public class when_observing_single_item_collection : given.a_scenario_web_application
+{
+    ObservableQueryExecutionContext<IEnumerable<ObservableReadModel>>? _executionResult;
+
+    void Establish() => LoadQueryProxy<ObservableReadModel>("ObserveSingleItemCollection");
+
+    async Task Because()
+    {
+        _executionResult = await Bridge.PerformObservableQueryViaProxyAsync<IEnumerable<ObservableReadModel>>("ObserveSingleItemCollection");
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_authorized() => _executionResult.Result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _executionResult.Result.IsValid.ShouldBeTrue();
+    [Fact] void should_have_data() => _executionResult.Result.Data.ShouldNotBeNull();
+    [Fact] void should_have_data_as_collection() => _executionResult.LatestData.ShouldNotBeNull();
+    [Fact] void should_have_one_item() => _executionResult.LatestData.Count().ShouldEqual(1);
+}

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_server_returns_single_item_for_collection.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_server_returns_single_item_for_collection.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useObservableQuery } from '../useObservableQuery';
+import { FakeObservableQuery } from './FakeObservableQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryResult, QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when server returns single item for collection', () => {
+    let capturedData: unknown = undefined;
+    let renderCount = 0;
+
+    beforeEach(() => {
+        FakeObservableQuery.reset();
+        capturedData = undefined;
+        renderCount = 0;
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    it('should have data as an array', async () => {
+        const TestComponent = () => {
+            const [result] = useObservableQuery(FakeObservableQuery);
+            renderCount++;
+
+            if (renderCount === 2) {
+                capturedData = result.data;
+            }
+
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        const callback = FakeObservableQuery.subscribeCallbacks[0];
+
+        await act(async () => {
+            callback(new QueryResult({
+                data: [{ id: '1', name: 'Single Item' }],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+            }, Object, true));
+        });
+
+        Array.isArray(capturedData).should.be.true;
+        (capturedData as unknown[]).should.have.lengthOf(1);
+    });
+});

--- a/Source/JavaScript/Arc/queries/for_QueryResult/when_data_is_single_item_for_enumerable/and_it_is_an_array.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResult/when_data_is_single_item_for_enumerable/and_it_is_an_array.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { QueryResult } from '../../QueryResult';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('when data is single item for enumerable and it is an array', () => {
+    const queryResult = new QueryResult<any>({
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: {
+            totalItems: 1,
+            totalPages: 1,
+            page: 0,
+            size: 0
+        },
+        validationResults: [],
+        data: [{ id: '1', name: 'Single Item' }]
+    }, Object, true);
+
+    it('should have data as an array', () => Array.isArray(queryResult.data).should.be.true);
+    it('should have one item', () => (queryResult.data as any[]).length.should.equal(1));
+});


### PR DESCRIPTION
## Added

- Spec for `QueryResult` (Arc JS) verifying that a single-element array response for an enumerable query is kept as an array
- Spec for `useObservableQuery` (Arc.React) verifying the hook data is an array when the server returns a single-item collection
- Scenario specs for ProxyGenerator ControllerBased and ModelBound verifying a collection observable query with one item is treated as a collection with count 1