### PR TITLE
Register identity authentication in AddCratis

### DIFF
--- a/Source/DotNET/Cratis/WebApplicationBuilderExtensions.cs
+++ b/Source/DotNET/Cratis/WebApplicationBuilderExtensions.cs
@@ -37,6 +37,8 @@ public static class WebApplicationBuilderExtensions
                 arcBuilder.WithChronicle(configureChronicleOptions, configureChronicleBuilder);
             });
 
+        builder.Services.AddMicrosoftIdentityPlatformIdentityAuthentication();
+
         return builder;
     }
 }


### PR DESCRIPTION
## Fixed
- Register Microsoft identity platform authentication from AddCratis so app setup includes identity by default
