### PR TITLE
Feat/compile time query metadata registration

### DIFF
--- a/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
+++ b/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cratis.Arc.Generators;
+
+/// <summary>
+/// Incremental source generator that generates compile-time query metadata for read models.
+/// </summary>
+/// <remarks>
+/// For each assembly that contains types decorated with <c>[ReadModel]</c>, this generator
+/// produces a generated initializer that registers fully-qualified query names with their read
+/// model <c>Type</c> in <c>QueryMetadataRegistry</c> at assembly-load time, enabling AOT-safe
+/// query lookup without runtime type scanning.
+/// </remarks>
+[Generator]
+public class QueryMetadataGenerator : IIncrementalGenerator
+{
+    const string ReadModelAttributeFullName = "Cratis.Arc.Queries.ModelBound.ReadModelAttribute";
+
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var readModelProvider = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (node, _) => node is TypeDeclarationSyntax typeDecl && typeDecl.AttributeLists.Count > 0,
+                transform: static (ctx, _) => GetReadModelInfo(ctx))
+            .Where(static info => info is not null)
+            .Select(static (info, _) => info!)
+            .Collect();
+
+        context.RegisterSourceOutput(readModelProvider, static (spc, readModels) =>
+            GenerateSource(spc, readModels));
+    }
+
+    static ReadModelInfo? GetReadModelInfo(GeneratorSyntaxContext context)
+    {
+        var typeDecl = (TypeDeclarationSyntax)context.Node;
+        if (context.SemanticModel.GetDeclaredSymbol(typeDecl) is not INamedTypeSymbol typeSymbol)
+        {
+            return null;
+        }
+
+        if (!HasReadModelAttribute(typeSymbol))
+        {
+            return null;
+        }
+
+        var queryMethods = typeSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(m =>
+                m.MethodKind == MethodKind.Ordinary &&
+                m.IsStatic &&
+                m.DeclaredAccessibility == Accessibility.Public &&
+                IsValidQueryMethod(m, typeSymbol))
+            .Select(m => m.Name)
+            .ToList();
+
+        if (queryMethods.Count == 0)
+        {
+            return null;
+        }
+
+        return new ReadModelInfo(
+            typeSymbol.ToDisplayString(),
+            queryMethods);
+    }
+
+    static bool HasReadModelAttribute(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetAttributes().Any(a =>
+            string.Equals(a.AttributeClass?.ToDisplayString(), ReadModelAttributeFullName, StringComparison.Ordinal));
+
+    static bool IsValidQueryMethod(IMethodSymbol method, INamedTypeSymbol readModelType)
+    {
+        var returnType = method.ReturnType;
+
+        // Unwrap Task<T>
+        if (returnType is INamedTypeSymbol taskType &&
+            string.Equals(taskType.Name, "Task", StringComparison.Ordinal) &&
+            taskType.TypeArguments.Length == 1 &&
+            string.Equals(taskType.ContainingNamespace.ToDisplayString(), "System.Threading.Tasks", StringComparison.Ordinal))
+        {
+            returnType = taskType.TypeArguments[0];
+        }
+
+        if (SymbolEqualityComparer.Default.Equals(returnType, readModelType))
+        {
+            return true;
+        }
+
+        if (IsCollectionOfType(returnType, readModelType))
+        {
+            return true;
+        }
+
+        if (returnType is INamedTypeSymbol asyncEnumerable &&
+            string.Equals(asyncEnumerable.Name, "IAsyncEnumerable", StringComparison.Ordinal) &&
+            asyncEnumerable.TypeArguments.Length == 1 &&
+            SymbolEqualityComparer.Default.Equals(asyncEnumerable.TypeArguments[0], readModelType))
+        {
+            return true;
+        }
+
+        if (returnType is INamedTypeSymbol subject &&
+            string.Equals(subject.Name, "ISubject", StringComparison.Ordinal) &&
+            subject.TypeArguments.Length == 1)
+        {
+            var subjectArg = subject.TypeArguments[0];
+            if (SymbolEqualityComparer.Default.Equals(subjectArg, readModelType) ||
+                IsCollectionOfType(subjectArg, readModelType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsCollectionOfType(ITypeSymbol type, INamedTypeSymbol elementType)
+    {
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return SymbolEqualityComparer.Default.Equals(arrayType.ElementType, elementType);
+        }
+
+        if (type is INamedTypeSymbol namedType)
+        {
+            if (string.Equals(namedType.Name, "IEnumerable", StringComparison.Ordinal) &&
+                namedType.TypeArguments.Length == 1 &&
+                SymbolEqualityComparer.Default.Equals(namedType.TypeArguments[0], elementType))
+            {
+                return true;
+            }
+
+            return namedType.AllInterfaces.Any(i =>
+                string.Equals(i.Name, "IEnumerable", StringComparison.Ordinal) &&
+                i.TypeArguments.Length == 1 &&
+                SymbolEqualityComparer.Default.Equals(i.TypeArguments[0], elementType));
+        }
+
+        return false;
+    }
+
+    static void GenerateSource(SourceProductionContext context, ImmutableArray<ReadModelInfo> readModels)
+    {
+        context.AddSource("CratisArcGeneratedMarker.g.cs", GenerateMarkerType());
+
+        if (readModels.IsEmpty)
+        {
+            return;
+        }
+
+        var sb = new StringBuilder()
+            .AppendLine("// <auto-generated/>")
+            .AppendLine("#pragma warning disable")
+            .AppendLine("using System;")
+            .AppendLine("using System.Runtime.CompilerServices;")
+            .AppendLine("using Cratis.Arc.Queries.ModelBound;")
+            .AppendLine()
+            .AppendLine("namespace Cratis.Arc.Queries.ModelBound.Generated;")
+            .AppendLine()
+            .AppendLine("/// <summary>")
+            .AppendLine("/// Compile-time generated query metadata registration. Do not modify.")
+            .AppendLine("/// </summary>")
+            .AppendLine("internal static class GeneratedQueryMetadata")
+            .AppendLine("{")
+            .AppendLine("    [ModuleInitializer]")
+            .AppendLine("    internal static void Initialize()")
+            .AppendLine("    {");
+
+        foreach (var readModel in readModels)
+        {
+            foreach (var method in readModel.QueryMethodNames)
+            {
+                sb.Append("        QueryMetadataRegistry.Register(\"")
+                  .Append(readModel.FullyQualifiedTypeName)
+                  .Append('.')
+                  .Append(method)
+                  .Append("\", typeof(global::")
+                  .Append(readModel.FullyQualifiedTypeName)
+                  .AppendLine("));");
+            }
+        }
+
+        sb.AppendLine("    }")
+            .AppendLine("}");
+
+        context.AddSource("GeneratedQueryMetadata.g.cs", sb.ToString());
+    }
+
+    static string GenerateMarkerType() => new StringBuilder()
+        .AppendLine("// <auto-generated/>")
+        .AppendLine("#pragma warning disable")
+        .AppendLine()
+        .AppendLine("namespace Cratis.Arc.Generated;")
+        .AppendLine()
+        .AppendLine("/// <summary>")
+        .AppendLine("/// Marker type that confirms Arc source generators have run for the assembly.")
+        .AppendLine("/// </summary>")
+        .AppendLine("public static class GeneratedMarker")
+        .AppendLine("{")
+        .AppendLine("}")
+        .ToString();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/InternalQueries.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/InternalQueries.cs
@@ -35,3 +35,18 @@ public class PublicReadModelWithInternalQuery
         return new PublicReadModelWithInternalQuery { Id = id, Value = "Internal query result" };
     }
 }
+
+/// <summary>
+/// Public read model with internal query method for testing.
+/// </summary>
+[ReadModel]
+public class PublicReadModelWithValidQuery
+{
+    public Guid Id { get; set; }
+    public string Value { get; set; } = string.Empty;
+
+    public static PublicReadModelWithValidQuery GetById(Guid id)
+    {
+        return new PublicReadModelWithValidQuery { Id = id, Value = "Valid query result" };
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/given/a_query_performer_provider_with_no_metadata.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/given/a_query_performer_provider_with_no_metadata.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.ModelBound.for_QueryPerformerProvider.given;
+
+public class a_query_performer_provider_with_no_metadata : Specification
+{
+    protected QueryPerformerProvider _provider;
+    protected ITypes _types;
+    protected IQueryMetadataRegistry _registry;
+    protected IServiceProviderIsService _serviceProviderIsService;
+    protected IAuthorizationEvaluator _authorizationEvaluator;
+
+    void Establish()
+    {
+        _types = Substitute.For<ITypes>();
+        _serviceProviderIsService = Substitute.For<IServiceProviderIsService>();
+        _authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
+
+        _registry = Substitute.For<IQueryMetadataRegistry>();
+        _registry.All.Returns(new Dictionary<string, Type>());
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_generated_metadata.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_generated_metadata.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.Queries.ModelBound.for_QueryPerformerProvider;
 
-public class when_initializing_with_internal_read_model : Specification
+public class when_initializing_with_generated_metadata : Specification
 {
     QueryPerformerProvider _provider;
     ITypes _types;
@@ -17,15 +17,19 @@ public class when_initializing_with_internal_read_model : Specification
     void Establish()
     {
         _types = Substitute.For<ITypes>();
-        _types.All.Returns([typeof(InternalReadModel)]);
         _serviceProviderIsService = Substitute.For<IServiceProviderIsService>();
         _authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
 
         _registry = Substitute.For<IQueryMetadataRegistry>();
-        _registry.All.Returns(new Dictionary<string, Type>());
+        _registry.All.Returns(
+            new Dictionary<string, Type>
+            {
+                [$"{typeof(PublicReadModelWithValidQuery).FullName}.{nameof(PublicReadModelWithValidQuery.GetById)}"] = typeof(PublicReadModelWithValidQuery)
+            });
     }
 
     void Because() => _provider = new QueryPerformerProvider(_types, _registry, _serviceProviderIsService, _authorizationEvaluator);
 
-    [Fact] void should_have_no_performers() => _provider.Performers.Count().ShouldEqual(0);
+    [Fact] void should_have_one_performer() => _provider.Performers.Count().ShouldEqual(1);
+    [Fact] void should_not_use_reflection_types() => _ = _types.DidNotReceive().All;
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_no_generated_metadata.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_no_generated_metadata.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.Queries.ModelBound.for_QueryPerformerProvider;
 
-public class when_initializing_with_internal_read_model : Specification
+public class when_initializing_with_no_generated_metadata : Specification
 {
     QueryPerformerProvider _provider;
     ITypes _types;
@@ -17,7 +17,7 @@ public class when_initializing_with_internal_read_model : Specification
     void Establish()
     {
         _types = Substitute.For<ITypes>();
-        _types.All.Returns([typeof(InternalReadModel)]);
+        _types.All.Returns([typeof(PublicReadModelWithValidQuery)]);
         _serviceProviderIsService = Substitute.For<IServiceProviderIsService>();
         _authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
 
@@ -27,5 +27,5 @@ public class when_initializing_with_internal_read_model : Specification
 
     void Because() => _provider = new QueryPerformerProvider(_types, _registry, _serviceProviderIsService, _authorizationEvaluator);
 
-    [Fact] void should_have_no_performers() => _provider.Performers.Count().ShouldEqual(0);
+    [Fact] void should_have_one_performer() => _provider.Performers.Count().ShouldEqual(1);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_public_read_model_with_internal_query.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_public_read_model_with_internal_query.cs
@@ -10,6 +10,7 @@ public class when_initializing_with_public_read_model_with_internal_query : Spec
 {
     QueryPerformerProvider _provider;
     ITypes _types;
+    IQueryMetadataRegistry _registry;
     IServiceProviderIsService _serviceProviderIsService;
     IAuthorizationEvaluator _authorizationEvaluator;
 
@@ -19,9 +20,12 @@ public class when_initializing_with_public_read_model_with_internal_query : Spec
         _types.All.Returns([typeof(PublicReadModelWithInternalQuery)]);
         _serviceProviderIsService = Substitute.For<IServiceProviderIsService>();
         _authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
+
+        _registry = Substitute.For<IQueryMetadataRegistry>();
+        _registry.All.Returns(new Dictionary<string, Type>());
     }
 
-    void Because() => _provider = new QueryPerformerProvider(_types, _serviceProviderIsService, _authorizationEvaluator);
+    void Because() => _provider = new QueryPerformerProvider(_types, _registry, _serviceProviderIsService, _authorizationEvaluator);
 
     [Fact] void should_have_no_performers() => _provider.Performers.Count().ShouldEqual(0);
 }

--- a/Source/DotNET/Arc.Core/GeneratedMetadataRegistration.cs
+++ b/Source/DotNET/Arc.Core/GeneratedMetadataRegistration.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Cratis.Arc;
+
+/// <summary>
+/// Performs startup registration of generated metadata from project assemblies.
+/// </summary>
+static class GeneratedMetadataRegistration
+{
+    static int _hasLoadedProjectAssemblies;
+
+    /// <summary>
+    /// Ensures generated metadata has been registered for all project assemblies.
+    /// </summary>
+    public static void EnsureGeneratedMetadataRegistered()
+    {
+        EnsureProjectAssembliesLoaded();
+    }
+
+    static void EnsureProjectAssembliesLoaded()
+    {
+        if (Interlocked.Exchange(ref _hasLoadedProjectAssemblies, 1) == 1)
+        {
+            return;
+        }
+
+        var dependencyContext = DependencyContext.Default;
+        if (dependencyContext is null)
+        {
+            return;
+        }
+
+        foreach (var runtimeLibrary in dependencyContext.RuntimeLibraries.Where(_ => _.Type == "project"))
+        {
+            try
+            {
+                _ = Assembly.Load(new AssemblyName(runtimeLibrary.Name));
+            }
+            catch
+            {
+                // Ignore failures and continue with assemblies that can be loaded.
+            }
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -73,6 +73,8 @@ public static class HostBuilderExtensions
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
     public static IServiceCollection AddCratisArcCore(this IServiceCollection services)
     {
+        GeneratedMetadataRegistration.EnsureGeneratedMetadataRegistered();
+
         Internals.Types = Types.Types.Instance;
         Internals.Types.RegisterTypeConvertersForConcepts();
         Internals.DerivedTypes = DerivedTypes.Instance;

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/IQueryMetadataRegistry.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/IQueryMetadataRegistry.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.ModelBound;
+
+/// <summary>
+/// Defines the registry for compile-time generated query metadata.
+/// </summary>
+public interface IQueryMetadataRegistry
+{
+    /// <summary>
+    /// Gets all registered query mappings from fully qualified query name to read model type.
+    /// </summary>
+    IDictionary<string, Type> All { get; }
+}

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/QueryMetadataRegistry.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/QueryMetadataRegistry.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+
+namespace Cratis.Arc.Queries.ModelBound;
+
+/// <summary>
+/// Represents the registry for compile-time generated query metadata.
+/// </summary>
+/// <remarks>
+/// Source-generated module initializers call <see cref="Register"/> at assembly load time.
+/// The static collection is shared across all instances, so any <see cref="QueryMetadataRegistry"/>
+/// instance surfaced through <see cref="IQueryMetadataRegistry"/> sees all registered metadata.
+/// </remarks>
+public class QueryMetadataRegistry : IQueryMetadataRegistry
+{
+    static readonly ConcurrentDictionary<string, Type> _queries = [];
+
+    /// <inheritdoc/>
+    public IDictionary<string, Type> All => _queries;
+
+    /// <summary>
+    /// Registers a query mapping if it has not already been registered.
+    /// </summary>
+    /// <param name="queryName">The fully qualified query name.</param>
+    /// <param name="readModelType">The read model type for the query.</param>
+    public static void Register(string queryName, Type readModelType) => _queries.TryAdd(queryName, readModelType);
+}
+

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
@@ -20,11 +20,17 @@ public class QueryPerformerProvider : IQueryPerformerProvider
     /// Initializes a new instance of the <see cref="QueryPerformerProvider"/> class.
     /// </summary>
     /// <param name="types">The types to scan for read models.</param>
+    /// <param name="queryMetadataRegistry">The registry of compile-time generated query metadata.</param>
     /// <param name="serviceProviderIsService">Service to determine if a type is registered as a service.</param>
     /// <param name="authorizationEvaluator">The authorization evaluator.</param>
-    public QueryPerformerProvider(ITypes types, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
+    public QueryPerformerProvider(ITypes types, IQueryMetadataRegistry queryMetadataRegistry, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
     {
-        var readModelTypes = types.All.Where(t => t.IsReadModel());
+        IEnumerable<Type> readModelTypes;
+
+        var generatedMetadata = queryMetadataRegistry.All;
+        readModelTypes = generatedMetadata.Count > 0
+            ? generatedMetadata.Values.Distinct()
+            : types.All.Where(t => t.IsReadModel());
         _performers = readModelTypes
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Where(m => m.IsValidQueryFor(t))

--- a/Source/DotNET/Arc.Core/Queries/QueryServiceCollectionExtensions.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Queries;
+using Cratis.Arc.Queries.ModelBound;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting;
@@ -21,6 +22,7 @@ public static class QueryServiceCollectionExtensions
         services.AddSingleton<IQueryContextManager, QueryContextManager>();
         services.AddSingleton<IQueryPipeline, QueryPipeline>();
         services.AddSingleton<IQueryFilters, QueryFilters>();
+        services.AddSingleton<IQueryMetadataRegistry, QueryMetadataRegistry>();
         services.AddSingleton<IQueryPerformerProviders, QueryPerformerProviders>();
         services.AddSingleton<IQueryRenderers, QueryRenderers>();
         return services;

--- a/TestApps/ArcCore/main.tsx
+++ b/TestApps/ArcCore/main.tsx
@@ -9,6 +9,65 @@ import { App, Page } from '../Shared/App';
 import { QueryTransportMethod } from '@cratis/arc/queries';
 import { ObservableQueryTransferMode } from '@cratis/arc';
 
+const storageKeys = {
+    transport: 'arccore.transport',
+    connectionCount: 'arccore.connectionCount',
+    directMode: 'arccore.directMode',
+    transferMode: 'arccore.transferMode',
+    loggedIn: 'arccore.loggedIn',
+    userId: 'arccore.userId',
+    userName: 'arccore.userName',
+    roles: 'arccore.roles',
+};
+
+const getString = (key: string, fallback: string): string => {
+    const value = localStorage.getItem(key);
+    return value ?? fallback;
+};
+
+const getNumber = (key: string, fallback: number): number => {
+    const value = Number.parseInt(localStorage.getItem(key) ?? '', 10);
+    return Number.isNaN(value) ? fallback : value;
+};
+
+const getBoolean = (key: string, fallback: boolean): boolean => {
+    const value = localStorage.getItem(key);
+    if (value === null) {
+        return fallback;
+    }
+    return value === 'true';
+};
+
+const getTransport = (): QueryTransportMethod => {
+    const value = getString(storageKeys.transport, QueryTransportMethod.WebSocket);
+    return value === QueryTransportMethod.ServerSentEvents ? QueryTransportMethod.ServerSentEvents : QueryTransportMethod.WebSocket;
+};
+
+const getTransferMode = (): ObservableQueryTransferMode => {
+    const value = getString(storageKeys.transferMode, ObservableQueryTransferMode.Delta);
+    return value === ObservableQueryTransferMode.Full ? ObservableQueryTransferMode.Full : ObservableQueryTransferMode.Delta;
+};
+
+const persistSettings = (
+    transport: QueryTransportMethod,
+    connectionCount: number,
+    directMode: boolean,
+    transferMode: ObservableQueryTransferMode,
+    loggedIn: boolean,
+    userId: string,
+    userName: string,
+    roles: string,
+) => {
+    localStorage.setItem(storageKeys.transport, transport);
+    localStorage.setItem(storageKeys.connectionCount, connectionCount.toString());
+    localStorage.setItem(storageKeys.directMode, directMode.toString());
+    localStorage.setItem(storageKeys.transferMode, transferMode);
+    localStorage.setItem(storageKeys.loggedIn, loggedIn.toString());
+    localStorage.setItem(storageKeys.userId, userId);
+    localStorage.setItem(storageKeys.userName, userName);
+    localStorage.setItem(storageKeys.roles, roles);
+};
+
 const encodeClientPrincipal = (userId: string, userName: string, roles: string): string => {
     const rolesList = roles.split(',').filter(r => r.trim()).map(r => r.trim());
     const clientPrincipal = {
@@ -68,16 +127,25 @@ const AuthBridge = ({ loggedIn, userId, userName, roles }: { loggedIn: boolean; 
 };
 
 const Root = () => {
-    const [transport, setTransport] = useState<QueryTransportMethod>(QueryTransportMethod.WebSocket);
-    const [connectionCount, setConnectionCount] = useState(1);
-    const [directMode, setDirectMode] = useState(false);
-    const [transferMode, setTransferMode] = useState<ObservableQueryTransferMode>(ObservableQueryTransferMode.Delta);
-    const [loggedIn, setLoggedIn] = useState(false);
-    const [userId, setUserId] = useState('demo-user');
-    const [userName, setUserName] = useState('Demo User');
-    const [roles, setRoles] = useState('User');
+    const [transport, setTransport] = useState<QueryTransportMethod>(() => getTransport());
+    const [connectionCount, setConnectionCount] = useState(() => Math.max(1, Math.min(10, getNumber(storageKeys.connectionCount, 1))));
+    const [directMode, setDirectMode] = useState(() => getBoolean(storageKeys.directMode, false));
+    const [transferMode, setTransferMode] = useState<ObservableQueryTransferMode>(() => getTransferMode());
+    const [loggedIn, setLoggedIn] = useState(() => getBoolean(storageKeys.loggedIn, false));
+    const [userId, setUserId] = useState(() => getString(storageKeys.userId, 'demo-user'));
+    const [userName, setUserName] = useState(() => getString(storageKeys.userName, 'Demo User'));
+    const [roles, setRoles] = useState(() => getString(storageKeys.roles, 'User'));
     const [configKey, setConfigKey] = useState(0);
     const [page, setPage] = useState<Page>('authenticationqueries');
+
+    useEffect(() => {
+        if (loggedIn) {
+            setAuthCookie(userId, userName, roles);
+        } else {
+            // Ensure browser auth state is deterministic on load and refresh.
+            clearAuthCookie();
+        }
+    }, []);
 
     const apply = (
         newTransport: QueryTransportMethod,
@@ -105,6 +173,8 @@ const Root = () => {
         } else {
             clearAuthCookie();
         }
+
+        persistSettings(newTransport, newCount, newDirect, newTransferMode, newLoggedIn, newUserId, newUserName, newRoles);
 
         if (configChanged) {
             setConfigKey(current => current + 1);

--- a/TestApps/Shared/Shared.csproj
+++ b/TestApps/Shared/Shared.csproj
@@ -13,6 +13,8 @@
     <CratisProxiesSkipOutputDeletion>true</CratisProxiesSkipOutputDeletion>
     <CratisProxiesSkipCommandNameInRoute>true</CratisProxiesSkipCommandNameInRoute>
     <CratisProxiesUseSourceFileAsOutputFile>true</CratisProxiesUseSourceFileAsOutputFile>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>obj/Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Added

- Added code generator for query metadata related to Model Bound queries. This automatically runs as a Roslyn incremental code generator and is used by the runtime if the metadata is available rather than using reflection for discovery. For AOT type of scenarios, this means mangling of the types won't impact the runtime.
