### PR TITLE
Restore Arc.Core.Generators.Specs project

### DIFF
--- a/Arc.slnx
+++ b/Arc.slnx
@@ -8,6 +8,7 @@
         <Project Path="Source/DotNET/Swagger.Specs/Swagger.Specs.csproj" />
         <Project Path="Source\DotNET\Arc.Core.CodeAnalysis.Specs\Arc.Core.CodeAnalysis.Specs.csproj" />
         <Project Path="Source\DotNET\Arc.Core.Generators\Arc.Core.Generators.csproj" />
+        <Project Path="Source\DotNET\Arc.Core.Generators.Specs\Arc.Core.Generators.Specs.csproj" />
         <Project Path="Source\DotNET\Arc\Arc.csproj" />
         <Project Path="Source\DotNET\Arc.Specs\Arc.Specs.csproj" />
         <Project Path="Source\DotNET\Testing\Testing.csproj" />

--- a/Source/DotNET/Arc.Core.Generators.Specs/Arc.Core.Generators.Specs.csproj
+++ b/Source/DotNET/Arc.Core.Generators.Specs/Arc.Core.Generators.Specs.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Core.Generators.Specs</AssemblyName>
+        <RootNamespace>Cratis.Arc.Generators</RootNamespace>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <NoWarn>$(NoWarn);MA0101;RCS1266;MA0136</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Remove="../GlobalUsings.Specs.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+        <ProjectReference Include="../Arc.Core.Generators/Arc.Core.Generators.csproj" />
+        <ProjectReference Include="../Arc.Core/Arc.Core.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Specs/GlobalUsings.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable IDE0005 // Using directive is unnecessary.
+
+global using Cratis.Specifications;
+global using NSubstitute;
+global using Xunit;

--- a/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Arc.Generators.Specs.Testing;
+
+/// <summary>
+/// Helper utilities for running and testing source generators.
+/// </summary>
+public static class GeneratorTestHelper
+{
+    /// <summary>
+    /// Runs the <see cref="QueryMetadataGenerator"/> against the supplied source text and
+    /// returns the result.
+    /// </summary>
+    /// <param name="source">C# source code to compile and pass to the generator.</param>
+    /// <returns>The <see cref="GeneratorDriverRunResult"/>.</returns>
+    public static GeneratorDriverRunResult RunGenerator(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [CSharpSyntaxTree.ParseText(source)],
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        var generator = new QueryMetadataGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator)
+            .RunGenerators(compilation);
+
+        return driver.GetRunResult();
+    }
+
+    /// <summary>
+    /// Gets generated source text for a file with a specific hint name.
+    /// </summary>
+    /// <param name="result">The generator run result.</param>
+    /// <param name="hintName">The exact generated file hint name.</param>
+    /// <returns>The generated source, or an empty string if not found.</returns>
+    public static string GetGeneratedSourceByHintName(GeneratorDriverRunResult result, string hintName)
+    {
+        var source = result.Results
+            .SelectMany(_ => _.GeneratedSources)
+            .FirstOrDefault(_ => _.HintName == hintName);
+
+        return source.HintName is null ? string.Empty : source.SourceText.ToString();
+    }
+
+    static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        var systemRuntime = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "System.Runtime");
+
+        return
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),
+            MetadataReference.CreateFromFile(systemRuntime!.Location),
+            MetadataReference.CreateFromFile(typeof(Cratis.Arc.Queries.ModelBound.ReadModelAttribute).Assembly.Location),
+        ];
+    }
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_multiple_read_models_exist.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_multiple_read_models_exist.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
+
+public class and_multiple_read_models_exist : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+            using System.Collections.Generic;
+
+            namespace TestApp;
+
+            [ReadModel]
+            public class FirstReadModel
+            {
+                public static FirstReadModel GetById(int id) => new();
+            }
+
+            [ReadModel]
+            public class SecondReadModel
+            {
+                public static IEnumerable<SecondReadModel> GetAll() => [];
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "GeneratedQueryMetadata.g.cs");
+    }
+
+    [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+    [Fact] void should_include_first_read_model_query() => _generatedSource.ShouldContain("TestApp.FirstReadModel.GetById");
+    [Fact] void should_include_second_read_model_query() => _generatedSource.ShouldContain("TestApp.SecondReadModel.GetAll");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_multiple_query_methods.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_multiple_query_methods.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
+
+public class and_read_model_has_multiple_query_methods : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+            using System.Collections.Generic;
+
+            namespace TestApp;
+
+            [ReadModel]
+            public class MyReadModel
+            {
+                public static MyReadModel GetById(int id) => new();
+                public static IEnumerable<MyReadModel> GetAll() => [];
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "GeneratedQueryMetadata.g.cs");
+    }
+
+    [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+    [Fact] void should_include_get_by_id_query_key() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetById");
+    [Fact] void should_include_get_all_query_key() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetAll");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_nested_namespace.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_nested_namespace.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
+
+public class and_read_model_has_nested_namespace : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+
+            namespace TestApp.Features.Sample;
+
+            [ReadModel]
+            public class MyReadModel
+            {
+                public static MyReadModel GetById(int id) => new();
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "GeneratedQueryMetadata.g.cs");
+    }
+
+    [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+    [Fact] void should_use_global_qualified_type_reference() => _generatedSource.ShouldContain("typeof(global::TestApp.Features.Sample.MyReadModel)");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_non_public_query_method.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_non_public_query_method.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
+
+public class and_read_model_has_non_public_query_method : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+
+            namespace TestApp;
+
+            [ReadModel]
+            public class MyReadModel
+            {
+                public static MyReadModel GetById(int id) => new();
+                internal static MyReadModel GetByName(string name) => new();
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "GeneratedQueryMetadata.g.cs");
+    }
+
+    [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
+    [Fact] void should_include_public_query() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetById");
+    [Fact] void should_not_include_internal_query() => _generatedSource.ShouldNotContain("TestApp.MyReadModel.GetByName");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_single_query_method.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_has_single_query_method.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
+
+public class and_read_model_has_single_query_method : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+            using System.Collections.Generic;
+
+            namespace TestApp;
+
+            [ReadModel]
+            public class MyReadModel
+            {
+                public static MyReadModel GetById(int id) => new();
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "GeneratedQueryMetadata.g.cs");
+    }
+
+    [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+    [Fact] void should_contain_query_metadata_class() => _generatedSource.ShouldContain("GeneratedQueryMetadata");
+    [Fact] void should_contain_module_initializer() => _generatedSource.ShouldContain("[ModuleInitializer]");
+    [Fact] void should_register_with_query_metadata_registry() => _generatedSource.ShouldContain("QueryMetadataRegistry.Register");
+    [Fact] void should_include_query_key() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetById");
+    [Fact] void should_include_read_model_type() => _generatedSource.ShouldContain("typeof(global::TestApp.MyReadModel)");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_class_without_read_model_attribute_exists.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_class_without_read_model_attribute_exists.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_without_read_models;
+
+public class and_class_without_read_model_attribute_exists : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            namespace TestApp;
+
+            public class NotAReadModel
+            {
+                public static NotAReadModel GetAll() => new();
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "CratisArcGeneratedMarker.g.cs");
+    }
+
+    [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_no_types_exist.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_no_types_exist.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_without_read_models;
+
+public class and_no_types_exist : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator(string.Empty);
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "CratisArcGeneratedMarker.g.cs");
+    }
+
+    [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_read_model_exists_with_no_valid_query_methods.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_read_model_exists_with_no_valid_query_methods.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_without_read_models;
+
+public class and_read_model_exists_with_no_valid_query_methods : Specification
+{
+    GeneratorDriverRunResult _result;
+    string _generatedSource;
+
+    void Because()
+    {
+        _result = GeneratorTestHelper.RunGenerator("""
+            using Cratis.Arc.Queries.ModelBound;
+
+            namespace TestApp;
+
+            [ReadModel]
+            public class MyReadModel
+            {
+                public string Value { get; set; } = string.Empty;
+            }
+            """);
+
+        _generatedSource = GeneratorTestHelper.GetGeneratedSourceByHintName(_result, "CratisArcGeneratedMarker.g.cs");
+    }
+
+    [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
+}


### PR DESCRIPTION
## Added
- Restored the Arc.Core generator specs project to validate query metadata source generation behavior.

## Fixed
- Updated generator specs expectations to align with current generator output, including marker source generation and metadata source hint selection.
- Re-added the generator specs project to the solution so it runs in normal build and test workflows.