### PR TITLE
Fix Arc.Core.Generators not shipped as analyzer asset in the nupkg

### DIFF
--- a/Arc.slnx
+++ b/Arc.slnx
@@ -9,6 +9,7 @@
         <Project Path="Source\DotNET\Arc.Core.CodeAnalysis.Specs\Arc.Core.CodeAnalysis.Specs.csproj" />
         <Project Path="Source\DotNET\Arc.Core.Generators\Arc.Core.Generators.csproj" />
         <Project Path="Source\DotNET\Arc.Core.Generators.Specs\Arc.Core.Generators.Specs.csproj" />
+        <Project Path="Source\DotNET\Arc.Core.Generators.Integration\Specs\Specs.csproj" />
         <Project Path="Source\DotNET\Arc\Arc.csproj" />
         <Project Path="Source\DotNET\Arc.Specs\Arc.Specs.csproj" />
         <Project Path="Source\DotNET\Testing\Testing.csproj" />

--- a/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/Directory.Build.props
+++ b/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="5.3.0" PrivateAssets="All" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/SampleApp.csproj
+++ b/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/SampleApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Cratis.Arc.Core" Version="1.0.0" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/WeatherReadModel.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/SampleApp/WeatherReadModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries.ModelBound;
+
+namespace SampleApp;
+
+[ReadModel]
+public record WeatherReadModel(string City)
+{
+    public static WeatherReadModel GetByName(string city) => new(city);
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/Specs.csproj
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/Specs.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Arc.Core.Generators.Integration.Specs</AssemblyName>
+        <RootNamespace>Cratis.Arc.Core.Generators.Integration.Specs</RootNamespace>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <NoWarn>$(NoWarn);MA0101;RCS1266;MA0136</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../../Arc.Core/Arc.Core.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/PackagedArcCoreBuildResult.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/PackagedArcCoreBuildResult.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+/// <summary>
+/// Represents the result of packing Arc.Core and building the sample consumer app from the packed nupkg.
+/// </summary>
+/// <param name="packagePath">The path to the packed Arc.Core nupkg.</param>
+/// <param name="packageEntries">The entries inside the packed Arc.Core nupkg.</param>
+/// <param name="generatedFilePath">The path to the generated query metadata file emitted by the sample app build.</param>
+/// <param name="generatedFileContent">The content of the generated query metadata file.</param>
+/// <param name="workingDirectory">The temporary working directory used by the integration scenario.</param>
+public sealed class PackagedArcCoreBuildResult(
+    string packagePath,
+    IReadOnlyCollection<string> packageEntries,
+    string generatedFilePath,
+    string generatedFileContent,
+    string workingDirectory)
+{
+    /// <summary>
+    /// Gets the path to the packed Arc.Core nupkg.
+    /// </summary>
+    public string PackagePath { get; } = packagePath;
+
+    /// <summary>
+    /// Gets the entries inside the packed Arc.Core nupkg.
+    /// </summary>
+    public IReadOnlyCollection<string> PackageEntries { get; } = packageEntries;
+
+    /// <summary>
+    /// Gets the path to the generated query metadata file emitted by the sample app build.
+    /// </summary>
+    public string GeneratedFilePath { get; } = generatedFilePath;
+
+    /// <summary>
+    /// Gets the content of the generated query metadata file.
+    /// </summary>
+    public string GeneratedFileContent { get; } = generatedFileContent;
+
+    /// <summary>
+    /// Gets the temporary working directory used by the integration scenario.
+    /// </summary>
+    public string WorkingDirectory { get; } = workingDirectory;
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/PackagedArcCoreBuildScenario.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/PackagedArcCoreBuildScenario.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO.Compression;
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+/// <summary>
+/// Executes the packaged Arc.Core integration scenario against the sample consumer app.
+/// </summary>
+internal static class PackagedArcCoreBuildScenario
+{
+    /// <summary>
+    /// Packs Arc.Core into a local feed, restores the sample app from that packed nupkg, and builds the sample app.
+    /// </summary>
+    /// <returns>A <see cref="PackagedArcCoreBuildResult"/> describing the packed nupkg and generated source output.</returns>
+    /// <exception cref="PackageIntegrationFailure">Thrown when packing Arc.Core or building the sample app does not produce the expected artifacts.</exception>
+    public static PackagedArcCoreBuildResult Execute()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var workingDirectory = CreateWorkingDirectory();
+        var packageDirectory = Path.Combine(workingDirectory, "packages");
+        var restoredPackagesDirectory = Path.Combine(workingDirectory, "restored-packages");
+        var integrationSourceDirectory = Path.Combine(repositoryRoot, "Source", "DotNET", "Arc.Core.Generators.Integration");
+        var integrationWorkingDirectory = Path.Combine(workingDirectory, "Arc.Core.Generators.Integration");
+        var sampleWorkingDirectory = Path.Combine(integrationWorkingDirectory, "SampleApp");
+
+        Directory.CreateDirectory(packageDirectory);
+        Directory.CreateDirectory(restoredPackagesDirectory);
+        CopyDirectory(integrationSourceDirectory, integrationWorkingDirectory);
+
+        var arcCoreProjectPath = Path.Combine(repositoryRoot, "Source", "DotNET", "Arc.Core", "Arc.Core.csproj");
+        RunDotNet(repositoryRoot, $"pack \"{arcCoreProjectPath}\" -c Release --output \"{packageDirectory}\" -p:IncludeSymbols=false -p:IncludeSource=false");
+
+        var packagePath = Directory.GetFiles(packageDirectory, "Cratis.Arc.Core.*.nupkg", SearchOption.TopDirectoryOnly)
+            .OrderDescending()
+            .FirstOrDefault()
+            ?? throw new PackageIntegrationFailure("Expected a packed Cratis.Arc.Core nupkg to be created.");
+
+        var sampleProjectPath = Path.Combine(sampleWorkingDirectory, "SampleApp.csproj");
+        RunDotNet(sampleWorkingDirectory, $"restore \"{sampleProjectPath}\" --source \"{packageDirectory}\" --source https://api.nuget.org/v3/index.json --packages \"{restoredPackagesDirectory}\"");
+        RunDotNet(sampleWorkingDirectory, $"build \"{sampleProjectPath}\" --no-restore");
+
+        var generatedFilePath = Directory.GetFiles(sampleWorkingDirectory, "GeneratedQueryMetadata.g.cs", SearchOption.AllDirectories)
+            .SingleOrDefault()
+            ?? throw new PackageIntegrationFailure("Expected the sample app build to emit GeneratedQueryMetadata.g.cs.");
+
+        using var package = ZipFile.OpenRead(packagePath);
+        var packageEntries = package.Entries.Select(_ => _.FullName).ToArray();
+
+        return new(
+            packagePath,
+            packageEntries,
+            generatedFilePath,
+            File.ReadAllText(generatedFilePath),
+            workingDirectory);
+    }
+
+    static string GetRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Arc.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new PackageIntegrationFailure("Could not locate the repository root from the integration spec output directory.");
+    }
+
+    static string CreateWorkingDirectory()
+    {
+        var workingDirectory = Path.Combine(Path.GetTempPath(), "Cratis.Arc.Core.Generators.Integration", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workingDirectory);
+        return workingDirectory;
+    }
+
+    static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        Directory.CreateDirectory(destinationDirectory);
+
+        foreach (var directory in Directory.GetDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, directory);
+            Directory.CreateDirectory(Path.Combine(destinationDirectory, relativePath));
+        }
+
+        foreach (var file in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, file);
+            var destinationPath = Path.Combine(destinationDirectory, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file, destinationPath, overwrite: true);
+        }
+    }
+
+    static void RunDotNet(string workingDirectory, string arguments)
+    {
+        using var process = new Process
+        {
+            StartInfo = new()
+            {
+                FileName = "dotnet",
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }
+        };
+
+        process.Start();
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        var standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        var standardError = standardErrorTask.GetAwaiter().GetResult();
+
+        if (process.ExitCode != 0)
+        {
+            throw new PackageIntegrationFailure($"dotnet {arguments} failed with exit code {process.ExitCode}.{Environment.NewLine}{standardOutput}{Environment.NewLine}{standardError}");
+        }
+    }
+
+    /// <summary>
+    /// The exception that is thrown when the packaged Arc.Core integration scenario fails.
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    sealed class PackageIntegrationFailure(string message) : Exception(message);
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_PackagedQueryMetadataGenerator/PackagedArcCoreBuildFixture.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_PackagedQueryMetadataGenerator/PackagedArcCoreBuildFixture.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.for_PackagedQueryMetadataGenerator;
+
+/// <summary>
+/// Executes the packaged Arc.Core integration scenario once for the test class.
+/// </summary>
+public sealed class PackagedArcCoreBuildFixture
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PackagedArcCoreBuildFixture"/> class.
+    /// </summary>
+    public PackagedArcCoreBuildFixture() => Result = PackagedArcCoreBuildScenario.Execute();
+
+    /// <summary>
+    /// Gets the result of packing Arc.Core and building the sample consumer app from the packed nupkg.
+    /// </summary>
+    public PackagedArcCoreBuildResult Result { get; }
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_PackagedQueryMetadataGenerator/when_restoring_arc_core_from_a_packed_nupkg.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_PackagedQueryMetadataGenerator/when_restoring_arc_core_from_a_packed_nupkg.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.for_PackagedQueryMetadataGenerator;
+
+/// <summary>
+/// Verifies that Arc.Core packages the query metadata generator and that a consumer app receives generated query metadata from the packed nupkg.
+/// </summary>
+/// <param name="fixture">The fixture that executes the packaged Arc.Core integration scenario once for the test class.</param>
+public class when_restoring_arc_core_from_a_packed_nupkg(PackagedArcCoreBuildFixture fixture) : IClassFixture<PackagedArcCoreBuildFixture>
+{
+    readonly PackagedArcCoreBuildResult _buildResult = fixture.Result;
+
+    /// <summary>
+    /// Verifies that the packed Arc.Core nupkg contains the query metadata generator as an analyzer asset.
+    /// </summary>
+    [Fact]
+    public void should_pack_the_generator_dll_as_an_analyzer_asset() =>
+        _buildResult.PackageEntries.ShouldContain("analyzers/dotnet/cs/Cratis.Arc.Core.Generators.dll");
+
+    /// <summary>
+    /// Verifies that building the sample app from the packed Arc.Core nupkg emits the generated query metadata source file.
+    /// </summary>
+    [Fact]
+    public void should_emit_the_generated_query_metadata_file() =>
+        File.Exists(_buildResult.GeneratedFilePath).ShouldBeTrue();
+
+    /// <summary>
+    /// Verifies that the generated query metadata registers the sample app query.
+    /// </summary>
+    [Fact]
+    public void should_register_the_sample_query_in_generated_metadata() =>
+        _buildResult.GeneratedFileContent.ShouldContain("SampleApp.WeatherReadModel.GetByName");
+
+    /// <summary>
+    /// Verifies that the generated query metadata registers the sample app read model type.
+    /// </summary>
+    [Fact]
+    public void should_register_the_sample_read_model_type_in_generated_metadata() =>
+        _buildResult.GeneratedFileContent.ShouldContain("typeof(global::SampleApp.WeatherReadModel)");
+}

--- a/Source/DotNET/Arc.Core/Arc.Core.csproj
+++ b/Source/DotNET/Arc.Core/Arc.Core.csproj
@@ -28,9 +28,18 @@
     <ItemGroup>
         <ProjectReference Include="../Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj" 
                           OutputItemType="Analyzer" 
-                          ReferenceOutputAssembly="false" />
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="all" />
         <ProjectReference Include="../Arc.Core.Generators/Arc.Core.Generators.csproj"
                           OutputItemType="Analyzer"
-                          ReferenceOutputAssembly="false" />
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="../Arc.Core.Generators/bin/$(Configuration)/netstandard2.0/Cratis.Arc.Core.Generators.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs"
+              Visible="false" />
     </ItemGroup>
 </Project>

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
@@ -32,7 +32,7 @@ public class QueryPerformerProvider : IQueryPerformerProvider
             ? generatedMetadata.Values.Distinct()
             : types.All.Where(t => t.IsReadModel());
         _performers = readModelTypes
-            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
                 .Where(m => m.IsValidQueryFor(t))
                 .Select(m => new ModelBoundQueryPerformer(t, m, serviceProviderIsService, authorizationEvaluator)))
             .ToDictionary(p => p.FullyQualifiedName, p => (IQueryPerformer)p);


### PR DESCRIPTION
## Fixed
- `Cratis.Arc.Core.Generators.dll` is now correctly embedded at `analyzers/dotnet/cs/` in the `Cratis.Arc.Core` nupkg so that consumers installing from NuGet receive the source generator and get `GeneratedQueryMetadata.g.cs` emitted at build time.
- `QueryPerformerProvider` now discovers non-public static query methods on read model types, not just public ones.

## Added
- End-to-end integration specs that pack `Cratis.Arc.Core`, restore a sample consumer app from the local feed, build it, and assert that the generator DLL is present in the nupkg and `GeneratedQueryMetadata.g.cs` is emitted correctly.