### PR TITLE
Set request context accessor in ASP.NET endpoint mapper

### DIFF
--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_get/setting_current_http_request_context.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_get/setting_current_http_request_context.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.when_mapping_get;
+
+public class setting_current_http_request_context : given.an_endpoint_mapper
+{
+    const string Pattern = "/test/get-accessor";
+    RouteEndpoint _endpoint;
+    HttpContext _httpContext;
+    IHttpRequestContextAccessor _accessor;
+    IHttpRequestContext _contextReceivedByHandler;
+
+    void Establish()
+    {
+        _accessor = Substitute.For<IHttpRequestContextAccessor>();
+        _mapper.MapGet(Pattern, context =>
+        {
+            _contextReceivedByHandler = context;
+            return Task.CompletedTask;
+        });
+
+        _endpoint = FindEndpoint(Pattern);
+
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(_accessor)
+            .BuildServiceProvider();
+
+        _httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+    }
+
+    async Task Because() => await _endpoint.RequestDelegate!(_httpContext);
+
+    [Fact] void should_set_current_on_the_accessor() => _accessor.Current.ShouldNotBeNull();
+    [Fact] void should_set_current_to_the_same_context_passed_to_the_handler() => _accessor.Current.ShouldEqual(_contextReceivedByHandler);
+}

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_post/setting_current_http_request_context.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_post/setting_current_http_request_context.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Http.for_AspNetCoreEndpointMapper.when_mapping_post;
+
+public class setting_current_http_request_context : given.an_endpoint_mapper
+{
+    const string Pattern = "/test/post-accessor";
+    RouteEndpoint _endpoint;
+    HttpContext _httpContext;
+    IHttpRequestContextAccessor _accessor;
+    IHttpRequestContext _contextReceivedByHandler;
+
+    void Establish()
+    {
+        _accessor = Substitute.For<IHttpRequestContextAccessor>();
+        _mapper.MapPost(Pattern, context =>
+        {
+            _contextReceivedByHandler = context;
+            return Task.CompletedTask;
+        });
+
+        _endpoint = FindEndpoint(Pattern);
+
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(_accessor)
+            .BuildServiceProvider();
+
+        _httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+    }
+
+    async Task Because() => await _endpoint.RequestDelegate!(_httpContext);
+
+    [Fact] void should_set_current_on_the_accessor() => _accessor.Current.ShouldNotBeNull();
+    [Fact] void should_set_current_to_the_same_context_passed_to_the_handler() => _accessor.Current.ShouldEqual(_contextReceivedByHandler);
+}

--- a/Source/DotNET/Arc/Http/AspNetCoreEndpointMapper.cs
+++ b/Source/DotNET/Arc/Http/AspNetCoreEndpointMapper.cs
@@ -26,6 +26,8 @@ public class AspNetCoreEndpointMapper(IEndpointRouteBuilder endpoints, string? g
         Delegate requestHandler = async (HttpContext httpContext) =>
         {
             var context = new AspNetCoreHttpRequestContext(httpContext);
+            var accessor = httpContext.RequestServices.GetRequiredService<IHttpRequestContextAccessor>();
+            accessor.Current = context;
             await handler(context);
         };
 
@@ -40,6 +42,8 @@ public class AspNetCoreEndpointMapper(IEndpointRouteBuilder endpoints, string? g
         Delegate requestHandler = async (HttpContext httpContext) =>
         {
             var context = new AspNetCoreHttpRequestContext(httpContext);
+            var accessor = httpContext.RequestServices.GetRequiredService<IHttpRequestContextAccessor>();
+            accessor.Current = context;
             await handler(context);
         };
 


### PR DESCRIPTION
## Fixed
- Set `IHttpRequestContextAccessor.Current` in mapped ASP.NET Core GET and POST endpoints before invoking handlers.
- Added regression specs that execute mapped GET/POST handlers and verify the accessor receives the active request context.