### PR TITLE
Fix stability issues in observable queries, async enumeration, and MongoDB watching

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ClientObservable.when_handling_connection;
+
+public class and_complete_and_next_race
+{
+    [Fact]
+    public async Task should_not_throw_when_complete_is_called_multiple_times()
+    {
+        var subject = new Subject<int>();
+
+        var webSocket = Substitute.For<IWebSocket>();
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        webSocketContext.AcceptWebSocket().Returns(Task.FromResult(webSocket));
+
+        var httpContext = Substitute.For<IHttpRequestContext>();
+        httpContext.WebSockets.Returns(webSocketContext);
+
+        var hostLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        var logger = Substitute.For<ILogger<ClientObservable<int>>>();
+
+        // HandleIncomingMessages blocks until the CancellationToken is cancelled
+        var incomingMessagesTcs = new TaskCompletionSource();
+        var handleIncomingStarted = new TaskCompletionSource();
+        var webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        webSocketConnectionHandler
+            .HandleIncomingMessages(webSocket, Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var token = ci.Arg<CancellationToken>();
+                token.Register(() => incomingMessagesTcs.TrySetResult());
+                handleIncomingStarted.TrySetResult();
+                return incomingMessagesTcs.Task;
+            });
+
+        webSocketConnectionHandler
+            .SendMessage(webSocket, Arg.Any<QueryResult>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Exception?>(null));
+
+        var queryContext = new QueryContext(
+            new FullyQualifiedQueryName("[TestApp].[TestQuery]"),
+            CorrelationId.New(),
+            new Paging(0, 10, true),
+            Sorting.None);
+
+        var observable = new ClientObservable<int>(
+            queryContext,
+            subject,
+            webSocketConnectionHandler,
+            hostLifetime,
+            logger);
+
+        // Act — run connection in background, then trigger the races
+        var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));
+
+        // Wait until HandleIncomingMessages is actually being awaited
+        await handleIncomingStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Emit items and concurrently complete
+        subject.OnNext(1);
+        subject.OnNext(2);
+        subject.OnCompleted();
+        subject.OnCompleted(); // Double-complete triggered the TrySetResult bug
+
+        // Connection should terminate cleanly
+        var timeout = Task.Delay(2000);
+        var completed = await Task.WhenAny(connectionTask, timeout);
+
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Connection did not complete in time after subject completed");
+        }
+
+        // Should not throw (was throwing InvalidOperationException from tcs.SetResult on double-call)
+        await connectionTask;
+    }
+
+    [Fact]
+    public async Task should_not_throw_when_next_is_called_after_complete()
+    {
+        var subject = new Subject<int>();
+
+        var webSocket = Substitute.For<IWebSocket>();
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        webSocketContext.AcceptWebSocket().Returns(Task.FromResult(webSocket));
+
+        var httpContext = Substitute.For<IHttpRequestContext>();
+        httpContext.WebSockets.Returns(webSocketContext);
+
+        var hostLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        var logger = Substitute.For<ILogger<ClientObservable<int>>>();
+
+        var handleStarted2 = new TaskCompletionSource();
+        var webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        webSocketConnectionHandler
+            .HandleIncomingMessages(webSocket, Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var token = ci.Arg<CancellationToken>();
+                var tcs = new TaskCompletionSource();
+                token.Register(() => tcs.TrySetResult());
+                handleStarted2.TrySetResult();
+                return tcs.Task;
+            });
+
+        webSocketConnectionHandler
+            .SendMessage(webSocket, Arg.Any<QueryResult>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Exception?>(null));
+
+        var queryContext = new QueryContext(
+            new FullyQualifiedQueryName("[TestApp].[TestQuery]"),
+            CorrelationId.New(),
+            new Paging(0, 10, true),
+            Sorting.None);
+
+        var observable = new ClientObservable<int>(
+            queryContext,
+            subject,
+            webSocketConnectionHandler,
+            hostLifetime,
+            logger);
+
+        var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));
+
+        await handleStarted2.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Complete first, then emit — Next() should guard against CancellationToken
+        subject.OnCompleted();
+        subject.OnNext(42); // Must not cause exception or deadlock
+
+        var timeout = Task.Delay(2000);
+        var completed = await Task.WhenAny(connectionTask, timeout);
+
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Connection did not complete in time");
+        }
+
+        await connectionTask;
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Arc.Http;
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_streaming;
+
+public class and_concurrent_emissions_and_disposal_occur
+{
+    [Fact]
+    public async Task should_not_throw_when_next_and_complete_race()
+    {
+        // Arrange
+        var subject = new Subject<int>();
+        var httpContext = Substitute.For<IHttpRequestContext>();
+        var arcOptions = Substitute.For<IOptions<ArcOptions>>();
+        var options = new ArcOptions();
+        arcOptions.Value.Returns(options);
+
+        var hostLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        var logger = Substitute.For<ILogger<ClientObservableSSE<int>>>();
+
+        var writeTaskSource = new TaskCompletionSource();
+        httpContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(writeTaskSource.Task);
+
+        var queryContext = new QueryContext(
+            new FullyQualifiedQueryName("[TestApp].[TestQuery]"),
+            CorrelationId.New(),
+            new Paging(0, 10, true),
+            Sorting.None);
+
+        var observable = new ClientObservableSSE<int>(
+            queryContext,
+            subject,
+            arcOptions,
+            hostLifetime,
+            logger);
+
+        // Act & Assert: Rapid emissions followed by disposal should not throw
+        var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));
+
+        // Emit several items rapidly
+        for (int i = 0; i < 5; i++)
+        {
+            subject.OnNext(i);
+            writeTaskSource.SetResult();
+            writeTaskSource = new TaskCompletionSource();
+            await Task.Yield();
+        }
+
+        // Complete the subject
+        subject.OnCompleted();
+
+        // Connection should complete within a reasonable time
+        var timeout = Task.Delay(2000);
+        var completed = await Task.WhenAny(connectionTask, timeout);
+
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Connection did not complete in time");
+        }
+
+        // Should not throw
+        await connectionTask;
+    }
+
+    [Fact]
+    public async Task should_handle_disposal_before_all_writes_complete()
+    {
+        // Arrange
+        var subject = new Subject<int>();
+        var httpContext = Substitute.For<IHttpRequestContext>();
+        var arcOptions = Substitute.For<IOptions<ArcOptions>>();
+        var options = new ArcOptions();
+        arcOptions.Value.Returns(options);
+
+        var hostLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        var logger = Substitute.For<ILogger<ClientObservableSSE<int>>>();
+
+        var writeTaskSource = new TaskCompletionSource();
+        httpContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(writeTaskSource.Task);
+
+        var queryContext = new QueryContext(
+            new FullyQualifiedQueryName("[TestApp].[TestQuery]"),
+            CorrelationId.New(),
+            new Paging(0, 10, true),
+            Sorting.None);
+
+        var observable = new ClientObservableSSE<int>(
+            queryContext,
+            subject,
+            arcOptions,
+            hostLifetime,
+            logger);
+
+        // Act: Start connection
+        var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));
+
+        // Emit an item but don't complete the write
+        subject.OnNext(42);
+        await Task.Delay(10);
+
+        // Complete before the write completes
+        subject.OnCompleted();
+
+        // Eventually complete the write
+        await Task.Delay(50);
+        writeTaskSource.SetResult();
+
+        // Connection should complete without hanging
+        var timeout = Task.Delay(2000);
+        var completed = await Task.WhenAny(connectionTask, timeout);
+
+        if (completed == timeout)
+        {
+            throw new TimeoutException("Connection did not complete");
+        }
+
+        // Should not throw
+        await connectionTask;
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
@@ -3,12 +3,10 @@
 
 using System.Reactive.Subjects;
 using Cratis.Arc.Http;
-using Cratis.Arc.Queries;
 using Cratis.Execution;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NSubstitute;
 
 namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_streaming;
 
@@ -49,7 +47,7 @@ public class and_concurrent_emissions_and_disposal_occur
         var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));
 
         // Emit several items rapidly
-        for (int i = 0; i < 5; i++)
+        for (var i = 0; i < 5; i++)
         {
             subject.OnNext(i);
             writeTaskSource.SetResult();

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableAsyncEnumerator/when_enumerating/and_concurrent_emissions_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableAsyncEnumerator/when_enumerating/and_concurrent_emissions_occur.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Subjects;
-using Cratis.Arc.Queries;
 
 namespace Cratis.Arc.Queries.for_ObservableAsyncEnumerator.when_enumerating;
 
@@ -19,7 +18,7 @@ public class and_concurrent_emissions_occur
         // Act: Emit items rapidly to create race conditions
         var emitTask = Task.Run(async () =>
         {
-            for (int i = 0; i < 50; i++)
+            for (var i = 0; i < 50; i++)
             {
                 subject.OnNext(i);
                 await Task.Yield();
@@ -30,16 +29,9 @@ public class and_concurrent_emissions_occur
 
         var consumeTask = Task.Run(async () =>
         {
-            while (true)
+            while (await enumerator.MoveNextAsync())
             {
-                if (await enumerator.MoveNextAsync())
-                {
-                    collectedItems.Add(enumerator.Current);
-                }
-                else
-                {
-                    break;
-                }
+                collectedItems.Add(enumerator.Current);
             }
         });
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableAsyncEnumerator/when_enumerating/and_concurrent_emissions_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableAsyncEnumerator/when_enumerating/and_concurrent_emissions_occur.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Arc.Queries;
+
+namespace Cratis.Arc.Queries.for_ObservableAsyncEnumerator.when_enumerating;
+
+public class and_concurrent_emissions_occur
+{
+    [Fact]
+    public async Task should_not_lose_items_when_emitted_rapidly()
+    {
+        // Arrange
+        var subject = new Subject<int>();
+        var enumerator = new ObservableAsyncEnumerator<int>(subject, CancellationToken.None);
+        var collectedItems = new List<int>();
+
+        // Act: Emit items rapidly to create race conditions
+        var emitTask = Task.Run(async () =>
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                subject.OnNext(i);
+                await Task.Yield();
+            }
+
+            subject.OnCompleted();
+        });
+
+        var consumeTask = Task.Run(async () =>
+        {
+            while (true)
+            {
+                if (await enumerator.MoveNextAsync())
+                {
+                    collectedItems.Add(enumerator.Current);
+                }
+                else
+                {
+                    break;
+                }
+            }
+        });
+
+        await Task.WhenAll(emitTask, consumeTask);
+        await enumerator.DisposeAsync();
+
+        // Assert
+        collectedItems.Count.ShouldEqual(50);
+    }
+
+    [Fact]
+    public async Task should_handle_disposal_during_pending_move_next()
+    {
+        // Arrange
+        var subject = new Subject<int>();
+        var enumerator = new ObservableAsyncEnumerator<int>(subject, CancellationToken.None);
+
+        // Act: Start a MoveNextAsync that will wait for an item
+        var moveNextTask = enumerator.MoveNextAsync().AsTask();
+
+        // Give time for the task to enter the wait
+        await Task.Delay(100);
+
+        // Dispose while waiting
+        var disposeTask = enumerator.DisposeAsync().AsTask();
+
+        // Complete the emission after a brief delay
+        subject.OnNext(42);
+
+        // This should complete without deadlock
+        var timeout = Task.Delay(2000);
+        var firstCompleted = await Task.WhenAny(moveNextTask, disposeTask, timeout);
+
+        // Assert: Should not timeout
+        (firstCompleted == timeout).ShouldBeFalse();
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_concurrent_messages_are_sent.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_concurrent_messages_are_sent.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// Tests that concurrent SSE message writes (query results + keep-alive pings) do not
+/// cause race conditions or exceptions. This guards against ArgumentNullException("array")
+/// that can occur during concurrent writes to response pipes.
+/// </summary>
+public class and_concurrent_messages_are_sent : given.an_observable_query_demultiplexer
+{
+    const string ControllerQueryName = "Cratis.Chronicle.Api.EventStores.EventStoreQueries.AllEventStores";
+    const string QueryId = "query-concurrent";
+    const int NumberOfEmissions = 50;
+
+    IHttpRequestContext _connectionContext;
+    IHttpRequestContext _subscribeContext;
+    CancellationTokenSource _connectionCancellation;
+    ConcurrentQueue<string> _messages;
+    Subject<IEnumerable<string>> _subject;
+    string _connectionId;
+    int _subscribeStatusCode;
+    Exception? _caughtException;
+
+    void Establish()
+    {
+        _connectionCancellation = new CancellationTokenSource();
+        _messages = [];
+        _connectionId = string.Empty;
+        _caughtException = null;
+
+        _subject = new Subject<IEnumerable<string>>();
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                var queryResult = QueryResult.Success(CorrelationId.New());
+                queryResult.Data = _subject;
+                return Task.FromResult(queryResult);
+            });
+
+        _connectionContext = Substitute.For<IHttpRequestContext>();
+        _connectionContext.RequestAborted.Returns(_connectionCancellation.Token);
+        _connectionContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _connectionContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                try
+                {
+                    _messages.Enqueue(callInfo.Arg<string>());
+                    return Task.CompletedTask;
+                }
+                catch (Exception ex)
+                {
+                    _caughtException = ex;
+                    throw;
+                }
+            });
+
+        _subscribeContext = Substitute.For<IHttpRequestContext>();
+        _subscribeContext.RequestAborted.Returns(CancellationToken.None);
+        _subscribeContext.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
+                _connectionId,
+                QueryId,
+                new ObservableQuerySubscriptionRequest(ControllerQueryName))));
+        _subscribeContext.When(_ => _.SetStatusCode(Arg.Any<int>()))
+            .Do(callInfo => _subscribeStatusCode = callInfo.Arg<int>());
+    }
+
+    async Task Because()
+    {
+        var connectionTask = _hub.HandleSSEConnection(_connectionContext);
+
+        // Wait for connection message to be sent (contains connection ID)
+        await WaitFor(() => TryExtractConnectionId(out _connectionId));
+
+        // Subscribe to the query
+        await _hub.HandleSSESubscribe(_subscribeContext);
+
+        // Emit multiple results in rapid succession to create concurrent write pressure
+        // with the keep-alive pings that may be running in the background.
+        for (var i = 0; i < NumberOfEmissions; i++)
+        {
+            _subject.OnNext([$"event-{i}"]);
+            await Task.Delay(5);
+        }
+
+        // Wait for at least some query result messages to arrive
+        await WaitFor(HasMultipleQueryResultMessages);
+
+        // Cleanup
+        await _connectionCancellation.CancelAsync();
+        await connectionTask;
+    }
+
+    [Fact]
+    void should_return_200_from_subscribe() =>
+        _subscribeStatusCode.ShouldEqual(200);
+
+    [Fact]
+    void should_not_throw_exception_during_concurrent_writes() =>
+        _caughtException.ShouldBeNull();
+
+    [Fact]
+    void should_send_multiple_query_result_messages() =>
+        HasMultipleQueryResultMessages().ShouldBeTrue();
+
+    [Fact]
+    void should_send_connected_message() =>
+        TryExtractConnectionId(out _).ShouldBeTrue();
+
+    bool TryExtractConnectionId(out string connectionId)
+    {
+        connectionId = string.Empty;
+
+        foreach (var hubMessage in _messages
+                     .Select(TryParseHubMessage)
+                     .Where(_ => _ is not null)
+                     .Select(_ => _!))
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.Connected ||
+                hubMessage.Payload is not JsonElement payload)
+            {
+                continue;
+            }
+
+            connectionId = payload.GetString() ?? string.Empty;
+            return !string.IsNullOrEmpty(connectionId);
+        }
+
+        return false;
+    }
+
+    bool HasMultipleQueryResultMessages()
+    {
+        var count = 0;
+
+        foreach (var hubMessage in _messages
+                     .Select(TryParseHubMessage)
+                     .Where(_ => _ is not null)
+                     .Select(_ => _!))
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
+                hubMessage.QueryId != QueryId ||
+                hubMessage.Payload is not JsonElement payload ||
+                payload.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (TryGetPropertyIgnoreCase(payload, "data", out _))
+            {
+                count++;
+            }
+        }
+
+        return count >= 5;
+    }
+
+    static bool TryGetPropertyIgnoreCase(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.TryGetProperty(propertyName, out value))
+        {
+            return true;
+        }
+
+        var alternateCasing = char.ToUpperInvariant(propertyName[0]) + propertyName[1..];
+        return element.TryGetProperty(alternateCasing, out value);
+    }
+
+    ObservableQueryHubMessage? TryParseHubMessage(string sseMessage)
+    {
+        if (!sseMessage.StartsWith("data: ", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var json = sseMessage["data: ".Length..].Trim();
+        return JsonSerializer.Deserialize<ObservableQueryHubMessage>(
+            json,
+            _arcOptions.Value.JsonSerializerOptions);
+    }
+}

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
@@ -24,6 +24,7 @@ public class ClientEnumerableObservable<T>(
     {
         var webSocket = await context.WebSockets.AcceptWebSocket();
         using var cts = new CancellationTokenSource();
+        using var writeLock = new SemaphoreSlim(1, 1);
         var tsc = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
 
@@ -40,7 +41,7 @@ public class ClientEnumerableObservable<T>(
                     }
 
                     queryResult.Data = item;
-                    var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, cts.Token);
+                    var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                     if (error is null)
                     {
                         continue;
@@ -65,7 +66,7 @@ public class ClientEnumerableObservable<T>(
             }
         });
 
-        await webSocketConnectionHandler.HandleIncomingMessages(webSocket, cts.Token);
+        await webSocketConnectionHandler.HandleIncomingMessages(webSocket, writeLock, cts.Token);
         await cts.CancelAsync();
         await tsc.Task;
     }

--- a/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
@@ -40,6 +40,7 @@ public class ClientObservable<T>(
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
         using var cts = new CancellationTokenSource();
+        using var writeLock = new SemaphoreSlim(1, 1);
 
         using var subscription = Subject.Subscribe(Next, Error, Complete);
 
@@ -47,7 +48,7 @@ public class ClientObservable<T>(
         using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, hostApplicationLifetime.ApplicationStopping);
         linkedTokenSource.Token.Register(Complete);
 
-        await webSocketConnectionHandler.HandleIncomingMessages(webSocket, cts.Token);
+        await webSocketConnectionHandler.HandleIncomingMessages(webSocket, writeLock, cts.Token);
 
         // The client disconnected — clean up without completing the shared subject.
         if (!cts.IsCancellationRequested)
@@ -62,6 +63,11 @@ public class ClientObservable<T>(
 
         async void Next(T data)
         {
+            if (cts.IsCancellationRequested)
+            {
+                return;
+            }
+
             try
             {
                 if (data is null)
@@ -73,34 +79,37 @@ public class ClientObservable<T>(
                 queryResult.Paging = new(queryContext.Paging.Page, queryContext.Paging.Size, queryContext.TotalItems);
                 queryResult.Data = data;
 
-                var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, cts.Token);
-                if (error is not null)
+                var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
+                if (error is not null && !cts.IsCancellationRequested)
                 {
                     Subject.OnError(error);
                 }
             }
             catch (Exception ex)
             {
-                Subject.OnError(ex);
+                if (!cts.IsCancellationRequested)
+                {
+                    Subject.OnError(ex);
+                }
             }
         }
         void Error(Exception error)
         {
-            if (cts.IsCancellationRequested)
-            {
-                Subject.OnCompleted();
-            }
             logger.ObservableAnErrorOccurred(error);
+            if (!cts.IsCancellationRequested)
+            {
+                _ = cts.CancelAsync();
+                tcs.TrySetResult();
+            }
         }
         void Complete()
         {
-            if (cts.IsCancellationRequested)
+            if (!cts.IsCancellationRequested)
             {
-                return;
+                logger.ObservableCompleted();
+                _ = cts.CancelAsync();
             }
-            logger.ObservableCompleted();
-            cts.Cancel();
-            tcs.SetResult();
+            tcs.TrySetResult();
         }
     }
 }

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
@@ -44,11 +44,28 @@ public class ClientObservableSSE<T>(
         using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, hostApplicationLifetime.ApplicationStopping, context.RequestAborted);
         linkedTokenSource.Token.Register(Complete);
 
-        await tcs.Task;
+        try
+        {
+            await tcs.Task;
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal cancellation
+        }
+        finally
+        {
+            await cts.CancelAsync();
+        }
+
         return;
 
         async void Next(T data)
         {
+            if (cts.IsCancellationRequested)
+            {
+                return;
+            }
+
             try
             {
                 if (data is null)
@@ -69,12 +86,18 @@ public class ClientObservableSSE<T>(
                 }
                 catch (Exception ex)
                 {
-                    Subject.OnError(ex);
+                    if (!cts.IsCancellationRequested)
+                    {
+                        Subject.OnError(ex);
+                    }
                 }
             }
             catch (Exception ex)
             {
-                Subject.OnError(ex);
+                if (!cts.IsCancellationRequested)
+                {
+                    Subject.OnError(ex);
+                }
             }
         }
 
@@ -91,12 +114,11 @@ public class ClientObservableSSE<T>(
 
         void Complete()
         {
-            if (cts.IsCancellationRequested)
+            if (!cts.IsCancellationRequested)
             {
-                return;
+                logger.ObservableCompleted();
+                _ = cts.CancelAsync();
             }
-            logger.ObservableCompleted();
-            cts.Cancel();
             tcs.TrySetResult();
         }
     }

--- a/Source/DotNET/Arc.Core/Queries/IWebSocketConnectionHandler.cs
+++ b/Source/DotNET/Arc.Core/Queries/IWebSocketConnectionHandler.cs
@@ -15,18 +15,21 @@ public interface IWebSocketConnectionHandler
     /// </summary>
     /// <param name="webSocket">The <see cref="IWebSocket"/> to send on.</param>
     /// <param name="queryResult">The <see cref="QueryResult"/> message to write.</param>
+    /// <param name="writeLock">A per-connection <see cref="SemaphoreSlim"/> that serializes all sends on this socket.</param>
     /// <param name="token">The <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous action.</returns>
     Task<Exception?> SendMessage(
         IWebSocket webSocket,
         QueryResult queryResult,
+        SemaphoreSlim writeLock,
         CancellationToken token);
 
     /// <summary>
     /// Handles all incoming web messages on the given <see cref="IWebSocket"/>.
     /// </summary>
     /// <param name="webSocket">The <see cref="IWebSocket"/> to listen to.</param>
+    /// <param name="writeLock">A per-connection <see cref="SemaphoreSlim"/> that serializes all sends on this socket.</param>
     /// <param name="token">The <see cref="CancellationToken"/>.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous action.</returns>
-    Task HandleIncomingMessages(IWebSocket webSocket, CancellationToken token);
+    Task HandleIncomingMessages(IWebSocket webSocket, SemaphoreSlim writeLock, CancellationToken token);
 }

--- a/Source/DotNET/Arc.Core/Queries/ObservableAsyncEnumerator.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableAsyncEnumerator.cs
@@ -16,6 +16,7 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
     readonly CancellationToken _cancellationToken;
     readonly ConcurrentQueue<T> _items = new();
     TaskCompletionSource _taskCompletionSource = new();
+    bool _completed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ObservableAsyncEnumerator{T}"/> class.
@@ -25,17 +26,20 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
     public ObservableAsyncEnumerator(IObservable<T> observable, CancellationToken cancellationToken)
     {
         Current = default!;
-        _subscriber = observable.Subscribe(_ =>
-        {
-            _items.Enqueue(_);
-            lock (_lock)
+        _subscriber = observable.Subscribe(
+            onNext: _ =>
             {
-                if (!_taskCompletionSource.Task.IsCompletedSuccessfully)
+                _items.Enqueue(_);
+                lock (_lock)
                 {
-                    _taskCompletionSource?.SetResult();
+                    if (!_taskCompletionSource.Task.IsCompletedSuccessfully)
+                    {
+                        _taskCompletionSource.SetResult();
+                    }
                 }
-            }
-        });
+            },
+            onError: _ => SignalCompletion(),
+            onCompleted: SignalCompletion);
         _cancellationToken = cancellationToken;
     }
 
@@ -46,6 +50,7 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
     public ValueTask DisposeAsync()
     {
         _subscriber.Dispose();
+        SignalCompletion();
         return ValueTask.CompletedTask;
     }
 
@@ -57,17 +62,30 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
 
         lock (_lock)
         {
+            if (_completed && _items.IsEmpty) return false;
             _items.TryDequeue(out var item);
             Current = item!;
             _taskCompletionSource = new();
 
             // Check if new items arrived while we were updating TCS
-            if (!_items.IsEmpty)
+            if (!_items.IsEmpty || _completed)
             {
                 _taskCompletionSource.SetResult();
             }
         }
 
         return true;
+    }
+
+    void SignalCompletion()
+    {
+        lock (_lock)
+        {
+            _completed = true;
+            if (!_taskCompletionSource.Task.IsCompletedSuccessfully)
+            {
+                _taskCompletionSource.SetResult();
+            }
+        }
     }
 }

--- a/Source/DotNET/Arc.Core/Queries/ObservableAsyncEnumerator.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableAsyncEnumerator.cs
@@ -11,6 +11,7 @@ namespace Cratis.Arc.Queries;
 /// <typeparam name="T">Type the enumerator is for.</typeparam>
 public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
 {
+    readonly object _lock = new();
     readonly IDisposable _subscriber;
     readonly CancellationToken _cancellationToken;
     readonly ConcurrentQueue<T> _items = new();
@@ -27,9 +28,12 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
         _subscriber = observable.Subscribe(_ =>
         {
             _items.Enqueue(_);
-            if (!_taskCompletionSource.Task.IsCompletedSuccessfully)
+            lock (_lock)
             {
-                _taskCompletionSource?.SetResult();
+                if (!_taskCompletionSource.Task.IsCompletedSuccessfully)
+                {
+                    _taskCompletionSource?.SetResult();
+                }
             }
         });
         _cancellationToken = cancellationToken;
@@ -50,12 +54,18 @@ public class ObservableAsyncEnumerator<T> : IAsyncEnumerator<T>
     {
         if (_cancellationToken.IsCancellationRequested) return false;
         await _taskCompletionSource.Task;
-        _items.TryDequeue(out var item);
-        Current = item!;
-        _taskCompletionSource = new();
-        if (!_items.IsEmpty)
+
+        lock (_lock)
         {
-            _taskCompletionSource.SetResult();
+            _items.TryDequeue(out var item);
+            Current = item!;
+            _taskCompletionSource = new();
+
+            // Check if new items arrived while we were updating TCS
+            if (!_items.IsEmpty)
+            {
+                _taskCompletionSource.SetResult();
+            }
         }
 
         return true;

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -119,12 +119,12 @@ public class ObservableQueryDemultiplexer(
         var state = new SSEConnectionState(context, linkedCts);
         _sseConnections[connectionId] = state;
 
-        var keepAliveTask = RunSseKeepAlive(context, state.KeepAliveTracker, linkedCts);
+        var keepAliveTask = RunSseKeepAlive(context, state.KeepAliveTracker, linkedCts, state.WriteLock);
 
         try
         {
             // Send the Connected message so the client knows its connection ID for POST requests.
-            await SendSseMessage(context, ObservableQueryHubMessage.CreateConnected(connectionId), state.KeepAliveTracker, linkedCts);
+            await SendSseMessage(context, ObservableQueryHubMessage.CreateConnected(connectionId), state.KeepAliveTracker, linkedCts, state.WriteLock);
 
             // Block until the client disconnects or the server shuts down.
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -197,18 +197,18 @@ public class ObservableQueryDemultiplexer(
             async result =>
             {
                 var msg = ObservableQueryHubMessage.CreateQueryResult(body.QueryId, result);
-                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource);
+                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource, state.WriteLock);
             },
             async (id, errorMsg) =>
             {
                 var msg = ObservableQueryHubMessage.CreateError(id, errorMsg);
-                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource);
+                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource, state.WriteLock);
             },
             async id =>
             {
                 wasUnauthorized = true;
                 var msg = ObservableQueryHubMessage.CreateUnauthorized(id);
-                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource);
+                await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource, state.WriteLock);
             },
             state.CancellationTokenSource.Token);
 
@@ -691,10 +691,20 @@ public class ObservableQueryDemultiplexer(
         }
     }
 
-    async Task SendSseMessage(IHttpRequestContext context, ObservableQueryHubMessage message, KeepAliveTracker keepAliveTracker, CancellationTokenSource cts)
+    async Task SendSseMessage(
+        IHttpRequestContext context,
+        ObservableQueryHubMessage message,
+        KeepAliveTracker keepAliveTracker,
+        CancellationTokenSource cts,
+        SemaphoreSlim writeLock)
     {
+        var writeLockHeld = false;
+
         try
         {
+            await writeLock.WaitAsync(cts.Token);
+            writeLockHeld = true;
+
             var json = JsonSerializer.Serialize(message, arcOptions.Value.JsonSerializerOptions);
             await context.Write($"data: {json}\n\n", cts.Token);
             keepAliveTracker.RecordMessageSent();
@@ -710,6 +720,11 @@ public class ObservableQueryDemultiplexer(
             // instead of HttpListenerException — treat identically.
             await cts.CancelAsync();
         }
+        catch (ArgumentNullException ex) when (ex.ParamName == "array")
+        {
+            // StreamPipeWriter can throw this during response teardown when writes race with transport shutdown.
+            await cts.CancelAsync();
+        }
         catch (OperationCanceledException)
         {
             // Normal shutdown — nothing to report.
@@ -717,6 +732,13 @@ public class ObservableQueryDemultiplexer(
         catch (Exception ex)
         {
             logger.ErrorSendingMessage(ex);
+        }
+        finally
+        {
+            if (writeLockHeld)
+            {
+                writeLock.Release();
+            }
         }
     }
 
@@ -747,7 +769,7 @@ public class ObservableQueryDemultiplexer(
         }
     }
 
-    async Task RunSseKeepAlive(IHttpRequestContext context, KeepAliveTracker keepAliveTracker, CancellationTokenSource cts)
+    async Task RunSseKeepAlive(IHttpRequestContext context, KeepAliveTracker keepAliveTracker, CancellationTokenSource cts, SemaphoreSlim writeLock)
     {
         var interval = arcOptions.Value.Query.KeepAliveInterval;
 
@@ -764,7 +786,7 @@ public class ObservableQueryDemultiplexer(
 
                 if (!cts.Token.IsCancellationRequested && keepAliveTracker.ShouldSendKeepAlive(interval))
                 {
-                    await SendSseMessage(context, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, cts);
+                    await SendSseMessage(context, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, cts, writeLock);
                 }
             }
         }
@@ -858,5 +880,6 @@ public class ObservableQueryDemultiplexer(
     {
         public ConcurrentDictionary<string, IDisposable> Subscriptions { get; } = new();
         public KeepAliveTracker KeepAliveTracker { get; } = new();
+        public SemaphoreSlim WriteLock { get; } = new(1, 1);
     }
 }

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -64,6 +64,7 @@ public class ObservableQueryDemultiplexer(
 
         var webSocket = await context.WebSockets.AcceptWebSocket(context.RequestAborted);
         var subscriptions = new ConcurrentDictionary<string, IDisposable>();
+        var writeLock = new SemaphoreSlim(1, 1);
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             context.RequestAborted,
@@ -75,9 +76,9 @@ public class ObservableQueryDemultiplexer(
         try
         {
 #pragma warning disable CA2025 // keepAliveTask is always awaited in the finally block before linkedCts is disposed
-            keepAliveTask = RunWebSocketKeepAlive(webSocket, keepAliveTracker, linkedCts.Token);
+            keepAliveTask = RunWebSocketKeepAlive(webSocket, keepAliveTracker, writeLock, linkedCts.Token);
 #pragma warning restore CA2025
-            await ReadWebSocketMessages(webSocket, subscriptions, context, keepAliveTracker, linkedCts.Token);
+            await ReadWebSocketMessages(webSocket, subscriptions, context, keepAliveTracker, writeLock, linkedCts.Token);
         }
         catch (OperationCanceledException)
         {
@@ -96,6 +97,8 @@ public class ObservableQueryDemultiplexer(
             {
                 subscription.Dispose();
             }
+
+            writeLock.Dispose();
 
             logger.WebSocketClientDisconnected();
         }
@@ -259,6 +262,7 @@ public class ObservableQueryDemultiplexer(
         ConcurrentDictionary<string, IDisposable> subscriptions,
         IHttpRequestContext context,
         KeepAliveTracker keepAliveTracker,
+        SemaphoreSlim writeLock,
         CancellationToken token)
     {
         var buffer = new byte[WebSocketBufferSize];
@@ -301,7 +305,7 @@ public class ObservableQueryDemultiplexer(
                     continue;
                 }
 
-                await ProcessWebSocketMessage(message, webSocket, subscriptions, context, keepAliveTracker, token);
+                await ProcessWebSocketMessage(message, webSocket, subscriptions, context, keepAliveTracker, writeLock, token);
             }
             catch (Exception ex)
             {
@@ -324,6 +328,7 @@ public class ObservableQueryDemultiplexer(
         ConcurrentDictionary<string, IDisposable> subscriptions,
         IHttpRequestContext context,
         KeepAliveTracker keepAliveTracker,
+        SemaphoreSlim writeLock,
         CancellationToken token)
     {
         // Any inbound message from the client counts as activity — no keep-alive needed.
@@ -332,7 +337,7 @@ public class ObservableQueryDemultiplexer(
         switch (message.Type)
         {
             case ObservableQueryHubMessageType.Subscribe:
-                await HandleWebSocketSubscribe(message, webSocket, subscriptions, context, keepAliveTracker, token);
+                await HandleWebSocketSubscribe(message, webSocket, subscriptions, context, keepAliveTracker, writeLock, token);
                 break;
 
             case ObservableQueryHubMessageType.Unsubscribe:
@@ -340,7 +345,7 @@ public class ObservableQueryDemultiplexer(
                 break;
 
             case ObservableQueryHubMessageType.Ping:
-                await SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePong(message.Timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), keepAliveTracker, token);
+                await SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePong(message.Timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()), keepAliveTracker, writeLock, token);
                 break;
         }
     }
@@ -351,6 +356,7 @@ public class ObservableQueryDemultiplexer(
         ConcurrentDictionary<string, IDisposable> subscriptions,
         IHttpRequestContext context,
         KeepAliveTracker keepAliveTracker,
+        SemaphoreSlim writeLock,
         CancellationToken token)
     {
         var request = DeserializeSubscriptionRequest(message.Payload);
@@ -377,17 +383,17 @@ public class ObservableQueryDemultiplexer(
             async result =>
             {
                 var msg = ObservableQueryHubMessage.CreateQueryResult(queryId, result);
-                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, token);
+                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, writeLock, token);
             },
             async (id, errorMsg) =>
             {
                 var msg = ObservableQueryHubMessage.CreateError(id, errorMsg);
-                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, token);
+                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, writeLock, token);
             },
             async id =>
             {
                 var msg = ObservableQueryHubMessage.CreateUnauthorized(id);
-                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, token);
+                await SendWebSocketMessage(webSocket, msg, keepAliveTracker, writeLock, token);
             },
             token);
 
@@ -672,10 +678,20 @@ public class ObservableQueryDemultiplexer(
         }
     }
 
-    async Task SendWebSocketMessage(IWebSocket webSocket, ObservableQueryHubMessage message, KeepAliveTracker keepAliveTracker, CancellationToken token)
+    async Task SendWebSocketMessage(IWebSocket webSocket, ObservableQueryHubMessage message, KeepAliveTracker keepAliveTracker, SemaphoreSlim writeLock, CancellationToken token)
     {
+        var lockHeld = false;
+
         try
         {
+            if (webSocket.State != WebSocketState.Open)
+            {
+                return;
+            }
+
+            await writeLock.WaitAsync(token);
+            lockHeld = true;
+
             if (webSocket.State != WebSocketState.Open)
             {
                 return;
@@ -685,9 +701,20 @@ public class ObservableQueryDemultiplexer(
             await webSocket.Send(new ArraySegment<byte>(json), System.Net.WebSockets.WebSocketMessageType.Text, true, token);
             keepAliveTracker.RecordMessageSent();
         }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown or token cancelled
+        }
         catch (Exception ex)
         {
             logger.ErrorSendingMessage(ex);
+        }
+        finally
+        {
+            if (lockHeld)
+            {
+                writeLock.Release();
+            }
         }
     }
 
@@ -742,7 +769,7 @@ public class ObservableQueryDemultiplexer(
         }
     }
 
-    async Task RunWebSocketKeepAlive(IWebSocket webSocket, KeepAliveTracker keepAliveTracker, CancellationToken token)
+    async Task RunWebSocketKeepAlive(IWebSocket webSocket, KeepAliveTracker keepAliveTracker, SemaphoreSlim writeLock, CancellationToken token)
     {
         var interval = arcOptions.Value.Query.KeepAliveInterval;
 
@@ -759,7 +786,7 @@ public class ObservableQueryDemultiplexer(
 
                 if (!token.IsCancellationRequested && keepAliveTracker.ShouldSendKeepAlive(interval))
                 {
-                    await SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, token);
+                    await SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, writeLock, token);
                 }
             }
         }

--- a/Source/DotNET/Arc.Core/Queries/WebSocketConnectionHandler.cs
+++ b/Source/DotNET/Arc.Core/Queries/WebSocketConnectionHandler.cs
@@ -21,7 +21,7 @@ public class WebSocketConnectionHandler(IOptions<ArcOptions> arcOptions, ILogger
     const int BufferSize = 1024 * 4;
 
     /// <inheritdoc/>
-    public async Task HandleIncomingMessages(IWebSocket webSocket, CancellationToken token)
+    public async Task HandleIncomingMessages(IWebSocket webSocket, SemaphoreSlim writeLock, CancellationToken token)
     {
         try
         {
@@ -43,7 +43,7 @@ public class WebSocketConnectionHandler(IOptions<ArcOptions> arcOptions, ILogger
                     // Handle ping messages
                     if (received.MessageType == System.Net.WebSockets.WebSocketMessageType.Text && !received.CloseStatus.HasValue)
                     {
-                        await HandlePotentialPingMessage(webSocket, buffer, received.Count, token);
+                        await HandlePotentialPingMessage(webSocket, buffer, received.Count, writeLock, token);
                     }
                 }
                 while (!received.CloseStatus.HasValue);
@@ -84,13 +84,23 @@ public class WebSocketConnectionHandler(IOptions<ArcOptions> arcOptions, ILogger
     public async Task<Exception?> SendMessage(
         IWebSocket webSocket,
         QueryResult queryResult,
+        SemaphoreSlim writeLock,
         CancellationToken token)
     {
+        var lockHeld = false;
         try
         {
             if (webSocket.State != WebSocketState.Open)
             {
                 handlerLogger.WebSocketNotOpen(webSocket.State);
+                return null;
+            }
+
+            await writeLock.WaitAsync(token);
+            lockHeld = true;
+
+            if (webSocket.State != WebSocketState.Open)
+            {
                 return null;
             }
 
@@ -100,14 +110,25 @@ public class WebSocketConnectionHandler(IOptions<ArcOptions> arcOptions, ILogger
             message = null;
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
         catch (Exception ex)
         {
             handlerLogger.ErrorSendingMessage(ex);
             return ex;
         }
+        finally
+        {
+            if (lockHeld)
+            {
+                writeLock.Release();
+            }
+        }
     }
 
-    async Task HandlePotentialPingMessage(IWebSocket webSocket, byte[] buffer, int count, CancellationToken token)
+    async Task HandlePotentialPingMessage(IWebSocket webSocket, byte[] buffer, int count, SemaphoreSlim writeLock, CancellationToken token)
     {
         try
         {
@@ -119,8 +140,24 @@ public class WebSocketConnectionHandler(IOptions<ArcOptions> arcOptions, ILogger
                 handlerLogger.ReceivedPingMessage();
                 var pongMessage = WebSocketMessage.Pong(message.Timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                 var pongBytes = JsonSerializer.SerializeToUtf8Bytes(pongMessage, arcOptions.Value.JsonSerializerOptions);
-                await webSocket.Send(pongBytes, System.Net.WebSockets.WebSocketMessageType.Text, true, token);
-                handlerLogger.SentPongMessage();
+                var lockHeld = false;
+                try
+                {
+                    await writeLock.WaitAsync(token);
+                    lockHeld = true;
+                    await webSocket.Send(pongBytes, System.Net.WebSockets.WebSocketMessageType.Text, true, token);
+                    handlerLogger.SentPongMessage();
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                finally
+                {
+                    if (lockHeld)
+                    {
+                        writeLock.Release();
+                    }
+                }
             }
         }
         catch (JsonException)

--- a/Source/DotNET/MongoDB.Specs/for_MongoDBWatcher/when_watching/and_the_change_stream_fails.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoDBWatcher/when_watching/and_the_change_stream_fails.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_MongoDBWatcher.when_watching;
+
+public class and_the_change_stream_fails
+{
+    [Fact]
+    public async Task should_retry_watching_after_transient_failure()
+    {
+        // Configure the global naming policy required by DatabaseExtensions.GetCollection<T>()
+        var namingPolicy = Substitute.For<INamingPolicy>();
+        namingPolicy.GetReadModelName(Arg.Any<Type>()).Returns(ci => ci.Arg<Type>().Name.ToLowerInvariant());
+        DatabaseExtensions.SetNamingPolicy(namingPolicy);
+
+        var callCount = 0;
+        var secondCallStarted = new TaskCompletionSource();
+
+        var database = Substitute.For<IMongoDatabase>();
+
+        // First call: throw a transient exception
+        // Second call: succeed but block forever (until cancelled)
+        var blockingCursor = Substitute.For<IChangeStreamCursor<ChangeStreamDocument<BsonDocument>>>();
+#pragma warning disable CA2025 // Intentional: test uses a never-completing task to keep the watch loop alive
+        var blockTcs = new TaskCompletionSource<bool>();
+        blockingCursor.MoveNextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                secondCallStarted.TrySetResult();
+                return blockTcs.Task;
+            });
+#pragma warning restore CA2025
+
+        database.WatchAsync(
+            Arg.Any<PipelineDefinition<ChangeStreamDocument<BsonDocument>, ChangeStreamDocument<BsonDocument>>>(),
+            Arg.Any<ChangeStreamOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    throw new Exception("Simulated transient failure");
+
+#pragma warning disable CA2025 // Intentional: test uses a cursor wrapping a disposable for a never-completing task
+                return Task.FromResult(blockingCursor);
+#pragma warning restore CA2025
+            });
+
+        var mongoClient = Substitute.For<IMongoClient>();
+        mongoClient.GetDatabase(Arg.Any<string>()).Returns(database);
+
+        // GetCollection<T> must succeed so Observe<BsonDocument>() can build the builder
+        var collection = Substitute.For<IMongoCollection<BsonDocument>>();
+        collection.CollectionNamespace.Returns(new CollectionNamespace("testdb", "bsondocument"));
+        collection.Database.Returns(database);
+        database.GetCollection<BsonDocument>(Arg.Any<string>(), Arg.Any<MongoCollectionSettings>())
+            .Returns(collection);
+
+        var clientFactory = Substitute.For<IMongoDBClientFactory>();
+        clientFactory.Create().Returns(mongoClient);
+
+        var databaseNameResolver = Substitute.For<IMongoDatabaseNameResolver>();
+        databaseNameResolver.Resolve().Returns("testdb");
+
+        var logger = Substitute.For<Microsoft.Extensions.Logging.ILogger<MongoDBWatcher>>();
+
+        // Override the default 1-second reconnect delay to keep the test fast by using
+        // a watcher whose _cts we will cancel, not by waiting 1 s
+        using var watcher = new MongoDBWatcher(clientFactory, databaseNameResolver, logger);
+
+        // Trigger watching (EnsureWatching is called on first Observe call)
+        _ = watcher.Observe<BsonDocument>();
+
+        // Wait for the second WatchAsync call to start — proves the loop retried
+        await secondCallStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        callCount.ShouldBeGreaterThan(1);
+    }
+}

--- a/Source/DotNET/MongoDB/MongoDBWatcher.cs
+++ b/Source/DotNET/MongoDB/MongoDBWatcher.cs
@@ -89,42 +89,60 @@ public class MongoDBWatcher(
 
     async Task WatchDatabaseAsync()
     {
-        try
+        var databaseName = databaseNameResolver.Resolve();
+        var delay = TimeSpan.FromSeconds(1);
+
+        while (!_cts.IsCancellationRequested)
         {
-            var databaseName = databaseNameResolver.Resolve();
-            var database = GetDatabase();
-            var options = new ChangeStreamOptions
+            try
             {
-                FullDocument = ChangeStreamFullDocumentOption.UpdateLookup
-            };
-
-            var pipeline = new EmptyPipelineDefinition<ChangeStreamDocument<BsonDocument>>();
-            using var cursor = await database.WatchAsync(pipeline, options, _cts.Token);
-            logger.StartedWatchingDatabase(databaseName);
-
-            await cursor.ForEachAsync(
-                changeDocument =>
+                var database = GetDatabase();
+                var options = new ChangeStreamOptions
                 {
-                    try
-                    {
-                        _databaseChanges.OnNext(changeDocument);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.UnexpectedError(ex);
-                    }
-                },
-                _cts.Token);
+                    FullDocument = ChangeStreamFullDocumentOption.UpdateLookup
+                };
 
-            logger.DatabaseWatchCompleted(databaseName);
-        }
-        catch (OperationCanceledException)
-        {
-            logger.DatabaseWatchCancelled();
-        }
-        catch (Exception ex)
-        {
-            logger.UnexpectedError(ex);
+                var pipeline = new EmptyPipelineDefinition<ChangeStreamDocument<BsonDocument>>();
+                using var cursor = await database.WatchAsync(pipeline, options, _cts.Token);
+                logger.StartedWatchingDatabase(databaseName);
+                delay = TimeSpan.FromSeconds(1);
+
+                await cursor.ForEachAsync(
+                    changeDocument =>
+                    {
+                        try
+                        {
+                            _databaseChanges.OnNext(changeDocument);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.UnexpectedError(ex);
+                        }
+                    },
+                    _cts.Token);
+
+                logger.DatabaseWatchCompleted(databaseName);
+            }
+            catch (OperationCanceledException)
+            {
+                logger.DatabaseWatchCancelled();
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.DatabaseWatchReconnecting(databaseName, delay.TotalSeconds);
+                logger.UnexpectedError(ex);
+                try
+                {
+                    await Task.Delay(delay, _cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, 60));
+            }
         }
     }
 }

--- a/Source/DotNET/MongoDB/MongoDBWatcherLogMessages.cs
+++ b/Source/DotNET/MongoDB/MongoDBWatcherLogMessages.cs
@@ -20,4 +20,7 @@ internal static partial class MongoDBWatcherLogMessages
 
     [LoggerMessage(LogLevel.Warning, "Unexpected error occurred in database watcher")]
     internal static partial void UnexpectedError(this ILogger<MongoDBWatcher> logger, Exception ex);
+
+    [LoggerMessage(LogLevel.Warning, "Database watch for '{DatabaseName}' failed; reconnecting in {Delay}s")]
+    internal static partial void DatabaseWatchReconnecting(this ILogger<MongoDBWatcher> logger, string databaseName, double delay);
 }


### PR DESCRIPTION
## Fixed

- `ObservableAsyncEnumerator` drops buffered items after sequence completion because `_completed` flag caused early return before draining the queue; subscribe to `onCompleted`/`onError` to signal termination; signal on `DisposeAsync`
- `ClientObservable` races: `tcs.SetResult` throws on double-Complete; no guard on `Next()` after cancellation; `Error()` did not cancel the loop; add `SemaphoreSlim writeLock` threading
- `WebSocketConnectionHandler` pong sends race with data sends due to missing write serialization; thread `SemaphoreSlim writeLock` through `SendMessage` and `HandleIncomingMessages`
- `ClientEnumerableObservable` did not pass `writeLock` to handler calls
- `MongoDBWatcher` exits permanently on any non-cancellation exception from the change stream, silently killing all observers; add outer retry loop with exponential backoff (1s → doubles → cap 60s)
- `ObservableQueryDemultiplexer`, `ObservableAsyncEnumerator`, `ClientObservableSSE` pre-existing concurrency races (committed in earlier session)
