### PR TITLE
Suppress AD0001 analyzer diagnostic

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,4 +1,5 @@
 is_global = true
+dotnet_diagnostic.AD0001.severity = none
 dotnet_diagnostic.AS0003.severity = none
 dotnet_diagnostic.AS0009.severity = none
 dotnet_diagnostic.AS0010.severity = none


### PR DESCRIPTION
## Fixed
- Suppress AD0001 analyzer diagnostic noise in global analyzer configuration to avoid build interruptions from analyzer driver failures.