### PR TITLE
Suppress IDE0005 warnings in test app projects

### DIFF
--- a/TestApps/ArcCore/ArcCore.csproj
+++ b/TestApps/ArcCore/ArcCore.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>
+        <NoWarn>$(NoWarn);SA0001;SA1600;IDE0005</NoWarn>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/TestApps/AspNetCore/AspNetCore.csproj
+++ b/TestApps/AspNetCore/AspNetCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);SA0001;SA1600;SA1649;SA1402;MA0048</NoWarn>
+    <NoWarn>$(NoWarn);SA0001;SA1600;SA1649;SA1402;MA0048;IDE0005</NoWarn>
     <IsPackable>false</IsPackable>
 
     <CratisProxiesOutputPath>$(MSBuildThisFileDirectory)/</CratisProxiesOutputPath>

--- a/TestApps/Core/Core.csproj
+++ b/TestApps/Core/Core.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>
+        <NoWarn>$(NoWarn);SA0001;SA1600;IDE0005</NoWarn>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/TestApps/Shared/Shared.csproj
+++ b/TestApps/Shared/Shared.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);SA0001;SA1600;IDE0005</NoWarn>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 


### PR DESCRIPTION
## Fixed
- Suppress IDE0005 remove-using diagnostics in test app project builds by extending project-level NoWarn settings.