### PR TITLE
Use current identity on provider load

### DIFF
--- a/Source/JavaScript/Arc.React/identity/IdentityProvider.tsx
+++ b/Source/JavaScript/Arc.React/identity/IdentityProvider.tsx
@@ -52,7 +52,7 @@ export const IdentityProvider = (props: IdentityProviderProps) => {
     RootIdentityProvider.setOrigin(arc.origin ?? '');
 
     const fetchIdentity = (): Promise<IIdentity> => {
-        return RootIdentityProvider.refresh(props.detailsType).then(identity => {
+        return RootIdentityProvider.getCurrent(props.detailsType).then(identity => {
             const wrappedIdentity = wrapRefresh(identity);
             setIdentityState({
                 identity: wrappedIdentity,


### PR DESCRIPTION
## Fixed
- Preserve the current identity when the React identity provider initializes instead of forcing an immediate refresh.