### PR TITLE
Change MongoDB package name in documentation

### DIFF
--- a/Documentation/backend/getting-started/cratis-package.md
+++ b/Documentation/backend/getting-started/cratis-package.md
@@ -78,7 +78,7 @@ builder.AddCratis(
 By default, the Cratis package doesn't include MongoDB support. To use MongoDB with your application, add the MongoDB package separately:
 
 ```bash
-dotnet add package Cratis.Applications.MongoDB
+dotnet add package Cratis.Arc.MongoDB
 ```
 
 Then configure MongoDB using the `WithMongoDB` extension method:


### PR DESCRIPTION
The documentation looks outdated compare to the Library sample. The package referenced in the existing documentation doesn't work as intended in the example.

# Summary

## Fixed

- Fixed small reference error in documentation (no issue)