### PR TITLE
Support internal query methods in generated metadata

### DIFF
--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_is_internal.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_with_read_models/and_read_model_is_internal.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Cratis.Arc.Generators.for_QueryMetadataGenerator.when_generating_with_read_models;
 
-public class and_read_model_has_non_public_query_method : Specification
+public class and_read_model_is_internal : Specification
 {
     GeneratorDriverRunResult _result;
     string _generatedSource;
@@ -19,11 +19,9 @@ public class and_read_model_has_non_public_query_method : Specification
             namespace TestApp;
 
             [ReadModel]
-            public class MyReadModel
+            internal class MyReadModel
             {
-                public static MyReadModel GetById(int id) => new();
-                internal static MyReadModel GetByName(string name) => new();
-                private static MyReadModel GetByValue(string value) => new();
+                internal static MyReadModel GetById(int id) => new();
             }
             """);
 
@@ -31,7 +29,6 @@ public class and_read_model_has_non_public_query_method : Specification
     }
 
     [Fact] void should_generate_two_source_files() => _result.GeneratedTrees.Length.ShouldEqual(2);
-    [Fact] void should_include_public_query() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetById");
-    [Fact] void should_include_internal_query() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetByName");
-    [Fact] void should_not_include_private_query() => _generatedSource.ShouldNotContain("TestApp.MyReadModel.GetByValue");
+    [Fact] void should_include_internal_read_model_query() => _generatedSource.ShouldContain("TestApp.MyReadModel.GetById");
+    [Fact] void should_reference_internal_read_model_type() => _generatedSource.ShouldContain("typeof(global::TestApp.MyReadModel)");
 }

--- a/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
+++ b/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
@@ -55,7 +55,7 @@ public class QueryMetadataGenerator : IIncrementalGenerator
             .Where(m =>
                 m.MethodKind == MethodKind.Ordinary &&
                 m.IsStatic &&
-                m.DeclaredAccessibility == Accessibility.Public &&
+                IsSupportedQueryMethodAccessibility(m) &&
                 IsValidQueryMethod(m, typeSymbol))
             .Select(m => m.Name)
             .ToList();
@@ -73,6 +73,9 @@ public class QueryMetadataGenerator : IIncrementalGenerator
     static bool HasReadModelAttribute(INamedTypeSymbol typeSymbol) =>
         typeSymbol.GetAttributes().Any(a =>
             string.Equals(a.AttributeClass?.ToDisplayString(), ReadModelAttributeFullName, StringComparison.Ordinal));
+
+    static bool IsSupportedQueryMethodAccessibility(IMethodSymbol method) =>
+        method.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal;
 
     static bool IsValidQueryMethod(IMethodSymbol method, INamedTypeSymbol readModelType)
     {

--- a/TestApps/Chronicle/Chronicle.csproj
+++ b/TestApps/Chronicle/Chronicle.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>


### PR DESCRIPTION
## Fixed
- Query metadata generation now registers internal model-bound query methods and internal read models for AOT-safe lookup (#2098)