### PR TITLE
Fix MongoDB observer watch tasks leaking after client unsubscribe

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_LifetimeAwareSubject/when_disposing_last_subscription.cs
+++ b/Source/DotNET/MongoDB.Specs/for_LifetimeAwareSubject/when_disposing_last_subscription.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.MongoDB.for_LifetimeAwareSubject;
+
+public class when_disposing_last_subscription
+{
+    [Fact]
+    public void should_invoke_the_cleanup_callback()
+    {
+        var callbackInvocations = 0;
+        var subject = new LifetimeAwareSubject<int>(new Subject<int>(), () => callbackInvocations++);
+
+        var firstSubscription = subject.Subscribe(_ => { });
+        var secondSubscription = subject.Subscribe(_ => { });
+
+        firstSubscription.Dispose();
+        callbackInvocations.ShouldEqual(0);
+
+        secondSubscription.Dispose();
+        callbackInvocations.ShouldEqual(1);
+    }
+}

--- a/Source/DotNET/MongoDB.Specs/for_MongoDBJoinedObserveBuilder/when_disposing_the_subscription.cs
+++ b/Source/DotNET/MongoDB.Specs/for_MongoDBJoinedObserveBuilder/when_disposing_the_subscription.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.MongoDB.for_MongoDBJoinedObserveBuilder;
+
+public class when_disposing_the_subscription : given.a_joined_observe_builder
+{
+    IDisposable _subscription = default!;
+
+    async Task Because()
+    {
+        var firstEmission = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var subject = _builder.Select((a, b) => (a, b));
+        _subscription = subject.Subscribe(_ => firstEmission.TrySetResult());
+
+        await firstEmission.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        _subscription.Dispose();
+
+        SpinWait.SpinUntil(() => !_databaseChanges.HasObservers, TimeSpan.FromSeconds(5))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    void should_detach_from_database_changes() => _databaseChanges.HasObservers.ShouldBeFalse();
+}

--- a/Source/DotNET/MongoDB/LifetimeAwareSubject.cs
+++ b/Source/DotNET/MongoDB/LifetimeAwareSubject.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// Represents an <see cref="ISubject{T}"/> that invokes a callback when the last external subscriber unsubscribes.
+/// </summary>
+/// <param name="inner">The inner <see cref="ISubject{T}"/> to delegate to.</param>
+/// <param name="onNoSubscribers">The callback to invoke when the last subscriber unsubscribes.</param>
+/// <typeparam name="T">The type of elements in the subject.</typeparam>
+internal sealed class LifetimeAwareSubject<T>(ISubject<T> inner, Action onNoSubscribers) : ISubject<T>, IDisposable
+{
+    int _subscriberCount;
+    int _stopped;
+
+    /// <summary>
+    /// Creates a new <see cref="LifetimeAwareSubject{T}"/> backed by a <see cref="Subject{T}"/>.
+    /// </summary>
+    /// <param name="onNoSubscribers">The callback to invoke when the last subscriber unsubscribes.</param>
+    /// <returns>A new <see cref="LifetimeAwareSubject{T}"/> instance.</returns>
+    public static LifetimeAwareSubject<T> Create(Action onNoSubscribers)
+    {
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        return new LifetimeAwareSubject<T>(new Subject<T>(), onNoSubscribers);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+    }
+
+    /// <inheritdoc/>
+    public void OnCompleted()
+    {
+        try
+        {
+            inner.OnCompleted();
+        }
+        finally
+        {
+            Stop();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void OnError(Exception error)
+    {
+        try
+        {
+            inner.OnError(error);
+        }
+        finally
+        {
+            Stop();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void OnNext(T value) => inner.OnNext(value);
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        var subscription = inner.Subscribe(observer);
+        Interlocked.Increment(ref _subscriberCount);
+        return new Subscription(this, subscription);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Stop();
+        if (inner is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    void Release()
+    {
+        if (Interlocked.Decrement(ref _subscriberCount) == 0)
+        {
+            Stop();
+        }
+    }
+
+    void Stop()
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) == 0)
+        {
+            onNoSubscribers();
+        }
+    }
+
+    sealed class Subscription(LifetimeAwareSubject<T> owner, IDisposable innerSubscription) : IDisposable
+    {
+        int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            {
+                return;
+            }
+
+            innerSubscription.Dispose();
+            owner.Release();
+        }
+    }
+}

--- a/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
+++ b/Source/DotNET/MongoDB/MongoCollectionExtensions.cs
@@ -171,7 +171,6 @@ public static class MongoCollectionExtensions
         Action<IEnumerable<TDocument>, ISubject<TResult>> onNext)
     {
         var completedCleanup = false;
-        var subject = createSubject([]);
         var logger = Internals.ServiceProvider.GetRequiredService<ILogger<MongoCollection>>();
         var queryContextManager = Internals.ServiceProvider.GetRequiredService<IQueryContextManager>();
         var queryContext = queryContextManager.Current;
@@ -197,22 +196,23 @@ public static class MongoCollectionExtensions
 
         var pipeline = new EmptyPipelineDefinition<ChangeStreamDocument<TDocument>>().Match(fullFilter);
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
+    #pragma warning disable CA2000 // Dispose objects before losing scope
         var cancellationTokenSource = new CancellationTokenSource();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-        // When client unsubscribes, cancel the watch task
-        _ = subject.Subscribe(_ => { }, _ => { }, () =>
-        {
-            logger.ClientUnsubscribed();
-            cancellationTokenSource?.Cancel();
-        });
+    #pragma warning restore CA2000 // Dispose objects before losing scope
+        var subject = new LifetimeAwareSubject<TResult>(
+            createSubject([]),
+            () =>
+            {
+                logger.ClientUnsubscribed();
+                cancellationTokenSource?.Cancel();
+            });
+        ISubject<TResult> observable = subject;
 
         var cancellationToken = cancellationTokenSource.Token;
         cancellationToken.ThrowIfCancellationRequested();
 
         _ = Task.Run(Watch);
-        return subject;
+        return observable;
 
         async Task Watch()
         {
@@ -276,7 +276,8 @@ public static class MongoCollectionExtensions
             logger.CleaningUp();
             cancellationTokenSource?.Dispose();
             cancellationTokenSource = default;
-            subject?.OnCompleted();
+            subject.OnCompleted();
+            subject.Dispose();
         }
     }
 

--- a/Source/DotNET/MongoDB/MongoDBJoinedObserveBuilder.cs
+++ b/Source/DotNET/MongoDB/MongoDBJoinedObserveBuilder.cs
@@ -49,19 +49,15 @@ internal sealed class MongoDBJoinedObserveBuilder<T1, T2>(
     public ISubject<TResult> Select<TResult>(
         Func<IEnumerable<T1>, IEnumerable<T2>, TResult> selector)
     {
-#pragma warning disable CA2000 // Dispose objects before losing scope
+    #pragma warning disable CA2000 // Dispose objects before losing scope
         // The CancellationTokenSource is disposed in the finally block of the background Task.Run below.
         var cts = new CancellationTokenSource();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-        var subject = new Subject<TResult>();
+    #pragma warning restore CA2000 // Dispose objects before losing scope
+        var subject = LifetimeAwareSubject<TResult>.Create(cts.Cancel);
+        ISubject<TResult> observable = subject;
         var collectionName1 = collection1.CollectionNamespace.CollectionName;
         var collectionName2 = collection2.CollectionNamespace.CollectionName;
         var relevantCollections = new HashSet<string> { collectionName1, collectionName2 };
-
-        _ = subject.Subscribe(
-            _ => { },
-            _ => cts.Cancel(),
-            cts.Cancel);
 
         _ = Task.Run(async () =>
         {
@@ -118,11 +114,12 @@ internal sealed class MongoDBJoinedObserveBuilder<T1, T2>(
                 subscription.Dispose();
                 channel.Writer.TryComplete();
                 subject.OnCompleted();
+                subject.Dispose();
                 cts.Dispose();
             }
         });
 
-        return subject;
+        return observable;
     }
 }
 
@@ -153,20 +150,16 @@ internal sealed class MongoDBJoinedObserveBuilder<T1, T2, T3>(
     public ISubject<TResult> Select<TResult>(
         Func<IEnumerable<T1>, IEnumerable<T2>, IEnumerable<T3>, TResult> selector)
     {
-#pragma warning disable CA2000 // Dispose objects before losing scope
+    #pragma warning disable CA2000 // Dispose objects before losing scope
         // The CancellationTokenSource is disposed in the finally block of the background Task.Run below.
         var cts = new CancellationTokenSource();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-        var subject = new Subject<TResult>();
+    #pragma warning restore CA2000 // Dispose objects before losing scope
+        var subject = LifetimeAwareSubject<TResult>.Create(cts.Cancel);
+        ISubject<TResult> observable = subject;
         var collectionName1 = collection1.CollectionNamespace.CollectionName;
         var collectionName2 = collection2.CollectionNamespace.CollectionName;
         var collectionName3 = collection3.CollectionNamespace.CollectionName;
         var relevantCollections = new HashSet<string> { collectionName1, collectionName2, collectionName3 };
-
-        _ = subject.Subscribe(
-            _ => { },
-            _ => cts.Cancel(),
-            cts.Cancel);
 
         _ = Task.Run(async () =>
         {
@@ -229,10 +222,11 @@ internal sealed class MongoDBJoinedObserveBuilder<T1, T2, T3>(
                 subscription.Dispose();
                 channel.Writer.TryComplete();
                 subject.OnCompleted();
+                subject.Dispose();
                 cts.Dispose();
             }
         });
 
-        return subject;
+        return observable;
     }
 }


### PR DESCRIPTION
## Fixed

- MongoDB change-stream cursors and watch tasks now cancel when the last client unsubscribes from an observable query, preventing resource accumulation that previously caused read performance to degrade until restart.
- Joined observers (`MongoDBJoinedObserveBuilder`) no longer leak subscriptions in the singleton `MongoDBWatcher` database-change observable after all clients disconnect.