### PR TITLE
Add validation failure and exception tracking with nested scope support to CommandScope

### DIFF
--- a/Documentation/frontend/react/commands/scope.md
+++ b/Documentation/frontend/react/commands/scope.md
@@ -31,16 +31,24 @@ export const MyComposition = () => {
 
 ## Hierarchical Scopes
 
-Command scopes can be nested to create a hierarchy. Child scopes automatically recognize their parent scope,
-allowing you to track state at different levels of your component tree.
+Command scopes can be nested to create a hierarchy. When you add a `<CommandScope>` inside another
+one, the inner scope automatically registers itself with the nearest outer scope. Commands always
+bind to the **nearest** enclosing scope, so each part of the component tree only tracks the commands
+directly beneath it. The outer scope aggregates state across all inner scopes, giving you both
+local and global views of changes, performing state, validation failures, and exceptions.
 
 ```typescript
 export const MyPage = () => {
+    const [hasChanges, setHasChanges] = useState(false);
+    const [hasValidationFailures, setHasValidationFailures] = useState(false);
+
     return (
-        <CommandScope>
-            <PageToolbar/>
+        <CommandScope setHasChanges={setHasChanges}>
+            {/* PageToolbar sees aggregate state for the whole page */}
+            <PageToolbar hasChanges={hasChanges} hasValidationFailures={hasValidationFailures}/>
             <Section1>
                 <CommandScope>
+                    {/* SectionToolbar only sees state for Section1's commands */}
                     <SectionToolbar/>
                     <SectionContent/>
                 </CommandScope>
@@ -50,9 +58,77 @@ export const MyPage = () => {
 };
 ```
 
-In this example, the inner `CommandScope` has access to its parent scope through the `parent` property.
+In this example:
+- Commands inside `<Section1>` bind to the inner `<CommandScope>`.
+- The outer `<CommandScope>` sees their state through the nested scope link.
+- `pageScope.hasValidationFailures` is `true` whenever any inner scope has failures.
 
-## Callbacks
+## Validation Failures and Exceptions
+
+The `CommandScope` tracks which commands produced validation failures or exceptions after execution.
+These are cleared automatically when a command executes again — you never need to reset them manually.
+
+### Checking aggregate state
+
+```typescript
+import { useCommandScope } from '@cratis/arc/commands';
+
+export const Toolbar = () => {
+    const scope = useCommandScope();
+
+    return (
+        <div>
+            {scope.hasValidationFailures && (
+                <span className="error">Some inputs have validation errors.</span>
+            )}
+            {scope.hasExceptions && (
+                <span className="error">An unexpected error occurred.</span>
+            )}
+        </div>
+    );
+};
+```
+
+### Inspecting per-command detail
+
+When you need to know exactly which command had a problem and what the errors were, use the
+`validationFailures` and `exceptions` maps. Both are `ReadonlyMap<ICommand, ...>`.
+
+```typescript
+const scope = useCommandScope();
+
+// Validation failures — map of command → ValidationResult[]
+for (const [command, failures] of scope.validationFailures) {
+    failures.forEach(f => console.log(f.message, f.members));
+}
+
+// Exceptions — map of command → string[]
+for (const [command, messages] of scope.exceptions) {
+    messages.forEach(m => console.log(m));
+}
+```
+
+Only the **own commands** of a scope appear in its `validationFailures` and `exceptions` maps.
+Commands from nested child scopes appear in those child scopes' maps, but bubble up to the parent
+via `hasValidationFailures` and `hasExceptions`.
+
+### Automatic clearing on re-execution
+
+When a command executes again, its previous failures and exceptions are cleared **before** the new
+execution begins. This means a scope's `hasValidationFailures` and `hasExceptions` always reflect
+the result of the most recent execution, not a stale prior result.
+
+```typescript
+// First execute — validation fails
+await scope.execute();
+console.log(scope.hasValidationFailures); // true
+
+// User fixes the input; execute again — succeeds
+await scope.execute();
+console.log(scope.hasValidationFailures); // false — automatically cleared
+```
+
+
 
 You can provide callbacks to the `<CommandScope>` component to react to command execution results.
 These callbacks are invoked for any command tracked within the scope, and each receives the specific
@@ -114,11 +190,16 @@ The command scope provides the following properties and methods:
 | ---- | ---- | ----------- |
 | hasChanges | Boolean | Whether or not there are changes in any commands within the scope |
 | isPerforming | Boolean | Whether or not any commands or queries are currently being performed |
+| hasValidationFailures | Boolean | Whether any commands in this scope or child scopes have validation failures from the last execution |
+| hasExceptions | Boolean | Whether any commands in this scope or child scopes produced exceptions in the last execution |
+| validationFailures | ReadonlyMap\<ICommand, ValidationResult[]\> | Validation failures per command for this scope's own commands |
+| exceptions | ReadonlyMap\<ICommand, string[]\> | Exception messages per command for this scope's own commands |
 | parent | ICommandScope \| undefined | The parent scope, if this scope is nested |
 | execute() | Promise\<CommandResults\> | Execute all commands with changes within the scope |
 | revertChanges() | void | Revert any changes to commands within the scope |
 | addCommand(command) | void | Manually add a command for tracking (usually done automatically) |
 | addQuery(query) | void | Manually add a query for tracking (usually done automatically) |
+| addChildScope(scope) | void | Register a child scope for aggregate state propagation (done automatically) |
 
 ## Using Command Scope in React
 

--- a/Source/JavaScript/Arc.React/commands/CommandScope.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandScope.tsx
@@ -12,8 +12,13 @@ const defaultCommandScopeContext: ICommandScope = new class extends ICommandScop
     get parent() { return undefined; }
     get hasChanges() { return false; }
     get isPerforming() { return false; }
+    get hasValidationFailures() { return false; }
+    get hasExceptions() { return false; }
+    get validationFailures() { return new Map(); }
+    get exceptions() { return new Map(); }
     addCommand() { }
     addQuery() { }
+    addChildScope() { }
     async execute() { return new CommandResults(new Map()); }
     revertChanges() { }
 }();

--- a/Source/JavaScript/Arc.React/commands/CommandScopeImplementation.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandScopeImplementation.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ICommand, CommandResult, CommandResults } from '@cratis/arc/commands';
+import { ValidationResult } from '@cratis/arc/validation';
 import { IQueryFor } from '@cratis/arc/queries';
 import { ICommandScope } from './ICommandScope';
 
@@ -57,9 +58,12 @@ export interface CommandScopeCallbacks {
 export class CommandScopeImplementation extends ICommandScope {
     private _commands: ICommand[] = [];
     private _queries: IQueryFor<unknown, unknown>[] = [];
+    private _childScopes: ICommandScope[] = [];
     private _hasChanges = false;
     private _isPerforming = false;
     private _parent?: ICommandScope;
+    private _validationFailures: Map<ICommand, ValidationResult[]> = new Map();
+    private _exceptions: Map<ICommand, string[]> = new Map();
 
     constructor(
         private readonly _setHasChanges: (value: boolean) => void,
@@ -69,6 +73,7 @@ export class CommandScopeImplementation extends ICommandScope {
     ) {
         super();
         this._parent = parent;
+        parent?.addChildScope(this);
     }
 
     /** @inheritdoc */
@@ -84,6 +89,34 @@ export class CommandScopeImplementation extends ICommandScope {
     /** @inheritdoc */
     get isPerforming(): boolean {
         return this._isPerforming;
+    }
+
+    /** @inheritdoc */
+    get hasValidationFailures(): boolean {
+        return this._validationFailures.size > 0 || this._childScopes.some(_ => _.hasValidationFailures);
+    }
+
+    /** @inheritdoc */
+    get hasExceptions(): boolean {
+        return this._exceptions.size > 0 || this._childScopes.some(_ => _.hasExceptions);
+    }
+
+    /** @inheritdoc */
+    get validationFailures(): ReadonlyMap<ICommand, ValidationResult[]> {
+        return this._validationFailures;
+    }
+
+    /** @inheritdoc */
+    get exceptions(): ReadonlyMap<ICommand, string[]> {
+        return this._exceptions;
+    }
+
+    /** @inheritdoc */
+    addChildScope(scope: ICommandScope): void {
+        if (this._childScopes.some(_ => _ === scope)) {
+            return;
+        }
+        this._childScopes.push(scope);
     }
 
     /** @inheritdoc */
@@ -113,6 +146,9 @@ export class CommandScopeImplementation extends ICommandScope {
 
         try {
             for (const command of this._commands.filter(_ => _.hasChanges === true)) {
+                this._validationFailures.delete(command);
+                this._exceptions.delete(command);
+
                 const callbacks = this._getCallbacks?.();
                 callbacks?.onBeforeExecute?.(command);
                 const commandResult = await command.execute();
@@ -126,9 +162,11 @@ export class CommandScopeImplementation extends ICommandScope {
                         callbacks?.onUnauthorized?.(command, commandResult);
                     }
                     if (!commandResult.isValid) {
+                        this._validationFailures.set(command, commandResult.validationResults);
                         callbacks?.onValidationFailure?.(command, commandResult);
                     }
                     if (commandResult.hasExceptions) {
+                        this._exceptions.set(command, commandResult.exceptionMessages);
                         callbacks?.onException?.(command, commandResult);
                     }
                 }

--- a/Source/JavaScript/Arc.React/commands/ICommandScope.ts
+++ b/Source/JavaScript/Arc.React/commands/ICommandScope.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ICommand, CommandResults } from '@cratis/arc/commands';
+import { ValidationResult } from '@cratis/arc/validation';
 import { IQueryFor } from '@cratis/arc/queries';
 
 /**
@@ -25,6 +26,26 @@ export abstract class ICommandScope {
     abstract get isPerforming(): boolean;
 
     /**
+     * Gets whether or not any commands in this scope or any child scopes have validation failures from the last execution.
+     */
+    abstract get hasValidationFailures(): boolean;
+
+    /**
+     * Gets whether or not any commands in this scope or any child scopes have exceptions from the last execution.
+     */
+    abstract get hasExceptions(): boolean;
+
+    /**
+     * Gets the validation failures per command for this scope's commands.
+     */
+    abstract get validationFailures(): ReadonlyMap<ICommand, ValidationResult[]>;
+
+    /**
+     * Gets the exception messages per command for this scope's commands.
+     */
+    abstract get exceptions(): ReadonlyMap<ICommand, string[]>;
+
+    /**
      * Add a command for tracking in the scope.
      * @param {ICommand} command Command to add.
      */
@@ -35,6 +56,12 @@ export abstract class ICommandScope {
      * @param {IQueryFor<unknown, unknown>} query Query to add.
      */
     abstract addQuery(query: IQueryFor<unknown, unknown>): void;
+
+    /**
+     * Add a child scope to this scope for aggregate state tracking.
+     * @param {ICommandScope} scope Child scope to add.
+     */
+    abstract addChildScope(scope: ICommandScope): void;
 
     /**
      * Execute all commands with changes.

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_child_scope_has_exception.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_child_scope_has_exception.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when child scope has exception and parent checks aggregate state', async () => {
+    const exceptionResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: true,
+        validationResults: [],
+        exceptionMessages: ['Something went wrong'],
+        exceptionStackTrace: 'Stack trace here',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const parentScope = new CommandScopeImplementation(() => {});
+    const childScope = new CommandScopeImplementation(() => {}, undefined, parentScope);
+
+    const parentCommand = new FakeCommand(false);
+    const childCommand = new FakeCommand(true, exceptionResult);
+    parentScope.addCommand(parentCommand);
+    childScope.addCommand(childCommand);
+
+    await childScope.execute();
+
+    it('should report has exceptions on the child scope', () => childScope.hasExceptions.should.be.true);
+    it('should report has exceptions on the parent scope', () => parentScope.hasExceptions.should.be.true);
+    it('should not have exceptions on the parent scope directly', () => parentScope.exceptions.has(childCommand).should.be.false);
+    it('should not have validation failures on the child scope', () => childScope.hasValidationFailures.should.be.false);
+    it('should not have validation failures on the parent scope', () => parentScope.hasValidationFailures.should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_child_scope_has_validation_failure.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_child_scope_has_validation_failure.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when child scope has validation failure and parent checks aggregate state', async () => {
+    const failedResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [{ severity: 0, message: 'Name is required', members: ['name'], state: {} }],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const parentScope = new CommandScopeImplementation(() => {});
+    const childScope = new CommandScopeImplementation(() => {}, undefined, parentScope);
+
+    const parentCommand = new FakeCommand(false);
+    const childCommand = new FakeCommand(true, failedResult);
+    parentScope.addCommand(parentCommand);
+    childScope.addCommand(childCommand);
+
+    await childScope.execute();
+
+    it('should report has validation failures on the child scope', () => childScope.hasValidationFailures.should.be.true);
+    it('should report has validation failures on the parent scope', () => parentScope.hasValidationFailures.should.be.true);
+    it('should not have validation failures on the parent scope directly', () => parentScope.validationFailures.has(childCommand).should.be.false);
+    it('should not have exceptions on the child scope', () => childScope.hasExceptions.should.be.false);
+    it('should not have exceptions on the parent scope', () => parentScope.hasExceptions.should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_command_registers_to_nearest_scope.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_command_registers_to_nearest_scope.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when command registers to nearest scope with nested scopes', () => {
+    const parentScope = new CommandScopeImplementation(() => {});
+    const childScope = new CommandScopeImplementation(() => {}, undefined, parentScope);
+
+    const childCommand = new FakeCommand(true);
+    childScope.addCommand(childCommand);
+
+    it('should register the child scope with the parent', () => parentScope['_childScopes'].includes(childScope).should.be.true);
+    it('should track the command in the child scope', () => childScope['_commands'].includes(childCommand).should.be.true);
+    it('should not track the command in the parent scope directly', () => parentScope['_commands'].includes(childCommand).should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_again_after_exception.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_again_after_exception.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when executing command again after exception', async () => {
+    const exceptionResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: true,
+        validationResults: [],
+        exceptionMessages: ['Something went wrong'],
+        exceptionStackTrace: 'Stack trace here',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const scope = new CommandScopeImplementation(() => {});
+    const command = new FakeCommand(true, exceptionResult);
+    scope.addCommand(command);
+
+    await scope.execute();
+
+    // Re-execute: command reports hasChanges again and succeeds this time
+    command['_hasChanges'] = true;
+    command.execute = sinon.fake(() => Promise.resolve(CommandResult.empty));
+
+    await scope.execute();
+
+    it('should not have exceptions after successful re-execution', () => scope.hasExceptions.should.be.false);
+    it('should not track exceptions for the command', () => scope.exceptions.has(command).should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_again_after_validation_failure.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_again_after_validation_failure.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when executing command again after validation failure', async () => {
+    const failedResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [{ severity: 0, message: 'Name is required', members: ['name'], state: {} }],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const scope = new CommandScopeImplementation(() => {});
+    const command = new FakeCommand(true, failedResult);
+    scope.addCommand(command);
+
+    await scope.execute();
+
+    // Re-execute: command reports hasChanges again (simulating user correcting input)
+    command['_hasChanges'] = true;
+    command.execute = sinon.fake(() => Promise.resolve(CommandResult.empty));
+
+    await scope.execute();
+
+    it('should not have validation failures after successful re-execution', () => scope.hasValidationFailures.should.be.false);
+    it('should not track validation failures for the command', () => scope.validationFailures.has(command).should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_exception.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_exception.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when executing command with exception', async () => {
+    const exceptionResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: true,
+        validationResults: [],
+        exceptionMessages: ['Something went wrong', 'Another error'],
+        exceptionStackTrace: 'Stack trace here',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const scope = new CommandScopeImplementation(() => {});
+    const command = new FakeCommand(true, exceptionResult);
+    scope.addCommand(command);
+
+    await scope.execute();
+
+    it('should have exceptions', () => scope.hasExceptions.should.be.true);
+    it('should not have validation failures', () => scope.hasValidationFailures.should.be.false);
+    it('should track exceptions for the command', () => scope.exceptions.has(command).should.be.true);
+    it('should store the correct number of exception messages', () => scope.exceptions.get(command)!.length.should.equal(2));
+    it('should store the first exception message', () => scope.exceptions.get(command)![0].should.equal('Something went wrong'));
+    it('should store the second exception message', () => scope.exceptions.get(command)![1].should.equal('Another error'));
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_validation_failure.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_validation_failure.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '@cratis/arc/commands';
+import { ValidationResult } from '@cratis/arc/validation';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when executing command with validation failure', async () => {
+    const validationResult = new ValidationResult(0, 'Name is required', ['name'], {});
+    const failedResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [{ severity: 0, message: 'Name is required', members: ['name'], state: {} }],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const scope = new CommandScopeImplementation(() => {});
+    const command = new FakeCommand(true, failedResult);
+    scope.addCommand(command);
+
+    await scope.execute();
+
+    it('should have validation failures', () => scope.hasValidationFailures.should.be.true);
+    it('should not have exceptions', () => scope.hasExceptions.should.be.false);
+    it('should track validation failures for the command', () => scope.validationFailures.has(command).should.be.true);
+    it('should store the correct number of validation results', () => scope.validationFailures.get(command)!.length.should.equal(1));
+    it('should store the validation result message', () => scope.validationFailures.get(command)![0].message.should.equal('Name is required'));
+});

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_parent_and_child_scopes_have_validation_failures.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_parent_and_child_scopes_have_validation_failures.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '@cratis/arc/commands';
+import { CommandScopeImplementation } from '../CommandScopeImplementation';
+import { FakeCommand } from './FakeCommand';
+
+describe('when both parent and child scopes have their own validation failures', async () => {
+    const parentFailedResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000000',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [{ severity: 0, message: 'Parent field required', members: ['parentField'], state: {} }],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const childFailedResult = new CommandResult({
+        correlationId: '00000000-0000-0000-0000-000000000001',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [{ severity: 0, message: 'Child field required', members: ['childField'], state: {} }],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: {}
+    }, Object, false);
+
+    const parentScope = new CommandScopeImplementation(() => {});
+    const childScope = new CommandScopeImplementation(() => {}, undefined, parentScope);
+
+    const parentCommand = new FakeCommand(true, parentFailedResult);
+    const childCommand = new FakeCommand(true, childFailedResult);
+    parentScope.addCommand(parentCommand);
+    childScope.addCommand(childCommand);
+
+    await parentScope.execute();
+    await childScope.execute();
+
+    it('should report has validation failures on the parent scope', () => parentScope.hasValidationFailures.should.be.true);
+    it('should report has validation failures on the child scope', () => childScope.hasValidationFailures.should.be.true);
+    it('should track parent command validation failure in parent scope', () => parentScope.validationFailures.has(parentCommand).should.be.true);
+    it('should track child command validation failure in child scope', () => childScope.validationFailures.has(childCommand).should.be.true);
+    it('should not track child command in parent scope directly', () => parentScope.validationFailures.has(childCommand).should.be.false);
+});


### PR DESCRIPTION
## Added
- `hasValidationFailures` and `hasExceptions` boolean properties on `ICommandScope` and `CommandScopeImplementation` — aggregate across the scope and all nested child scopes
- `validationFailures` (`ReadonlyMap<ICommand, ValidationResult[]>`) and `exceptions` (`ReadonlyMap<ICommand, string[]>`) maps for per-command inspection of the most recent execution result
- `addChildScope` on `ICommandScope`; child scopes self-register with their parent on construction so nesting is fully automatic — commands always bind to the nearest enclosing `<CommandScope>`
- Validation failures and exceptions are cleared per-command before each re-execution so state always reflects the latest result
- Comprehensive specs covering all new behaviors (89 passing)
- Updated `scope.md` documentation with nested-scope explanation, validation/exception sections, and extended API table