### PR TITLE
ADding support for typed Dictionaries with support for both Record<,> and Map<,> depending on key type

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,33 +5,33 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.16.3" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.16.1" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.16.3" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.7.3" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.3" />
+    <PackageVersion Include="Cratis.Chronicle" Version="15.18.17" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.18.17" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.18.17" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.7.6" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.6" />
     <!-- Microsoft -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
     <!-- System -->
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.5" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.6" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="castle.core" Version="5.2.1" />
@@ -47,19 +47,19 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!-- Override vulnerable/incompatible transitive dependencies from analyzer testing packages -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.48" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.54" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="18.5.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.0" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.0" />

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryHttp.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryHttp.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
-using System.Linq;
 using System.Net;
 
 namespace Cratis.Arc.Queries;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/DictionaryTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/DictionaryTypes.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+public class ScenarioDictionaryKeyType
+{
+    public string Id { get; set; } = string.Empty;
+}
+
+public class ScenarioDictionaryValueType
+{
+    public string Name { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class TypeWithStringKeyDictionaryProperty
+{
+    public IDictionary<string, ScenarioDictionaryValueType> Items { get; set; } = new Dictionary<string, ScenarioDictionaryValueType>();
+}
+
+public class TypeWithComplexKeyDictionaryProperty
+{
+    public IDictionary<ScenarioDictionaryKeyType, ScenarioDictionaryValueType> Items { get; set; } = new Dictionary<ScenarioDictionaryKeyType, ScenarioDictionaryValueType>();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_type_with_complex_key_dictionary.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_type_with_complex_key_dictionary.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+public class when_generating_type_with_complex_key_dictionary : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    TypeDescriptor _descriptor = null!;
+    bool _typeScriptIsValid;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var type = typeof(TypeWithComplexKeyDictionaryProperty);
+        var properties = type.GetProperties()
+            .Select(p => p.ToPropertyDescriptor())
+            .ToList();
+
+        _descriptor = new TypeDescriptor(
+            type,
+            "TypeWithComplexKeyDictionaryProperty",
+            properties,
+            Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
+            []);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateType(_descriptor);
+
+        try
+        {
+            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
+            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
+        }
+        catch
+        {
+            _typeScriptIsValid = false;
+        }
+    }
+
+    [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
+    [Fact] void should_contain_class_name() => _generatedCode.ShouldContain("TypeWithComplexKeyDictionaryProperty");
+    [Fact] void should_contain_map_type() => _generatedCode.ShouldContain("Map<ScenarioDictionaryKeyType, ScenarioDictionaryValueType>");
+    [Fact] void should_use_map_constructor() => _generatedCode.ShouldContain("@field(Map)");
+    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_type_with_string_key_dictionary.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_type_with_string_key_dictionary.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+public class when_generating_type_with_string_key_dictionary : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    TypeDescriptor _descriptor = null!;
+    bool _typeScriptIsValid;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var type = typeof(TypeWithStringKeyDictionaryProperty);
+        var properties = type.GetProperties()
+            .Select(p => p.ToPropertyDescriptor())
+            .ToList();
+
+        _descriptor = new TypeDescriptor(
+            type,
+            "TypeWithStringKeyDictionaryProperty",
+            properties,
+            Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
+            []);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateType(_descriptor);
+
+        try
+        {
+            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
+            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
+        }
+        catch
+        {
+            _typeScriptIsValid = false;
+        }
+    }
+
+    [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
+    [Fact] void should_contain_class_name() => _generatedCode.ShouldContain("TypeWithStringKeyDictionaryProperty");
+    [Fact] void should_contain_record_type() => _generatedCode.ShouldContain("Record<string, ScenarioDictionaryValueType>");
+    [Fact] void should_use_object_constructor() => _generatedCode.ShouldContain("@field(Object)");
+    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/DictionaryKeyType.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/DictionaryKeyType.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions;
+
+public class DictionaryKeyType
+{
+    public string Id { get; set; } = string.Empty;
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/DictionaryValueType.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/DictionaryValueType.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions;
+
+public class DictionaryValueType
+{
+    public int Count { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithComplexKeyDictionary.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithComplexKeyDictionary.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions;
+
+public class TypeWithComplexKeyDictionary
+{
+    public IDictionary<DictionaryKeyType, DictionaryValueType> Items { get; set; } = new Dictionary<DictionaryKeyType, DictionaryValueType>();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithStringKeyDictionary.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithStringKeyDictionary.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions;
+
+public class TypeWithStringKeyDictionary
+{
+    public IDictionary<string, DictionaryValueType> Items { get; set; } = new Dictionary<string, DictionaryValueType>();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_dictionary_with_complex_key.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_dictionary_with_complex_key.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions.when_converting_property_to_descriptor;
+
+public class with_dictionary_with_complex_key : Specification
+{
+    PropertyInfo _property;
+    PropertyDescriptor _result;
+
+    void Establish() => _property = typeof(TypeWithComplexKeyDictionary).GetProperty(nameof(TypeWithComplexKeyDictionary.Items));
+
+    void Because() => _result = _property.ToPropertyDescriptor();
+
+    [Fact] void should_have_correct_name() => _result.Name.ShouldEqual("Items");
+    [Fact] void should_have_map_type() => _result.Type.ShouldEqual("Map<DictionaryKeyType, DictionaryValueType>");
+    [Fact] void should_have_map_constructor() => _result.Constructor.ShouldEqual("Map");
+    [Fact] void should_not_be_enumerable() => _result.IsEnumerable.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_dictionary_with_string_key.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_dictionary_with_string_key.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions.when_converting_property_to_descriptor;
+
+public class with_dictionary_with_string_key : Specification
+{
+    PropertyInfo _property;
+    PropertyDescriptor _result;
+
+    void Establish() => _property = typeof(TypeWithStringKeyDictionary).GetProperty(nameof(TypeWithStringKeyDictionary.Items));
+
+    void Because() => _result = _property.ToPropertyDescriptor();
+
+    [Fact] void should_have_correct_name() => _result.Name.ShouldEqual("Items");
+    [Fact] void should_have_record_type() => _result.Type.ShouldEqual("Record<string, DictionaryValueType>");
+    [Fact] void should_have_object_constructor() => _result.Constructor.ShouldEqual("Object");
+    [Fact] void should_not_be_enumerable() => _result.IsEnumerable.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Text.RegularExpressions;
 using Cratis.Arc.ProxyGenerator.Templates;
 using Microsoft.Extensions.DependencyModel;
 
@@ -271,6 +272,32 @@ public static class TypeExtensions
         type.GetInterfaces().Any(_ => _.IsGenericType && _.GetGenericTypeDefinition() == _dictionaryType);
 
     /// <summary>
+    /// Get the key type of a dictionary type.
+    /// </summary>
+    /// <param name="type">Dictionary type to get key type from.</param>
+    /// <returns>The key <see cref="Type"/>.</returns>
+    public static Type GetDictionaryKeyType(this Type type)
+    {
+        var dictionaryInterface = type.IsGenericType && type.GetGenericTypeDefinition() == _dictionaryType
+            ? type
+            : type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == _dictionaryType);
+        return dictionaryInterface.GetGenericArguments()[0];
+    }
+
+    /// <summary>
+    /// Get the value type of a dictionary type.
+    /// </summary>
+    /// <param name="type">Dictionary type to get value type from.</param>
+    /// <returns>The value <see cref="Type"/>.</returns>
+    public static Type GetDictionaryValueType(this Type type)
+    {
+        var dictionaryInterface = type.IsGenericType && type.GetGenericTypeDefinition() == _dictionaryType
+            ? type
+            : type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == _dictionaryType);
+        return dictionaryInterface.GetGenericArguments()[1];
+    }
+
+    /// <summary>
     /// Get property descriptors for a type.
     /// </summary>
     /// <param name="type">Type to get for.</param>
@@ -296,7 +323,24 @@ public static class TypeExtensions
 
         if (type.IsDictionary())
         {
-            return ObjectTypeFinal;
+            var keyType = type.GetDictionaryKeyType();
+            var valueType = type.GetDictionaryValueType();
+
+            var resolvedKeyType = keyType.IsConcept() ? keyType.GetConceptValueType() : keyType;
+            var keyTargetType = resolvedKeyType.IsEnum
+                ? new TargetType(resolvedKeyType, resolvedKeyType.Name, "Number")
+                : _primitiveTypeMap.TryGetValue(resolvedKeyType.FullName!, out var primitiveKeyType)
+                    ? primitiveKeyType
+                    : new TargetType(resolvedKeyType, resolvedKeyType.Name, resolvedKeyType.Name);
+
+            var valueTargetType = valueType.GetTargetType();
+
+            if (keyTargetType.Type == "string")
+            {
+                return new(type, $"Record<string, {valueTargetType.Type}>", "Object", Final: true);
+            }
+
+            return new(type, $"Map<{keyTargetType.Type}, {valueTargetType.Type}>", "Map", Final: true);
         }
 
         if (type.IsConcept())
@@ -340,6 +384,20 @@ public static class TypeExtensions
             {
                 property.CollectTypesInvolved(typesInvolved);
             }
+            if (property.OriginalType.IsDictionary())
+            {
+                var keyType = property.OriginalType.GetDictionaryKeyType();
+                var valueType = property.OriginalType.GetDictionaryValueType();
+                var resolvedKeyType = keyType.IsConcept() ? keyType.GetConceptValueType() : keyType;
+                if (!resolvedKeyType.IsAPrimitiveType() && !resolvedKeyType.IsEnum)
+                {
+                    resolvedKeyType.CollectTypesInvolved(typesInvolved);
+                }
+                if (!valueType.IsAPrimitiveType() && !valueType.IsConcept())
+                {
+                    valueType.CollectTypesInvolved(typesInvolved);
+                }
+            }
             if (!string.IsNullOrEmpty(property.Module))
             {
                 imports.Add(new ImportStatement(property.OriginalType, property.Type, property.Module));
@@ -349,7 +407,7 @@ public static class TypeExtensions
         imports.AddRange(typesInvolved.GetImports(targetPath, type.ResolveTargetPath(segmentsToSkip), segmentsToSkip));
         imports = [.. imports
                     .DistinctBy(_ => _.Type)
-                    .Where(_ => propertyDescriptors.Exists(pd => pd.Type == _.Type) && _.OriginalType != type)];
+                    .Where(_ => propertyDescriptors.Exists(pd => TypeNameIsReferenced(pd.Type, _.Type)) && _.OriginalType != type)];
 
         var documentation = type.GetDocumentation();
 
@@ -838,6 +896,12 @@ public static class TypeExtensions
 
         return type;
     }
+
+#pragma warning disable MA0009 // Add regex evaluation timeout
+    static bool TypeNameIsReferenced(string propertyType, string importTypeName) =>
+        propertyType == importTypeName ||
+        Regex.IsMatch(propertyType, $@"\b{Regex.Escape(importTypeName)}\b");
+#pragma warning restore MA0009 // Add regex evaluation timeout
 
     static void InitializeWellKnownTypes()
     {


### PR DESCRIPTION
## Fixed

- Fixing how we generate dictionaries. It will now generate the correct value type for dictionaries with a string as key  into `Record<,>`. If the key is not string type, it will generate a `Map<,>`.
