### PR TITLE
Fix multiplexed SSE query argument forwarding

### DIFF
--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_validation_failure.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/when_executing_command_with_validation_failure.ts
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { CommandResult } from '@cratis/arc/commands';
-import { ValidationResult } from '@cratis/arc/validation';
 import { CommandScopeImplementation } from '../CommandScopeImplementation';
 import { FakeCommand } from './FakeCommand';
 
 describe('when executing command with validation failure', async () => {
-    const validationResult = new ValidationResult(0, 'Name is required', ['name'], {});
     const failedResult = new CommandResult({
         correlationId: '00000000-0000-0000-0000-000000000000',
         isSuccess: false,

--- a/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
@@ -103,11 +103,13 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
             });
         }
 
-        // Build query arguments including unused args parameters, parameter descriptor values, and paging/sorting
+        // For multiplexed mode, include route arguments as plain arguments in the subscribe payload.
+        // In direct mode, route arguments are already part of the URL path and should not be duplicated.
         const parameterValues = ParametersHelper.collectParameterValues(this);
         const { unusedParameters } = UrlHelpers.replaceRouteParameters(this.route, args as object);
+        const routeAndQueryArguments = (args as object) || {};
         const connectionQueryArguments: any = {
-            ...unusedParameters,
+            ...(Globals.queryDirectMode ? unusedParameters : routeAndQueryArguments),
             ...parameterValues,
             ...this.buildQueryArguments()
         };

--- a/Source/JavaScript/Arc/queries/ObservableQueryMultiplexer.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryMultiplexer.ts
@@ -126,7 +126,8 @@ export class ObservableQueryMultiplexer {
 
         for (const [key, value] of Object.entries(a)) {
             if (pagingAndSortingKeys.has(key)) continue;
-            remaining[key] = value !== undefined && value !== null ? String(value) : null;
+            if (value === undefined || value === null) continue;
+            remaining[key] = String(value);
             hasRemaining = true;
         }
 

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_sse_transport_and_null_or_undefined_args.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_sse_transport_and_null_or_undefined_args.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { HubMessageType } from '../../WebSocketHubConnection';
+import { resetSharedMultiplexer } from '../../ObservableQueryMultiplexer';
+
+import * as sinon from 'sinon';
+
+describe('when subscribing with hub mode and SSE transport and null or undefined args', given(an_observable_query_for, context => {
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+    let fetchStub: sinon.SinonStub;
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let eventSourceInstance: EventSource & {
+        onopen: (() => void) | null;
+        onmessage: ((event: { data: string }) => void) | null;
+    };
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        resetSharedMultiplexer();
+
+        Globals.queryDirectMode = false;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        context.queryWithParameterDescriptorValues.setOrigin('https://example.com');
+        callback = sinon.stub();
+
+        const FakeEventSourceConstructor = function (this: EventSource, url: string) {
+            void url;
+            eventSourceInstance = this as EventSource & {
+                onopen: (() => void) | null;
+                onmessage: ((event: { data: string }) => void) | null;
+            };
+            Object.assign(this, {
+                onopen: null,
+                onerror: null,
+                onmessage: null,
+                close: sinon.stub(),
+                addEventListener: sinon.stub(),
+                removeEventListener: sinon.stub(),
+                readyState: 0,
+            });
+        };
+        (globalThis as Record<string, unknown>)['EventSource'] = FakeEventSourceConstructor;
+
+        fetchStub = sinon.stub().resolves({ ok: true } as Response);
+        (globalThis as Record<string, unknown>)['fetch'] = fetchStub;
+
+        subscription = context.queryWithParameterDescriptorValues.subscribe(callback, {
+            filter: undefined,
+            limit: null
+        });
+
+        eventSourceInstance.onopen?.();
+        eventSourceInstance.onmessage?.({
+            data: JSON.stringify({
+                type: HubMessageType.Connected,
+                payload: 'conn-1'
+            })
+        });
+    });
+
+    afterEach(() => {
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+        delete (globalThis as Record<string, unknown>)['fetch'];
+        resetSharedMultiplexer();
+        sinon.restore();
+    });
+
+    it('should not include null or undefined arguments in the subscribe request', () => {
+        fetchStub.called.should.be.true;
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        (subscribeBody.request.arguments === undefined).should.be.true;
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_sse_transport_and_route_and_query_args.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_sse_transport_and_route_and_query_args.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { HubMessageType } from '../../WebSocketHubConnection';
+import { resetSharedMultiplexer } from '../../ObservableQueryMultiplexer';
+
+import * as sinon from 'sinon';
+
+describe('when subscribing with hub mode and SSE transport and route and query args', given(an_observable_query_for, context => {
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+    let fetchStub: sinon.SinonStub;
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let eventSourceInstance: EventSource & {
+        onopen: (() => void) | null;
+        onmessage: ((event: { data: string }) => void) | null;
+    };
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        resetSharedMultiplexer();
+
+        Globals.queryDirectMode = false;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        context.queryWithRouteAndQueryArgs.setOrigin('https://example.com');
+        callback = sinon.stub();
+
+        const FakeEventSourceConstructor = function (this: EventSource, url: string) {
+            void url;
+            eventSourceInstance = this as EventSource & {
+                onopen: (() => void) | null;
+                onmessage: ((event: { data: string }) => void) | null;
+            };
+            Object.assign(this, {
+                onopen: null,
+                onerror: null,
+                onmessage: null,
+                close: sinon.stub(),
+                addEventListener: sinon.stub(),
+                removeEventListener: sinon.stub(),
+                readyState: 0,
+            });
+        };
+        (globalThis as Record<string, unknown>)['EventSource'] = FakeEventSourceConstructor;
+
+        fetchStub = sinon.stub().resolves({ ok: true } as Response);
+        (globalThis as Record<string, unknown>)['fetch'] = fetchStub;
+
+        subscription = context.queryWithRouteAndQueryArgs.subscribe(callback, {
+            id: 'my-item-id',
+            filter: 'active',
+            limit: 50
+        });
+
+        eventSourceInstance.onopen?.();
+        eventSourceInstance.onmessage?.({
+            data: JSON.stringify({
+                type: HubMessageType.Connected,
+                payload: 'conn-1'
+            })
+        });
+    });
+
+    afterEach(() => {
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+        delete (globalThis as Record<string, unknown>)['fetch'];
+        resetSharedMultiplexer();
+        sinon.restore();
+    });
+
+    it('should include route and query arguments in the subscribe request', () => {
+        fetchStub.called.should.be.true;
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        subscribeBody.request.arguments.id.should.equal('my-item-id');
+        subscribeBody.request.arguments.filter.should.equal('active');
+        subscribeBody.request.arguments.limit.should.equal('50');
+    });
+}));


### PR DESCRIPTION
## Fixed
- Fixed hub-mode observable query subscriptions to forward route arguments when direct mode is disabled, so required query values are available in multiplexed SSE mode.
- Fixed multiplexed subscription argument serialization to omit null and undefined values instead of sending invalid placeholders.
- Fixed lint noise in the command scope validation failure spec by removing an unused symbol.

## Added
- Added regression specs that verify hub-mode SSE subscribe requests include route and query arguments.
- Added regression specs that verify null and undefined arguments are omitted from subscribe payloads.