### PR TITLE
Fix nullable reference type query parameters incorrectly marked as required in proxy generator

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/ReadModels.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/ReadModels.cs
@@ -108,6 +108,22 @@ public class ParameterizedReadModel
     [
         new ParameterizedReadModel { Id = Guid.NewGuid(), Name = name, Category = category }
     ];
+
+    /// <summary>
+    /// Searches by category with an optional observer ID.
+    /// </summary>
+    /// <param name="category">The category filter.</param>
+    /// <param name="observerId">Optional observer ID.</param>
+    /// <returns>Collection of matching read models.</returns>
+    public static IEnumerable<ParameterizedReadModel> SearchByCategoryWithOptionalObserverId(string category, string? observerId) =>
+    [
+        new ParameterizedReadModel
+        {
+            Id = Guid.NewGuid(),
+            Name = observerId ?? "No Observer",
+            Category = category
+        }
+    ];
 }
 
 /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_nullable_reference_parameter_and_checking_url.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_with_nullable_reference_parameter_and_checking_url.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+
+public class when_performing_query_with_nullable_reference_parameter_and_checking_url : given.a_scenario_web_application
+{
+    QueryExecutionResult<IEnumerable<ParameterizedReadModel>>? _executionResult;
+
+    void Establish() => LoadQueryProxy<ParameterizedReadModel>(nameof(ParameterizedReadModel.SearchByCategoryWithOptionalObserverId));
+
+    async Task Because()
+    {
+        var parameters = new Dictionary<string, object>
+        {
+            ["category"] = "TestCategory"
+        };
+
+        _executionResult = await Bridge.PerformQueryViaProxyAsync<IEnumerable<ParameterizedReadModel>>(
+            nameof(ParameterizedReadModel.SearchByCategoryWithOptionalObserverId),
+            parameters);
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_valid() => _executionResult.Result.IsValid.ShouldBeTrue();
+    [Fact] void should_include_category_in_url() => _executionResult.RequestUrl.ShouldContain("category=TestCategory");
+    [Fact] void should_not_include_observer_id_in_url() => _executionResult.RequestUrl.ShouldNotContain("observerId=");
+    [Fact] void should_use_null_as_default_for_observer_id() => _executionResult.RawJson.ShouldContain("No Observer");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
@@ -269,6 +269,18 @@ public static class QueryExtensions
     /// <returns>True if it is optional, false if not.</returns>
     static bool IsOptional(this ParameterInfo parameter)
     {
-        return parameter.ParameterType.IsNullable() || parameter.HasDefaultValue;
+        if (parameter.HasDefaultValue)
+        {
+            return true;
+        }
+
+        if (parameter.ParameterType.IsValueType)
+        {
+            return parameter.ParameterType.IsNullable();
+        }
+
+        var context = new NullabilityInfoContext();
+        var nullabilityInfo = context.Create(parameter);
+        return nullabilityInfo.WriteState == NullabilityState.Nullable;
     }
 }


### PR DESCRIPTION
- Fix `IsOptional` in `ModelBound/QueryExtensions.cs` to correctly handle nullable reference type parameters (`string?`, `SomeClass?`) — previously only `Nullable<T>` value types and default values were treated as optional, causing nullable reference type parameters to appear in `requiredRequestParameters` in the generated TypeScript proxy.
- Add regression spec that verifies a nullable `string?` parameter is omitted from the request URL and that the query succeeds end-to-end.