### PR TITLE
Fix subscribe arg ordering so fresh args override stale descriptor-backed instance properties

### DIFF
--- a/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
@@ -103,14 +103,19 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
             });
         }
 
-        // For multiplexed mode, include route arguments as plain arguments in the subscribe payload.
-        // In direct mode, route arguments are already part of the URL path and should not be duplicated.
+        // Descriptor-backed instance properties provide defaults; fresh args passed to subscribe()
+        // must take precedence over any stale instance property values. Spread parameterValues
+        // first so that the caller-supplied args can override them.
+        //
+        // In direct mode the route arguments are already embedded in the URL path, so only
+        // the unused (non-route) parameters are appended as additional query arguments.
+        // In multiplexed mode ALL arguments — including route-derived ones — must be included
+        // in the subscribe payload so the server can execute the query correctly.
         const parameterValues = ParametersHelper.collectParameterValues(this);
         const { unusedParameters } = UrlHelpers.replaceRouteParameters(this.route, args as object);
-        const routeAndQueryArguments = (args as object) || {};
         const connectionQueryArguments: any = {
-            ...(Globals.queryDirectMode ? unusedParameters : routeAndQueryArguments),
             ...parameterValues,
+            ...(Globals.queryDirectMode ? unusedParameters : (args as object) || {}),
             ...this.buildQueryArguments()
         };
 

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_multiple_required_route_parameters.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_multiple_required_route_parameters.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { HubMessageType } from '../../WebSocketHubConnection';
+import { resetSharedMultiplexer } from '../../ObservableQueryMultiplexer';
+
+import * as sinon from 'sinon';
+
+describe('when subscribing with hub mode and multiple required route parameters', given(an_observable_query_for, context => {
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+    let fetchStub: sinon.SinonStub;
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let eventSourceInstance: EventSource & {
+        onopen: (() => void) | null;
+        onmessage: ((event: { data: string }) => void) | null;
+    };
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        resetSharedMultiplexer();
+
+        Globals.queryDirectMode = false;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        context.queryWithMultipleRequiredParameters.setOrigin('https://example.com');
+        callback = sinon.stub();
+
+        const FakeEventSourceConstructor = function (this: EventSource, url: string) {
+            void url;
+            eventSourceInstance = this as EventSource & {
+                onopen: (() => void) | null;
+                onmessage: ((event: { data: string }) => void) | null;
+            };
+            Object.assign(this, {
+                onopen: null,
+                onerror: null,
+                onmessage: null,
+                close: sinon.stub(),
+                addEventListener: sinon.stub(),
+                removeEventListener: sinon.stub(),
+                readyState: 0,
+            });
+        };
+        (globalThis as Record<string, unknown>)['EventSource'] = FakeEventSourceConstructor;
+
+        fetchStub = sinon.stub().resolves({ ok: true } as Response);
+        (globalThis as Record<string, unknown>)['fetch'] = fetchStub;
+
+        subscription = context.queryWithMultipleRequiredParameters.subscribe(callback, {
+            userId: 'user-42',
+            category: 'books'
+        });
+
+        eventSourceInstance.onopen?.();
+        eventSourceInstance.onmessage?.({
+            data: JSON.stringify({
+                type: HubMessageType.Connected,
+                payload: 'conn-1'
+            })
+        });
+    });
+
+    afterEach(() => {
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+        delete (globalThis as Record<string, unknown>)['fetch'];
+        resetSharedMultiplexer();
+        sinon.restore();
+    });
+
+    it('should include the first route parameter in the subscribe request', () => {
+        fetchStub.called.should.be.true;
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        subscribeBody.request.arguments.userId.should.equal('user-42');
+    });
+
+    it('should include the second route parameter in the subscribe request', () => {
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        subscribeBody.request.arguments.category.should.equal('books');
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_stale_descriptor_backed_instance_property.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_subscribing/with_hub_mode_and_stale_descriptor_backed_instance_property.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+import { HubMessageType } from '../../WebSocketHubConnection';
+import { resetSharedMultiplexer } from '../../ObservableQueryMultiplexer';
+
+import * as sinon from 'sinon';
+
+describe('when subscribing with hub mode and stale descriptor-backed instance property', given(an_observable_query_for, context => {
+    let callback: sinon.SinonStub;
+    let subscription: ObservableQuerySubscription<string>;
+    let fetchStub: sinon.SinonStub;
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let eventSourceInstance: EventSource & {
+        onopen: (() => void) | null;
+        onmessage: ((event: { data: string }) => void) | null;
+    };
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        resetSharedMultiplexer();
+
+        Globals.queryDirectMode = false;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        context.queryWithParameterDescriptorValues.setOrigin('https://example.com');
+        callback = sinon.stub();
+
+        // Simulate stale values on the descriptor-backed instance properties — these must be
+        // overridden by the fresh args passed to subscribe().
+        context.queryWithParameterDescriptorValues.filter = 'stale-filter';
+        context.queryWithParameterDescriptorValues.limit = 99;
+
+        const FakeEventSourceConstructor = function (this: EventSource, url: string) {
+            void url;
+            eventSourceInstance = this as EventSource & {
+                onopen: (() => void) | null;
+                onmessage: ((event: { data: string }) => void) | null;
+            };
+            Object.assign(this, {
+                onopen: null,
+                onerror: null,
+                onmessage: null,
+                close: sinon.stub(),
+                addEventListener: sinon.stub(),
+                removeEventListener: sinon.stub(),
+                readyState: 0,
+            });
+        };
+        (globalThis as Record<string, unknown>)['EventSource'] = FakeEventSourceConstructor;
+
+        fetchStub = sinon.stub().resolves({ ok: true } as Response);
+        (globalThis as Record<string, unknown>)['fetch'] = fetchStub;
+
+        // Fresh args: these must win over the stale instance property values above.
+        subscription = context.queryWithParameterDescriptorValues.subscribe(callback, {
+            filter: 'fresh-filter',
+            limit: 42
+        });
+
+        eventSourceInstance.onopen?.();
+        eventSourceInstance.onmessage?.({
+            data: JSON.stringify({
+                type: HubMessageType.Connected,
+                payload: 'conn-1'
+            })
+        });
+    });
+
+    afterEach(() => {
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+        delete (globalThis as Record<string, unknown>)['fetch'];
+        resetSharedMultiplexer();
+        sinon.restore();
+    });
+
+    it('should use fresh args filter value instead of stale instance property', () => {
+        fetchStub.called.should.be.true;
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        subscribeBody.request.arguments.filter.should.equal('fresh-filter');
+    });
+
+    it('should use fresh args limit value instead of stale instance property', () => {
+        const subscribeBody = JSON.parse(fetchStub.firstCall.args[1].body as string);
+        subscribeBody.request.arguments.limit.should.equal('42');
+    });
+}));


### PR DESCRIPTION
## Fixed
- Multiplexed observable queries no longer let stale descriptor-backed instance property values silently override fresh arguments passed to `subscribe()`. Route-derived parameters continue to be included in the subscribe payload as before. (#2174)
