### PR TITLE
Fix Guid field deserialization in observable query delta reconstruction (#2173)

### DIFF
--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeGuidObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeGuidObservableQuery.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ObservableQueryFor, QueryResult, ObservableQuerySubscription, OnNextResult } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+import { field, Guid } from '@cratis/fundamentals';
+
+export class FakeGuidItem {
+    @field(Guid)
+    id!: Guid;
+
+    @field(String)
+    name!: string;
+}
+
+export type SubscribeCallback = OnNextResult<QueryResult<FakeGuidItem[]>>;
+
+export class FakeGuidObservableQuery extends ObservableQueryFor<FakeGuidItem[]> {
+    readonly route = '/api/fake-guid-observable-query';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: FakeGuidItem[] = [];
+
+    constructor() {
+        super(FakeGuidItem, true);
+    }
+
+    static subscribeCallbacks: SubscribeCallback[] = [];
+    static subscriptionReturned: ObservableQuerySubscription<FakeGuidItem[]>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    subscribe(callback: SubscribeCallback, args?: object): ObservableQuerySubscription<FakeGuidItem[]> {
+        FakeGuidObservableQuery.subscribeCallbacks.push(callback);
+        FakeGuidObservableQuery.subscriptionReturned = {
+            unsubscribe: () => {}
+        } as unknown as ObservableQuerySubscription<FakeGuidItem[]>;
+        return FakeGuidObservableQuery.subscriptionReturned;
+    }
+
+    static reset() {
+        FakeGuidObservableQuery.subscribeCallbacks = [];
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_reconstructing_delta_state_with_guid_fields.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_reconstructing_delta_state_with_guid_fields.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useObservableQuery } from '../useObservableQuery';
+import { FakeGuidObservableQuery, FakeGuidItem } from './FakeGuidObservableQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryResult, QueryResultWithState, QueryInstanceCache } from '@cratis/arc/queries';
+import { Guid } from '@cratis/fundamentals';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when reconstructing delta state with guid fields', () => {
+    let capturedResult: QueryResultWithState<FakeGuidItem[]> | undefined;
+
+    beforeEach(() => {
+        FakeGuidObservableQuery.reset();
+        capturedResult = undefined;
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    it('should keep Guid methods on items added through change set', async () => {
+        const firstId = Guid.create();
+        const secondId = Guid.create();
+
+        const TestComponent = () => {
+            const [result] = useObservableQuery<FakeGuidItem[], FakeGuidObservableQuery>(FakeGuidObservableQuery);
+            capturedResult = result;
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        const callback = FakeGuidObservableQuery.subscribeCallbacks[0];
+
+        await act(async () => {
+            callback(new QueryResult({
+                data: [{ id: firstId.toString(), name: 'First' }],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 1, totalPages: 1 }
+            }, FakeGuidItem, true));
+        });
+
+        await act(async () => {
+            callback({
+                data: [],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 2, totalPages: 1 },
+                changeSet: {
+                    added: [{ id: secondId.toString(), name: 'Second' }],
+                    replaced: [],
+                    removed: [],
+                }
+            } as unknown as QueryResult<FakeGuidItem[]>);
+        });
+
+        capturedResult!.data.length.should.equal(2);
+        capturedResult!.data[1].id.equals(secondId).should.be.true;
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { QueryResultWithState, IObservableQueryFor, Sorting, Paging, ChangeSet } from '@cratis/arc/queries';
-import { Constructor } from '@cratis/fundamentals';
+import { Constructor, JsonSerializer } from '@cratis/fundamentals';
 import { useState, useEffect, useContext, useRef, useMemo } from 'react';
 import { SetSorting } from './SetSorting';
 import { SetPage } from './SetPage';
@@ -40,6 +40,14 @@ function applyChangeSet<T>(previous: T[], changeSet: ChangeSet<unknown>): T[] {
     }
 
     return [...result, ...changeSet.added] as T[];
+}
+
+function deserializeChangeSet(changeSet: ChangeSet<unknown>, modelType: Constructor): ChangeSet<unknown> {
+    return {
+        added: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.added ?? []),
+        replaced: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.replaced ?? []),
+        removed: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.removed ?? []),
+    };
 }
 
 function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {
@@ -138,7 +146,9 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
                     // Reconstruct the full collection by applying the ChangeSet to the previous state.
                     const previousResult = queryCache.getLastResult<TDataType>(key);
                     if (previousResult && Array.isArray(previousResult.data)) {
-                        const reconstructed = applyChangeSet(previousResult.data as unknown[], response.changeSet) as TDataType;
+                        const modelType = (queryInstance as unknown as { modelType?: Constructor }).modelType ?? Object;
+                        const deserializedChangeSet = deserializeChangeSet(response.changeSet, modelType);
+                        const reconstructed = applyChangeSet(previousResult.data as unknown[], deserializedChangeSet) as TDataType;
                         withState = new QueryResultWithState<TDataType>(
                             reconstructed,
                             response.paging,
@@ -150,7 +160,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
                             response.exceptionMessages,
                             response.exceptionStackTrace,
                             false,
-                            response.changeSet
+                            deserializedChangeSet
                         );
                     } else {
                         withState = QueryResultWithState.fromQueryResult(response, false);


### PR DESCRIPTION
## Fixed
- Guid fields in observable query items now retain their methods (like `.equals()`) when reconstructed from change sets in delta mode (#2173)

## Summary

Commit b52ecbae introduced delta change-set optimization to reduce bandwidth by only sending items that were added, replaced, or removed since the last update. However, the change-set items were not being deserialized into typed model instances, causing Guid fields (and other strongly-typed fields) to remain as plain JSON objects and lose their methods.

This fix adds deserialization of all change-set items (added, replaced, removed) using `JsonSerializer.deserializeArrayFromInstance` before applying delta reconstruction in `useObservableQuery`, ensuring Guid fields are properly instantiated and methods like `.equals()` work correctly.

The fix includes a regression test that reproduces the exact failure scenario and ensures this issue doesn't regress in the future.