### PR TITLE
Complete fix: Deserialize observable query response data for all transfer modes (#2173)

### DIFF
--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -50,6 +50,15 @@ function deserializeChangeSet(changeSet: ChangeSet<unknown>, modelType: Construc
     };
 }
 
+function deserializeResponseData<TDataType>(data: unknown, modelType: Constructor | null): TDataType {
+    // If data is an array and we have a model type, deserialize each item
+    if (Array.isArray(data) && modelType && modelType !== Object) {
+        return JsonSerializer.deserializeArrayFromInstance(modelType, data) as TDataType;
+    }
+    // Otherwise return data as-is (could be null, undefined, or non-array type)
+    return data as TDataType;
+}
+
 function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {
     if (requiredRequestParameters.length === 0) {
         return true;
@@ -140,14 +149,14 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
         if (!queryCache.isSubscribed(key)) {
             const subscription = queryInstance.subscribe(response => {
                 let withState: QueryResultWithState<TDataType>;
+                const modelType = (queryInstance as unknown as { modelType?: Constructor }).modelType ?? null;
 
                 if (response.changeSet && Array.isArray(response.data) && response.data.length === 0) {
                     // Delta mode subsequent push: the server omits `data` (serialised as null → []).
                     // Reconstruct the full collection by applying the ChangeSet to the previous state.
                     const previousResult = queryCache.getLastResult<TDataType>(key);
                     if (previousResult && Array.isArray(previousResult.data)) {
-                        const modelType = (queryInstance as unknown as { modelType?: Constructor }).modelType ?? Object;
-                        const deserializedChangeSet = deserializeChangeSet(response.changeSet, modelType);
+                        const deserializedChangeSet = deserializeChangeSet(response.changeSet, modelType ?? Object);
                         const reconstructed = applyChangeSet(previousResult.data as unknown[], deserializedChangeSet) as TDataType;
                         withState = new QueryResultWithState<TDataType>(
                             reconstructed,
@@ -163,10 +172,36 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
                             deserializedChangeSet
                         );
                     } else {
-                        withState = QueryResultWithState.fromQueryResult(response, false);
+                        // Fallback if there's no previous result
+                        const deserializedData = deserializeResponseData<TDataType>(response.data, modelType);
+                        withState = new QueryResultWithState<TDataType>(
+                            deserializedData,
+                            response.paging,
+                            response.isSuccess,
+                            response.isAuthorized,
+                            response.isValid,
+                            response.validationResults,
+                            response.hasExceptions,
+                            response.exceptionMessages,
+                            response.exceptionStackTrace,
+                            false,
+                            response.changeSet);
                     }
                 } else {
-                    withState = QueryResultWithState.fromQueryResult(response, false);
+                    // Initial response or full-data responses (non-delta mode)
+                    const deserializedData = deserializeResponseData<TDataType>(response.data, modelType);
+                    withState = new QueryResultWithState<TDataType>(
+                        deserializedData,
+                        response.paging,
+                        response.isSuccess,
+                        response.isAuthorized,
+                        response.isValid,
+                        response.validationResults,
+                        response.hasExceptions,
+                        response.exceptionMessages,
+                        response.exceptionStackTrace,
+                        false,
+                        response.changeSet);
                 }
 
                 queryCache.setLastResult(key, withState);


### PR DESCRIPTION
## Fixed
- Observable query response data is now properly deserialized for all transfer modes, fixing Guid fields and other strongly-typed fields losing their methods (#2173)

## Summary

The initial fix (PR #2176) only addressed delta mode changeSet deserialization, but the root cause affects **all observable query responses**, not just delta updates.

### The Problem
When observable query responses arrive from the server, the data is transmitted as plain JSON objects. The code was never deserializing this data into model instances with their `@field` decorators applied. This caused:

- Guid fields to lose their `.equals()` method
- DateTime fields to be plain strings instead of Date instances
- Other strongly-typed fields to lack their methods
- Downstream components (like ChecklistValidation) to crash when calling methods

### Root Cause
The issue exists in ALL response paths:

1. **Initial response** with full data array — `QueryResultWithState.fromQueryResult()` just passes data through without deserializing
2. **Subsequent full-data responses** (non-delta mode) — Same issue
3. **Delta mode** with changeSet items — The changeSet items were deserialized in PR #2176, but...
4. **Delta mode fallback** (no previous result) — Falls back to un-deserialized data

### The Fix
Added `deserializeResponseData()` function that:
- Checks if data is an array and modelType is available
- Calls `JsonSerializer.deserializeArrayFromInstance()` to instantiate all items with proper types
- Covers all response paths in the subscription callback

Now all response data, regardless of transfer mode, is properly instantiated with `@field` decorators applied and methods available.

### Testing
- Existing regression test from PR #2176 still passes
- All adjacent observable query tests pass
- Full Release build succeeds without warnings