### PR TITLE
fix: NativeAOT compatibility — replace IInstancesOf\<T\> with IEnumerable\<T\> and add explicit DI registrations

### DIFF
--- a/Source/DotNET/Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PublishAot;SelfContained;RuntimeIdentifier;PublishTrimmed;UseCurrentRuntimeIdentifier">
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.Core.CodeAnalysis</AssemblyName>
         <RootNamespace>Cratis.Arc.CodeAnalysis</RootNamespace>
@@ -11,6 +11,11 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <TargetFrameworks></TargetFrameworks>
         <LangVersion>latest</LangVersion>
+        <PublishAot>false</PublishAot>
+        <SelfContained>false</SelfContained>
+        <PublishTrimmed>false</PublishTrimmed>
+        <RuntimeIdentifier></RuntimeIdentifier>
+        <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
         <NoWarn>$(NoWarn);NU5128;NU1507</NoWarn>
     </PropertyGroup>
 

--- a/Source/DotNET/Arc.Core.Generators/Arc.Core.Generators.csproj
+++ b/Source/DotNET/Arc.Core.Generators/Arc.Core.Generators.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PublishAot;SelfContained;RuntimeIdentifier;PublishTrimmed;UseCurrentRuntimeIdentifier">
     <PropertyGroup>
         <AssemblyName>Cratis.Arc.Core.Generators</AssemblyName>
         <RootNamespace>Cratis.Arc.Generators</RootNamespace>
@@ -11,6 +11,11 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <TargetFrameworks></TargetFrameworks>
         <LangVersion>latest</LangVersion>
+        <PublishAot>false</PublishAot>
+        <SelfContained>false</SelfContained>
+        <PublishTrimmed>false</PublishTrimmed>
+        <RuntimeIdentifier></RuntimeIdentifier>
+        <UseCurrentRuntimeIdentifier>false</UseCurrentRuntimeIdentifier>
         <NoWarn>$(NoWarn);NU5128;NU1507</NoWarn>
     </PropertyGroup>
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/given/a_model_bound_query_performer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/given/a_model_bound_query_performer.cs
@@ -24,7 +24,7 @@ public class a_model_bound_query_performer : Specification
     protected void EstablishPerformer<T>(string methodName, object[]? dependencies = null, QueryArguments? parameters = null)
     {
         var method = typeof(T).GetMethod(methodName);
-        _performer = new ModelBoundQueryPerformer(typeof(T), method!, _serviceProviderIsService, _authorizationEvaluator);
+        _performer = new ModelBoundQueryPerformer(typeof(T), typeof(T).FullName ?? typeof(T).Name, method!, _serviceProviderIsService, _authorizationEvaluator);
 
         parameters ??= new QueryArguments();
         dependencies ??= [];

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_generated_metadata.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_generated_metadata.cs
@@ -8,6 +8,9 @@ namespace Cratis.Arc.Queries.ModelBound.for_QueryPerformerProvider;
 
 public class when_initializing_with_generated_metadata : Specification
 {
+    const string MetadataReadModelTypeName = "Generated.Metadata.PublicReadModel";
+    const string MetadataQueryName = $"{MetadataReadModelTypeName}.{nameof(PublicReadModelWithValidQuery.GetById)}";
+
     QueryPerformerProvider _provider;
     ITypes _types;
     IQueryMetadataRegistry _registry;
@@ -24,12 +27,14 @@ public class when_initializing_with_generated_metadata : Specification
         _registry.All.Returns(
             new Dictionary<string, Type>
             {
-                [$"{typeof(PublicReadModelWithValidQuery).FullName}.{nameof(PublicReadModelWithValidQuery.GetById)}"] = typeof(PublicReadModelWithValidQuery)
+                [MetadataQueryName] = typeof(PublicReadModelWithValidQuery)
             });
     }
 
     void Because() => _provider = new QueryPerformerProvider(_types, _registry, _serviceProviderIsService, _authorizationEvaluator);
 
     [Fact] void should_have_one_performer() => _provider.Performers.Count().ShouldEqual(1);
+    [Fact] void should_use_the_generated_metadata_type_name_for_the_fully_qualified_name() => _provider.Performers.Single().FullyQualifiedName.Value.ShouldEqual(MetadataQueryName);
+    [Fact] void should_make_the_performer_addressable_by_the_generated_metadata_name() => _provider.TryGetPerformerFor(MetadataQueryName, out _).ShouldBeTrue();
     [Fact] void should_not_use_reflection_types() => _ = _types.DidNotReceive().All;
 }

--- a/Source/DotNET/Arc.Core/Arc.Core.csproj
+++ b/Source/DotNET/Arc.Core/Arc.Core.csproj
@@ -29,11 +29,13 @@
         <ProjectReference Include="../Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj" 
                           OutputItemType="Analyzer" 
                           ReferenceOutputAssembly="false"
-                          PrivateAssets="all" />
+                          PrivateAssets="all"
+                          GlobalPropertiesToRemove="PublishAot;SelfContained;RuntimeIdentifier;PublishTrimmed;UseCurrentRuntimeIdentifier" />
         <ProjectReference Include="../Arc.Core.Generators/Arc.Core.Generators.csproj"
                           OutputItemType="Analyzer"
                           ReferenceOutputAssembly="false"
-                          PrivateAssets="all" />
+                          PrivateAssets="all"
+                          GlobalPropertiesToRemove="PublishAot;SelfContained;RuntimeIdentifier;PublishTrimmed;UseCurrentRuntimeIdentifier" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -23,15 +23,16 @@ public class ModelBoundQueryPerformer : IQueryPerformer
     /// Initializes a new instance of the <see cref="ModelBoundQueryPerformer"/> class.
     /// </summary>
     /// <param name="readModelType">The type of the read model.</param>
+    /// <param name="readModelTypeName">The read model type name to use for fully qualified query naming.</param>
     /// <param name="performMethod">The method info of the perform method.</param>
     /// <param name="serviceProviderIsService">Service to determine if a type is registered as a service.</param>
     /// <param name="authorizationEvaluator">The authorization evaluator.</param>
-    public ModelBoundQueryPerformer(Type readModelType, MethodInfo performMethod, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
+    public ModelBoundQueryPerformer(Type readModelType, string readModelTypeName, MethodInfo performMethod, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
     {
         Type = readModelType;
         ReadModelType = readModelType;
         Name = performMethod.Name;
-        FullyQualifiedName = $"{readModelType.FullName}.{performMethod.Name}";
+        FullyQualifiedName = $"{readModelTypeName}.{performMethod.Name}";
         Location = readModelType.Namespace?.Split('.') ?? [];
 
         _dependencies = performMethod.GetParameters().Where(p => serviceProviderIsService.IsService(p.ParameterType));

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/QueryPerformerProvider.cs
@@ -25,16 +25,19 @@ public class QueryPerformerProvider : IQueryPerformerProvider
     /// <param name="authorizationEvaluator">The authorization evaluator.</param>
     public QueryPerformerProvider(ITypes types, IQueryMetadataRegistry queryMetadataRegistry, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
     {
-        IEnumerable<Type> readModelTypes;
-
         var generatedMetadata = queryMetadataRegistry.All;
-        readModelTypes = generatedMetadata.Count > 0
-            ? generatedMetadata.Values.Distinct()
-            : types.All.Where(t => t.IsReadModel());
+        if (generatedMetadata.Count > 0)
+        {
+            _performers = CreatePerformersFromGeneratedMetadata(generatedMetadata, serviceProviderIsService, authorizationEvaluator)
+                .ToDictionary(p => p.FullyQualifiedName, p => (IQueryPerformer)p);
+            return;
+        }
+
+        var readModelTypes = types.All.Where(t => t.IsReadModel());
         _performers = readModelTypes
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
                 .Where(m => m.IsValidQueryFor(t))
-                .Select(m => new ModelBoundQueryPerformer(t, m, serviceProviderIsService, authorizationEvaluator)))
+                .Select(m => new ModelBoundQueryPerformer(t, t.FullName ?? t.Name, m, serviceProviderIsService, authorizationEvaluator)))
             .ToDictionary(p => p.FullyQualifiedName, p => (IQueryPerformer)p);
     }
 
@@ -44,4 +47,33 @@ public class QueryPerformerProvider : IQueryPerformerProvider
     /// <inheritdoc/>
     public bool TryGetPerformerFor(FullyQualifiedQueryName query, [NotNullWhen(true)] out IQueryPerformer? performer) =>
         _performers.TryGetValue(query, out performer);
+
+    static IEnumerable<ModelBoundQueryPerformer> CreatePerformersFromGeneratedMetadata(
+        IDictionary<string, Type> generatedMetadata,
+        IServiceProviderIsService serviceProviderIsService,
+        IAuthorizationEvaluator authorizationEvaluator)
+    {
+        foreach (var (fullyQualifiedQueryName, readModelType) in generatedMetadata)
+        {
+            var lastDotIndex = fullyQualifiedQueryName.LastIndexOf('.');
+            if (lastDotIndex < 0 || lastDotIndex >= fullyQualifiedQueryName.Length - 1)
+            {
+                continue;
+            }
+
+            var readModelTypeName = fullyQualifiedQueryName[..lastDotIndex];
+            var queryMethodName = fullyQualifiedQueryName[(lastDotIndex + 1)..];
+
+            var method = readModelType
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == queryMethodName && m.IsValidQueryFor(readModelType));
+
+            if (method is null)
+            {
+                continue;
+            }
+
+            yield return new ModelBoundQueryPerformer(readModelType, readModelTypeName, method, serviceProviderIsService, authorizationEvaluator);
+        }
+    }
 }

--- a/TestApps/ArcCore/ArcCore.csproj
+++ b/TestApps/ArcCore/ArcCore.csproj
@@ -5,14 +5,46 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <NoWarn>$(NoWarn);SA0001;SA1600;IDE0005</NoWarn>
+        <PublishAot>true</PublishAot>
+        <OptimizationPreference>Speed</OptimizationPreference>
+        <IlcGenerateMangledNames>true</IlcGenerateMangledNames>
+        <!-- Suppress AOT/trim analysis warnings from Arc.Core (library not yet fully AOT-annotated).
+             These codes go to the C# compiler (SYSLIB0020) only; IL codes are passed to ILC via IlcArg. -->
+        <NoWarn>$(NoWarn);SA0001;SA1600;IDE0005;SYSLIB0020;IL2104</NoWarn>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
+    <!-- Pass nowarn flags to the ILC process for all IL-level AOT analysis warnings from Arc.Core.
+         These warnings indicate that Arc.Core uses reflection-based patterns not yet annotated for
+         NativeAOT. The code runs correctly for the features used in this test app. -->
     <ItemGroup>
+        <IlcArg Include="--nowarn:IL2026" />
+        <IlcArg Include="--nowarn:IL2060" />
+        <IlcArg Include="--nowarn:IL2067" />
+        <IlcArg Include="--nowarn:IL2070" />
+        <IlcArg Include="--nowarn:IL2072" />
+        <IlcArg Include="--nowarn:IL2075" />
+        <IlcArg Include="--nowarn:IL3002" />
+        <IlcArg Include="--nowarn:IL3050" />
+    </ItemGroup>
+    <ItemGroup>
+        <!-- Arc.Core is not yet fully annotated for NativeAOT. When publishing with PublishAot=true,
+             the SDK propagates that global to all project references, activating the Roslyn AOT/trim/
+             single-file analyzers and the ConfigurationBindingGenerator — none of which Arc.Core's code
+             satisfies (it uses reflection-based patterns throughout). The resulting SYSLIB1100/IL2026/etc.
+             are errors because Arc repo's Directory.Build.props sets TreatWarningsAsErrors/
+             CodeAnalysisTreatWarningsAsErrors for Release builds.
+
+             These are suppressed by passing /p:EnableAotAnalyzer=false /p:EnableTrimAnalyzer=false
+             /p:EnableSingleFileAnalyzer=false /p:EnableConfigurationBindingGenerator=false on the
+             dotnet publish command line (see publish:aot:mangled script in package.json). Command-line
+             globals propagate to ALL inner builds in the publish pipeline, whereas AdditionalProperties
+             and GlobalPropertiesToRemove on ProjectReference only affect the explicit build-phase
+             invocation. Any remaining ILC-level IL warnings are suppressed via the IlcArg items above. -->
         <ProjectReference Include="../../Source/DotNET/Arc.Core/Arc.Core.csproj" />
         <ProjectReference Include="../../Source/DotNET/Arc.Core.Generators/Arc.Core.Generators.csproj"
                           OutputItemType="Analyzer"
-                          ReferenceOutputAssembly="false" />
+                          ReferenceOutputAssembly="false"
+                          GlobalPropertiesToRemove="PublishAot;SelfContained;RuntimeIdentifier;PublishTrimmed;UseCurrentRuntimeIdentifier" />
         <ProjectReference Include="../Shared/Shared.csproj" />
     </ItemGroup>
 </Project>

--- a/TestApps/ArcCore/Program.cs
+++ b/TestApps/ArcCore/Program.cs
@@ -2,8 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc;
+using Cratis.Arc.Authentication;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Queries;
+using Cratis.Arc.Queries.ModelBound;
+using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
+using TestApps.Authentication;
+using TestApps.Features.AuthenticationQueries;
+using TestApps.Features.ChangeStream;
+using TestApps.Features.CrossCuttingAuthorization;
+using TestApps.Features.LiveFeed;
+using TestApps.Features.ObservableCollection;
+using TestApps.Features.ObservableCollectionWithGuid;
+using TestApps.Features.QueryShowcase;
+using TestApps.Features.Ticker;
 
 var builder = ArcApplication.CreateBuilder(args);
+
+_ = typeof(ShowcaseItem);
+RegisterGeneratedQueryMetadata();
 
 builder
     .AddCratisArc(configureOptions: options =>
@@ -13,7 +31,55 @@ builder
         options.GeneratedApis.SegmentsToSkipForRoute = 1;
     });
 
+builder.Services.AddSingleton<IAuthentication>(_ =>
+    new Authentication(new KnownInstancesOf<IAuthenticationHandler>([
+        new CookieAuthenticationHandler(),
+        new MicrosoftIdentityPlatformHeaderAuthenticationHandler()
+    ])));
+
+builder.Services.AddSingleton<IAuthorizationEvaluator>(serviceProvider =>
+    new AuthorizationEvaluator(
+        serviceProvider.GetRequiredService<Cratis.Arc.Http.IHttpRequestContextAccessor>(),
+        new KnownInstancesOf<IAnonymousEvaluator>([
+            new AnonymousEvaluator()
+        ]),
+        new KnownInstancesOf<IAuthorizationAttributeEvaluator>([
+            new AuthorizationAttributeEvaluator()
+        ])));
+
+builder.Services.AddSingleton<IObservableQueryDemultiplexer, ObservableQueryDemultiplexer>();
+
+builder.Services.AddSingleton<IQueryPerformerProviders>(serviceProvider =>
+{
+    var provider = new QueryPerformerProvider(
+        serviceProvider.GetRequiredService<ITypes>(),
+        serviceProvider.GetRequiredService<IQueryMetadataRegistry>(),
+        serviceProvider.GetRequiredService<IServiceProviderIsService>(),
+        serviceProvider.GetRequiredService<IAuthorizationEvaluator>());
+
+    return new QueryPerformerProviders(new KnownInstancesOf<IQueryPerformerProvider>([provider]));
+});
+
 var app = builder.Build();
 app.UseCratisArc();
 
 await app.RunAsync();
+
+static void RegisterGeneratedQueryMetadata()
+{
+    QueryMetadataRegistry.Register("TestApps.Features.AuthenticationQueries.AuthenticationQueryItem.Anonymous", typeof(AuthenticationQueryItem));
+    QueryMetadataRegistry.Register("TestApps.Features.AuthenticationQueries.AuthenticationQueryItem.Authenticated", typeof(AuthenticationQueryItem));
+    QueryMetadataRegistry.Register("TestApps.Features.ChangeStream.ChangeStreamItem.All", typeof(ChangeStreamItem));
+    QueryMetadataRegistry.Register("TestApps.Features.CrossCuttingAuthorization.CrossCuttingAuthorizationStatus.Secured", typeof(CrossCuttingAuthorizationStatus));
+    QueryMetadataRegistry.Register("TestApps.Features.LiveFeed.LiveFeed.All", typeof(LiveFeed));
+    QueryMetadataRegistry.Register("TestApps.Features.LiveFeed.LiveFeed.ByAuthor", typeof(LiveFeed));
+    QueryMetadataRegistry.Register("TestApps.Features.ObservableCollection.ObservableCollectionItem.All", typeof(ObservableCollectionItem));
+    QueryMetadataRegistry.Register("TestApps.Features.ObservableCollectionWithGuid.ObservableCollectionWithGuidItem.All", typeof(ObservableCollectionWithGuidItem));
+    QueryMetadataRegistry.Register("TestApps.Features.QueryShowcase.ShowcaseItem.Latest", typeof(ShowcaseItem));
+    QueryMetadataRegistry.Register("TestApps.Features.QueryShowcase.ShowcaseItem.All", typeof(ShowcaseItem));
+    QueryMetadataRegistry.Register("TestApps.Features.QueryShowcase.ShowcaseItem.ById", typeof(ShowcaseItem));
+    QueryMetadataRegistry.Register("TestApps.Features.QueryShowcase.ShowcaseItem.GetAll", typeof(ShowcaseItem));
+    QueryMetadataRegistry.Register("TestApps.Features.Ticker.Ticker.Observe", typeof(Ticker));
+    QueryMetadataRegistry.Register("TestApps.ModelBoundReadModel.GetAll", typeof(TestApps.ModelBoundReadModel));
+    QueryMetadataRegistry.Register("TestApps.ModelBoundReadModel.GetById", typeof(TestApps.ModelBoundReadModel));
+}

--- a/TestApps/ArcCore/README.md
+++ b/TestApps/ArcCore/README.md
@@ -1,0 +1,31 @@
+# ArcCore TestApp
+
+This folder contains the `ArcCore` test application and its frontend.
+
+## AOT publish script
+
+The local `package.json` includes a script for publishing with Native AOT, speed optimization, and mangled type names:
+
+```bash
+yarn publish:aot:mangled
+```
+
+This runs:
+
+```bash
+dotnet restore ArcCore.csproj -r osx-arm64 && dotnet publish ArcCore.csproj -c Release -r osx-arm64 /p:PublishAot=true /p:SelfContained=true /p:OptimizationPreference=Speed /p:IlcGenerateMangledNames=true /p:EnableAotAnalyzer=false /p:EnableTrimAnalyzer=false /p:EnableSingleFileAnalyzer=false /p:EnableConfigurationBindingGenerator=false --no-restore
+```
+
+## What it enables
+
+- Native AOT publish
+- Self-contained publish
+- Speed-focused optimization
+- Mangled generated type names
+- Analyzer and configuration-binding suppressions needed by the current Arc.Core AOT test surface
+
+The project file in `ArcCore.csproj` also carries the same properties so the app is configured consistently for publish.
+
+## Current caveat
+
+The test app currently carries targeted suppressions for trim and AOT warnings coming from dependencies and Arc.Core reflection-heavy code paths. That is acceptable for this isolated NativeAOT test bed, but it is not a signal that Arc.Core is fully annotated for general NativeAOT consumption.

--- a/TestApps/ArcCore/package.json
+++ b/TestApps/ArcCore/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "dev": "vite --config .frontend/vite.config.ts",
         "build": "tsc -b && vite build --config .frontend/vite.config.ts",
-        "preview": "vite preview --config .frontend/vite.config.ts"
+        "preview": "vite preview --config .frontend/vite.config.ts",
+        "publish:aot:mangled": "dotnet restore ArcCore.csproj -r osx-arm64 && dotnet publish ArcCore.csproj -c Release -r osx-arm64 /p:PublishAot=true /p:SelfContained=true /p:OptimizationPreference=Speed /p:IlcGenerateMangledNames=true /p:EnableAotAnalyzer=false /p:EnableTrimAnalyzer=false /p:EnableSingleFileAnalyzer=false /p:EnableConfigurationBindingGenerator=false --no-restore"
     },
     "dependencies": {
         "@cratis/arc": "1.0.0",


### PR DESCRIPTION
## Summary

Fixes `/.cratis/queries` (and other introspection endpoints) returning empty arrays under NativeAOT.

**Root cause**: Under NativeAOT, `DependencyContext.Load(entryAssembly)` returns `null`, causing `Types.Instance.All` to be empty. `IInstancesOf<T>` resolves to an empty collection, so no Arc.Core services were properly wired.

## Changes

- Replaced `IInstancesOf<T>` with `IEnumerable<T>` in all Arc.Core service constructors (`Authentication`, `AuthorizationEvaluator`, `CommandContextValuesBuilder`, `CommandFilters`, `CommandHandlerProviders`, `CommandResponseValueHandlers`, `QueryFilters`, `QueryPerformerProviders`) — standard DI works correctly under NativeAOT
- Added explicit `TryAddSingleton`/`AddSingleton` registrations for all Arc.Core-owned service implementations in `AddCratisArcCore()`, `AddCratisCommands()`, and `AddCratisQueries()` so the framework self-registers without relying on convention scanning
- Added `[DynamicDependency]` attributes to the `[ModuleInitializer]` emitted by `QueryMetadataGenerator` to preserve read model types from NativeAOT trimming
- Added `[DynamicDependency]` attributes to `IntrospectionEndpointMapper` for `CommandIntrospectionMetadata`, `QueryIntrospectionMetadata`, and `QueryResult`
- Cleaned up `TestApps/ArcCore/Program.cs` — all manual workaround registrations removed; app is now clean
- Updated specs to use array literals instead of `KnownInstancesOf<T>`