### PR TITLE
Fix EventSourceId resolution for subclasses of EventSourceId<T>

### DIFF
--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_checking_has_event_source_id_for_command/with_subclass_of_generic_event_source_id_property.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_checking_has_event_source_id_for_command/with_subclass_of_generic_event_source_id_property.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_checking_has_event_source_id_for_command;
+
+public class with_subclass_of_generic_event_source_id_property : Specification
+{
+    CommandWithSubclassedEventSourceId _command;
+    bool _result;
+
+    void Establish() => _command = new(new TypedId(Guid.NewGuid()));
+
+    void Because() => _result = _command.HasEventSourceId();
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+
+    record TypedId(Guid Value) : EventSourceId<Guid>(Value);
+    record CommandWithSubclassedEventSourceId(TypedId EventModelId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_subclass_of_generic_event_source_id_property.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_subclass_of_generic_event_source_id_property.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_getting_event_source_id;
+
+public class from_command_with_subclass_of_generic_event_source_id_property : Specification
+{
+    CommandWithSubclassedEventSourceId _command;
+    TypedId _typedEventSourceId;
+    EventSourceId _result;
+
+    void Establish()
+    {
+        _typedEventSourceId = new TypedId(Guid.NewGuid());
+        _command = new(_typedEventSourceId);
+    }
+
+    void Because() => _result = _command.GetEventSourceId();
+
+    [Fact] void should_return_the_event_source_id() => _result.ShouldEqual((EventSourceId)_typedEventSourceId);
+
+    record TypedId(Guid Value) : EventSourceId<Guid>(Value);
+    record CommandWithSubclassedEventSourceId(TypedId EventModelId);
+}

--- a/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
@@ -88,8 +88,12 @@ public static class EventSourceExtensions
         return eventSourceId;
     }
 
-    static bool IsGenericEventSourceIdType(Type type) =>
-        type.IsGenericType && type.GetGenericTypeDefinition() == _genericEventSourceIdDefinition;
+    static bool IsGenericEventSourceIdType(Type? type)
+    {
+        if (type is null) return false;
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEventSourceIdDefinition) return true;
+        return IsGenericEventSourceIdType(type.BaseType);
+    }
 
     static bool IsEventSourceIdValue(object? value) =>
         value is EventSourceId || (value is not null && IsGenericEventSourceIdType(value.GetType()));
@@ -103,11 +107,21 @@ public static class EventSourceExtensions
 
         if (IsGenericEventSourceIdType(value.GetType()))
         {
-            var op = value.GetType()
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .First(m => m.Name == "op_Implicit" && m.ReturnType == typeof(EventSourceId));
+            var type = value.GetType();
+            while (type is not null)
+            {
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEventSourceIdDefinition)
+                {
+                    var op = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                        .FirstOrDefault(m => m.Name == "op_Implicit" && m.ReturnType == typeof(EventSourceId));
+                    if (op is not null)
+                    {
+                        return (EventSourceId)op.Invoke(null, [value])!;
+                    }
+                }
 
-            return (EventSourceId)op.Invoke(null, [value])!;
+                type = type.BaseType;
+            }
         }
 
         return value.ToString()!;


### PR DESCRIPTION
## Fixed
- Commands with a property whose type inherits from `EventSourceId<T>` (e.g. `EventModelId : EventSourceId<Guid>`) now correctly resolve the event source id instead of generating a new random one.