### PR TITLE
ProxyGenerator: derived types, flags enums, and assembly-to-package mappings

### DIFF
--- a/Documentation/backend/proxy-generation.md
+++ b/Documentation/backend/proxy-generation.md
@@ -1,17 +1,76 @@
 # Proxy Generation
 
-> **Status**: This documentation is in progress and will be updated soon.
-
-The TypeScript proxy generator automatically creates strongly-typed client code for your commands and queries, ensuring type safety between your backend and frontend.
+The TypeScript proxy generator automatically creates strongly-typed client code for your commands, queries, and types — ensuring compile-time type safety between your backend and frontend without any manual synchronization.
 
 ## Overview
 
-The proxy generator analyzes your backend API (commands and queries) and generates:
+The proxy generator analyzes your backend API at build time and generates:
 
 - TypeScript interfaces for all request and response types
-- Strongly-typed proxy methods for invoking commands and queries
+- Strongly-typed proxy classes for invoking commands and queries
+- TypeScript enums for all C# enum types referenced by your API
 - Full IntelliSense support in your IDE
-- Compile-time type checking
+
+## Enum Generation
+
+C# enums referenced by any command, query, or type are automatically discovered and generated as TypeScript enums. Member names are converted to camelCase.
+
+**C# source:**
+
+```csharp
+public enum ReadModelStatus
+{
+    Unknown = 0,
+    Active = 1,
+    Inactive = 2,
+    Archived = 3
+}
+```
+
+**Generated TypeScript:**
+
+```typescript
+export enum ReadModelStatus {
+    unknown = 0,
+    active = 1,
+    inactive = 2,
+    archived = 3,
+}
+```
+
+### Flags Enums
+
+Enums decorated with `[Flags]` receive special treatment: the generator uses a dedicated template that, in addition to the enum declaration, emits an `allXxx` constant combining every non-zero member with the bitwise OR operator. This constant is useful when you need to represent "all flags set" or build a full bitmask without repeating every member name by hand.
+
+**C# source:**
+
+```csharp
+[Flags]
+public enum AnchorEdges
+{
+    None = 0,
+    Top = 1 << 0,
+    Right = 1 << 1,
+    Bottom = 1 << 2,
+    Left = 1 << 3,
+}
+```
+
+**Generated TypeScript:**
+
+```typescript
+export enum AnchorEdges {
+    none = 0,
+    top = 1,
+    right = 2,
+    bottom = 4,
+    left = 8,
+}
+
+export const allAnchorEdges = AnchorEdges.top | AnchorEdges.right | AnchorEdges.bottom | AnchorEdges.left;
+```
+
+The `allAnchorEdges` constant excludes `none` (value `0`) because a zero-valued member contributes nothing to a bitwise OR expression. The name follows the convention `all<EnumName>` and is exported alongside the enum.
 
 ## Configuration
 

--- a/Documentation/backend/proxy-generation/configuration.md
+++ b/Documentation/backend/proxy-generation/configuration.md
@@ -212,7 +212,7 @@ When your project depends on types from an external assembly that already has a 
 
 A common scenario in larger .NET solutions is to have a shared class library used by multiple applications. Consider this solution structure:
 
-```
+```text
 MyCompany.Shared/           ← Shared class library (NuGet + npm package)
 MyCompany.Inventory/        ← Application referencing Shared
 MyCompany.Purchasing/       ← Application referencing Shared

--- a/Documentation/backend/proxy-generation/configuration.md
+++ b/Documentation/backend/proxy-generation/configuration.md
@@ -204,6 +204,77 @@ When using the proxy generator CLI directly:
 proxygenerator assembly.dll output-path --use-source-file-as-output-file
 ```
 
+## Assembly-to-Package Mappings
+
+When your project depends on types from an external assembly that already has a corresponding TypeScript package, you can configure the proxy generator to import those types from the npm package instead of generating local TypeScript files for them.
+
+### Use Case
+
+Consider a solution with two C# projects:
+
+- **Core** — your main application project
+- **Scene** — a shared library project with its own npm package `@cratis/scene`
+
+If `Core` references `Scene` and uses `Scene.UIElement` in a command:
+
+```csharp
+// In the Core project
+public class UpdateUIElements(IEnumerable<UIElement> Elements);
+```
+
+By default, the proxy generator would create a local `UIElement.ts` file. With an assembly-to-package mapping, it instead imports `UIElement` from `@cratis/scene`:
+
+```typescript
+import { UIElement } from '@cratis/scene';
+```
+
+### MSBuild Configuration
+
+Use the `AssemblyToPageMapping` item group in your `.csproj` file:
+
+```xml
+<ItemGroup>
+    <AssemblyToPageMapping Assembly="Scene" Package="@cratis/scene" />
+</ItemGroup>
+```
+
+Multiple mappings are supported:
+
+```xml
+<ItemGroup>
+    <AssemblyToPageMapping Assembly="Scene" Package="@cratis/scene" />
+    <AssemblyToPageMapping Assembly="Shared" Package="@myorg/shared" />
+</ItemGroup>
+```
+
+Where:
+- `Assembly` — the name of the C# assembly (without `.dll` extension) whose types should be mapped
+- `Package` — the npm package name to import from
+
+### CLI Usage
+
+When using the proxy generator CLI directly, pass one or more `--assembly-to-package` flags:
+
+```bash
+proxygenerator assembly.dll output-path --assembly-to-package=Scene=@cratis/scene
+```
+
+Multiple mappings:
+
+```bash
+proxygenerator assembly.dll output-path \
+  --assembly-to-package=Scene=@cratis/scene \
+  --assembly-to-package=Shared=@myorg/shared
+```
+
+### Behavior
+
+When an assembly mapping is configured:
+
+- Types from that assembly are **not** generated as local TypeScript files
+- Any command, query, or type that references a mapped type will instead `import` it from the configured npm package
+- The mapping applies to all types in the assembly, including enums and complex types
+
 ## Advanced Configuration
 
 For more complex scenarios, you can combine multiple configuration options:

--- a/Documentation/backend/proxy-generation/configuration.md
+++ b/Documentation/backend/proxy-generation/configuration.md
@@ -230,11 +230,11 @@ import { UIElement } from '@cratis/scene';
 
 ### MSBuild Configuration
 
-Use the `AssemblyToPageMapping` item group in your `.csproj` file:
+Use the `AssemblyToPackageMapping` item group in your `.csproj` file:
 
 ```xml
 <ItemGroup>
-    <AssemblyToPageMapping Assembly="Scene" Package="@cratis/scene" />
+    <AssemblyToPackageMapping Assembly="Scene" Package="@cratis/scene" />
 </ItemGroup>
 ```
 
@@ -242,8 +242,8 @@ Multiple mappings are supported:
 
 ```xml
 <ItemGroup>
-    <AssemblyToPageMapping Assembly="Scene" Package="@cratis/scene" />
-    <AssemblyToPageMapping Assembly="Shared" Package="@myorg/shared" />
+    <AssemblyToPackageMapping Assembly="Scene" Package="@cratis/scene" />
+    <AssemblyToPackageMapping Assembly="Shared" Package="@myorg/shared" />
 </ItemGroup>
 ```
 

--- a/Documentation/backend/proxy-generation/configuration.md
+++ b/Documentation/backend/proxy-generation/configuration.md
@@ -210,40 +210,56 @@ When your project depends on types from an external assembly that already has a 
 
 ### Use Case
 
-Consider a solution with two C# projects:
+A common scenario in larger .NET solutions is to have a shared class library used by multiple applications. Consider this solution structure:
 
-- **Core** — your main application project
-- **Scene** — a shared library project with its own npm package `@cratis/scene`
+```
+MyCompany.Shared/           ← Shared class library (NuGet + npm package)
+MyCompany.Inventory/        ← Application referencing Shared
+MyCompany.Purchasing/       ← Application referencing Shared
+```
 
-If `Core` references `Scene` and uses `Scene.UIElement` in a command:
+The `Shared` library contains reusable domain types and ships with an npm package (`@mycompany/shared`) that already exports the corresponding TypeScript types.
+
+For example, `Shared` contains:
 
 ```csharp
-// In the Core project
-public class UpdateUIElements(IEnumerable<UIElement> Elements);
+// MyCompany.Shared
+public record Money(decimal Amount, string Currency);
+public record ProductId(Guid Value);
 ```
 
-By default, the proxy generator would create a local `UIElement.ts` file. With an assembly-to-package mapping, it instead imports `UIElement` from `@cratis/scene`:
+And `Inventory` uses these types in commands:
+
+```csharp
+// MyCompany.Inventory
+public class AdjustProductPrice(ProductId Product, Money NewPrice);
+```
+
+Without a mapping, the proxy generator would regenerate `Money.ts` and `ProductId.ts` locally in the `Inventory` frontend — duplicating types that are already in `@mycompany/shared`. With an assembly-to-package mapping, the generator imports them from the published package instead:
 
 ```typescript
-import { UIElement } from '@cratis/scene';
+import { Money, ProductId } from '@mycompany/shared';
 ```
+
+The same mapping works for any number of applications (`Inventory`, `Purchasing`, …) that reference `Shared`, keeping all TypeScript types in sync with a single source of truth.
 
 ### MSBuild Configuration
 
-Use the `AssemblyToPackageMapping` item group in your `.csproj` file:
+Add the `AssemblyToPackageMapping` item group to the `.csproj` of each application that references the shared library:
 
 ```xml
+<!-- MyCompany.Inventory.csproj -->
 <ItemGroup>
-    <AssemblyToPackageMapping Assembly="Scene" Package="@cratis/scene" />
+    <AssemblyToPackageMapping Assembly="MyCompany.Shared" Package="@mycompany/shared" />
 </ItemGroup>
 ```
 
-Multiple mappings are supported:
+Multiple shared libraries are supported:
 
 ```xml
 <ItemGroup>
-    <AssemblyToPackageMapping Assembly="Scene" Package="@cratis/scene" />
-    <AssemblyToPackageMapping Assembly="Shared" Package="@myorg/shared" />
+    <AssemblyToPackageMapping Assembly="MyCompany.Shared"   Package="@mycompany/shared" />
+    <AssemblyToPackageMapping Assembly="MyCompany.UiModels" Package="@mycompany/ui-models" />
 </ItemGroup>
 ```
 
@@ -256,15 +272,16 @@ Where:
 When using the proxy generator CLI directly, pass one or more `--assembly-to-package` flags:
 
 ```bash
-proxygenerator assembly.dll output-path --assembly-to-package=Scene=@cratis/scene
+proxygenerator MyCompany.Inventory.dll output-path \
+  --assembly-to-package=MyCompany.Shared=@mycompany/shared
 ```
 
 Multiple mappings:
 
 ```bash
-proxygenerator assembly.dll output-path \
-  --assembly-to-package=Scene=@cratis/scene \
-  --assembly-to-package=Shared=@myorg/shared
+proxygenerator MyCompany.Inventory.dll output-path \
+  --assembly-to-package=MyCompany.Shared=@mycompany/shared \
+  --assembly-to-package=MyCompany.UiModels=@mycompany/ui-models
 ```
 
 ### Behavior

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/AnalyzerVerifier.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/AnalyzerVerifier.cs
@@ -34,7 +34,7 @@ public static class AnalyzerVerifier<TAnalyzer>
         var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
 
         var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer());
-        var compilationWithAnalyzers = compilation!.WithAnalyzers(analyzers);
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
         var orderedDiagnostics = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/CodeFixVerifier.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/CodeFixVerifier.cs
@@ -30,7 +30,7 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
         var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
 
         var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer());
-        var compilationWithAnalyzers = compilation!.WithAnalyzers(analyzers);
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
         var orderedDiagnostics = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 
@@ -41,7 +41,7 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
 
         var actions = new List<CodeAction>();
         var codeFixProvider = new TCodeFix();
-        var context = new CodeFixContext(document, diagnostic!, (action, _) => actions.Add(action), CancellationToken.None);
+        var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
         await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 
         actions.ShouldNotBeEmpty();
@@ -50,11 +50,11 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
         var applyChanges = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
         applyChanges.ShouldNotBeNull();
 
-        var newSolution = applyChanges!.ChangedSolution;
+        var newSolution = applyChanges.ChangedSolution;
         var newDocument = newSolution.GetDocument(document.Id);
         newDocument.ShouldNotBeNull();
 
-        var newText = await newDocument!.GetTextAsync().ConfigureAwait(false);
+        var newText = await newDocument.GetTextAsync().ConfigureAwait(false);
         NormalizeWhitespace(newText.ToString()).ShouldEqual(NormalizeWhitespace(fixedSource));
     }
 

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -54,7 +54,7 @@ public static class TestProject
             MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location),
-            MetadataReference.CreateFromFile(systemRuntime!.Location),
+            MetadataReference.CreateFromFile(systemRuntime.Location),
             MetadataReference.CreateFromFile(typeof(Commands.ModelBound.CommandAttribute).Assembly.Location)
         ];
     }

--- a/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
@@ -60,7 +60,7 @@ public static class GeneratorTestHelper
             MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),
-            MetadataReference.CreateFromFile(systemRuntime!.Location),
+            MetadataReference.CreateFromFile(systemRuntime.Location),
             MetadataReference.CreateFromFile(typeof(Cratis.Arc.Queries.ModelBound.ReadModelAttribute).Assembly.Location),
         ];
     }

--- a/Source/DotNET/Arc.Core.Specs/Authentication/for_Authentication/when_handling_authentication/with_single_handler_that_fails.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authentication/for_Authentication/when_handling_authentication/with_single_handler_that_fails.cs
@@ -21,5 +21,5 @@ public class with_single_handler_that_fails : given.an_authentication_system
 
     [Fact] void should_return_unauthenticated_result() => _result.IsAuthenticated.ShouldBeFalse();
     [Fact] void should_return_failure() => _result.Failure.ShouldNotBeNull();
-    [Fact] void should_return_failure_with_invalid_credentials_reason() => _result.Failure!.Reason.Value.ShouldEqual("Invalid credentials");
+    [Fact] void should_return_failure_with_invalid_credentials_reason() => _result.Failure.Reason.Value.ShouldEqual("Invalid credentials");
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_allow_anonymous.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_allow_anonymous.cs
@@ -6,7 +6,7 @@ public class with_method_with_allow_anonymous : given.an_authorization_helper
 {
     bool _result;
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithMethodAllowAnonymous).GetMethod(nameof(given.TypeWithMethodAllowAnonymous.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithMethodAllowAnonymous).GetMethod(nameof(given.TypeWithMethodAllowAnonymous.Method)));
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_allow_anonymous_and_type_with_authorization.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_allow_anonymous_and_type_with_authorization.cs
@@ -6,7 +6,7 @@ public class with_method_with_allow_anonymous_and_type_with_authorization : give
 {
     bool _result;
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodAllowAnonymous).GetMethod(nameof(given.TypeWithAuthorizationAndMethodAllowAnonymous.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodAllowAnonymous).GetMethod(nameof(given.TypeWithAuthorizationAndMethodAllowAnonymous.Method)));
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_authenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_authenticated_user.cs
@@ -11,7 +11,7 @@ public class with_method_with_authorization_and_authenticated_user : given.an_au
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization))!;
+        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization));
         SetupAuthenticatedUser();
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_no_http_context.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_no_http_context.cs
@@ -11,7 +11,7 @@ public class with_method_with_authorization_and_no_http_context : given.an_autho
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization))!;
+        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization));
         SetupNoHttpRequestContext();
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_no_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_no_user.cs
@@ -11,7 +11,7 @@ public class with_method_with_authorization_and_no_user : given.an_authorization
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization))!;
+        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization));
         SetupNoUser();
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_type_with_allow_anonymous_and_authenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_type_with_allow_anonymous_and_authenticated_user.cs
@@ -8,7 +8,7 @@ public class with_method_with_authorization_and_type_with_allow_anonymous_and_au
 
     void Establish() => SetupAuthenticatedUser();
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithAuthorization.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithAuthorization.Method)));
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_type_with_allow_anonymous_and_unauthenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_type_with_allow_anonymous_and_unauthenticated_user.cs
@@ -8,7 +8,7 @@ public class with_method_with_authorization_and_type_with_allow_anonymous_and_un
 
     void Establish() => SetupUnauthenticatedUser();
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithAuthorization.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithAuthorization.Method)));
 
     [Fact] void should_return_false() => _result.ShouldBeFalse();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_unauthenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_authorization_and_unauthenticated_user.cs
@@ -11,7 +11,7 @@ public class with_method_with_authorization_and_unauthenticated_user : given.an_
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization))!;
+        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithAuthorization));
         SetupUnauthenticatedUser();
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_multiple_roles_and_user_has_no_required_roles.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_multiple_roles_and_user_has_no_required_roles.cs
@@ -11,7 +11,7 @@ public class with_method_with_multiple_roles_and_user_has_no_required_roles : gi
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodMultipleRoles).GetMethod(nameof(given.TypeWithMethodMultipleRoles.MethodWithMultipleRoles))!;
+        _method = typeof(given.TypeWithMethodMultipleRoles).GetMethod(nameof(given.TypeWithMethodMultipleRoles.MethodWithMultipleRoles));
         SetupAuthenticatedUser("Guest");
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_multiple_roles_and_user_has_one_required_role.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_multiple_roles_and_user_has_one_required_role.cs
@@ -11,7 +11,7 @@ public class with_method_with_multiple_roles_and_user_has_one_required_role : gi
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodMultipleRoles).GetMethod(nameof(given.TypeWithMethodMultipleRoles.MethodWithMultipleRoles))!;
+        _method = typeof(given.TypeWithMethodMultipleRoles).GetMethod(nameof(given.TypeWithMethodMultipleRoles.MethodWithMultipleRoles));
         SetupAuthenticatedUser("Admin");
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_single_role_and_user_does_not_have_required_role.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_single_role_and_user_does_not_have_required_role.cs
@@ -11,7 +11,7 @@ public class with_method_with_single_role_and_user_does_not_have_required_role :
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodSingleRole).GetMethod(nameof(given.TypeWithMethodSingleRole.MethodWithSingleRole))!;
+        _method = typeof(given.TypeWithMethodSingleRole).GetMethod(nameof(given.TypeWithMethodSingleRole.MethodWithSingleRole));
         SetupAuthenticatedUser("User");
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_single_role_and_user_has_required_role.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_with_single_role_and_user_has_required_role.cs
@@ -11,7 +11,7 @@ public class with_method_with_single_role_and_user_has_required_role : given.an_
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodSingleRole).GetMethod(nameof(given.TypeWithMethodSingleRole.MethodWithSingleRole))!;
+        _method = typeof(given.TypeWithMethodSingleRole).GetMethod(nameof(given.TypeWithMethodSingleRole.MethodWithSingleRole));
         SetupAuthenticatedUser("Admin");
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization.cs
@@ -11,7 +11,7 @@ public class with_method_without_authorization : given.an_authorization_helper
 
     void Establish()
     {
-        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithoutAuthorization))!;
+        _method = typeof(given.TypeWithMethodAuthorization).GetMethod(nameof(given.TypeWithMethodAuthorization.MethodWithoutAuthorization));
     }
 
     void Because() => _result = _authorizationHelper.IsAuthorized(_method);

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_allow_anonymous.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_allow_anonymous.cs
@@ -6,7 +6,7 @@ public class with_method_without_authorization_and_type_with_allow_anonymous : g
 {
     bool _result;
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithoutAuthorization.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAllowAnonymousAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAllowAnonymousAndMethodWithoutAuthorization.Method)));
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_authorization_and_authenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_authorization_and_authenticated_user.cs
@@ -8,7 +8,7 @@ public class with_method_without_authorization_and_type_with_authorization_and_a
 
     void Establish() => SetupAuthenticatedUser();
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAuthorizationAndMethodWithoutAuthorization.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAuthorizationAndMethodWithoutAuthorization.Method)));
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_authorization_and_unauthenticated_user.cs
+++ b/Source/DotNET/Arc.Core.Specs/Authorization/for_AuthorizationEvaluator/when_checking_method_authorization/with_method_without_authorization_and_type_with_authorization_and_unauthenticated_user.cs
@@ -8,7 +8,7 @@ public class with_method_without_authorization_and_type_with_authorization_and_u
 
     void Establish() => SetupUnauthenticatedUser();
 
-    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAuthorizationAndMethodWithoutAuthorization.Method))!);
+    void Because() => _result = _authorizationHelper.IsAuthorized(typeof(given.TypeWithAuthorizationAndMethodWithoutAuthorization).GetMethod(nameof(given.TypeWithAuthorizationAndMethodWithoutAuthorization.Method)));
 
     [Fact] void should_return_false() => _result.ShouldBeFalse();
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_command_handler_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_command_handler_throws.cs
@@ -31,7 +31,7 @@ public class and_command_handler_throws : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), [], new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _thrownException = await Catch.Exception(async () => await _handler.Handle(_context));

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_task.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_task.cs
@@ -29,7 +29,7 @@ public class and_handler_returns_a_task : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value.cs
@@ -29,7 +29,7 @@ public class and_handler_returns_a_value : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value_task.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_a_value_task.cs
@@ -29,7 +29,7 @@ public class and_handler_returns_a_value_task : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_task_without_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_task_without_value.cs
@@ -27,7 +27,7 @@ public class and_handler_returns_async_task_without_value : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_value_task.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_async_value_task.cs
@@ -30,7 +30,7 @@ public class and_handler_returns_async_value_task : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_task_without_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_task_without_value.cs
@@ -27,7 +27,7 @@ public class and_handler_returns_task_without_value : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_value_task_without_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_value_task_without_value.cs
@@ -27,7 +27,7 @@ public class and_handler_returns_value_task_without_value : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_void.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/ModelBound/for_ModelBoundCommandHandler/when_handling/and_handler_returns_void.cs
@@ -26,7 +26,7 @@ public class and_handler_returns_void : Specification
         _context = new(CorrelationId.New(), typeof(Command), new Command(), _dependencies, new());
         _handler = new ModelBoundCommandHandler(
             typeof(Command),
-            typeof(Command).GetMethod(nameof(Command.Handle))!);
+            typeof(Command).GetMethod(nameof(Command.Handle)));
     }
 
     async Task Because() => _result = await _handler.Handle(_context);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_one_unhandled_and_two_handled_values.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_triple_with_one_unhandled_and_two_handled_values.cs
@@ -41,5 +41,5 @@ public class and_handler_returns_a_triple_with_one_unhandled_and_two_handled_val
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
     [Fact]
     void should_set_response_on_command_context() =>
-        _commandResponseValueHandlers.Received().Handle(Arg.Is<CommandContext>(ctx => ctx.Response!.Equals(_tuple.Item2)), Arg.Any<object>());
+        _commandResponseValueHandlers.Received().Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item2)), Arg.Any<object>());
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_tuple_with_value_that_can_be_handled_only_after_response_set.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_tuple_with_value_that_can_be_handled_only_after_response_set.cs
@@ -38,7 +38,7 @@ public class and_handler_returns_tuple_with_value_that_can_be_handled_only_after
 
     [Fact]
     void should_call_value_handler_for_value_that_can_be_handled() =>
-        _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response!.Equals(_tuple.Item1)), _tuple.Item2);
+        _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2);
 
     [Fact]
     void should_not_call_value_handler_for_unhandled_value() =>
@@ -46,5 +46,5 @@ public class and_handler_returns_tuple_with_value_that_can_be_handled_only_after
 
     [Fact]
     void should_set_unhandled_value_as_response_in_context_when_checking_if_it_can_be_handled() =>
-        _commandResponseValueHandlers.Received().CanHandle(Arg.Is<CommandContext>(ctx => ctx.Response!.Equals(_tuple.Item1)), _tuple.Item2);
+        _commandResponseValueHandlers.Received().CanHandle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2);
 }

--- a/Source/DotNET/Arc.Core.Specs/Http/for_HttpRequestPipeline/when_processing/with_no_middleware_handling.cs
+++ b/Source/DotNET/Arc.Core.Specs/Http/for_HttpRequestPipeline/when_processing/with_no_middleware_handling.cs
@@ -33,7 +33,7 @@ public class with_no_middleware_handling : given.an_http_request_pipeline
     }
 
     [Fact] void should_call_middleware() => _middleware.WasCalled.ShouldBeTrue();
-    [Fact] void should_return_404() => _response!.StatusCode.ShouldEqual(System.Net.HttpStatusCode.NotFound);
+    [Fact] void should_return_404() => _response.StatusCode.ShouldEqual(System.Net.HttpStatusCode.NotFound);
 
     void Destroy()
     {

--- a/Source/DotNET/Arc.Core.Specs/Http/for_StaticFilesMiddleware/when_invoking/and_file_exists.cs
+++ b/Source/DotNET/Arc.Core.Specs/Http/for_StaticFilesMiddleware/when_invoking/and_file_exists.cs
@@ -46,9 +46,9 @@ public class and_file_exists : given.a_static_files_middleware
     }
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
-    [Fact] void should_return_success_status() => _response!.IsSuccessStatusCode.ShouldBeTrue();
+    [Fact] void should_return_success_status() => _response.IsSuccessStatusCode.ShouldBeTrue();
     [Fact] void should_return_file_content() => _content.ShouldEqual(ExpectedContent);
-    [Fact] void should_set_correct_content_type() => _response!.Content.Headers.ContentType?.MediaType.ShouldEqual("text/html");
+    [Fact] void should_set_correct_content_type() => _response.Content.Headers.ContentType?.MediaType.ShouldEqual("text/html");
 
     void Destroy()
     {

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/when_modifying_details/and_details_are_available.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_IdentityProviderResultHandler/when_modifying_details/and_details_are_available.cs
@@ -41,7 +41,7 @@ public class and_details_are_available : given.an_identity_provider_result_handl
         var cookieValue = calls[0].GetArguments()[1] as string;
         cookieValue.ShouldNotBeNull();
 
-        var decodedJson = Encoding.UTF8.GetString(Convert.FromBase64String(cookieValue!));
+        var decodedJson = Encoding.UTF8.GetString(Convert.FromBase64String(cookieValue));
 
         var serializerOptions = new JsonSerializerOptions().ConfigureArcDefaults();
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/given/a_model_bound_query_performer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/given/a_model_bound_query_performer.cs
@@ -24,7 +24,7 @@ public class a_model_bound_query_performer : Specification
     protected void EstablishPerformer<T>(string methodName, object[]? dependencies = null, QueryArguments? parameters = null)
     {
         var method = typeof(T).GetMethod(methodName);
-        _performer = new ModelBoundQueryPerformer(typeof(T), typeof(T).FullName ?? typeof(T).Name, method!, _serviceProviderIsService, _authorizationEvaluator);
+        _performer = new ModelBoundQueryPerformer(typeof(T), typeof(T).FullName ?? typeof(T).Name, method, _serviceProviderIsService, _authorizationEvaluator);
 
         parameters ??= new QueryArguments();
         dependencies ??= [];

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_checking_is_authorized.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_checking_is_authorized.cs
@@ -12,7 +12,7 @@ public class when_checking_is_authorized : given.a_model_bound_query_performer
 
     void Establish()
     {
-        _method = typeof(TestQuery).GetMethod(nameof(TestQuery.SimpleQuery))!;
+        _method = typeof(TestQuery).GetMethod(nameof(TestQuery.SimpleQuery));
         EstablishPerformer<TestQuery>(nameof(TestQuery.SimpleQuery));
         _authorizationEvaluator.IsAuthorized(_method).Returns(true);
     }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ChangeSetComputor/when_finding_identity_property/and_type_has_id_property.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ChangeSetComputor/when_finding_identity_property/and_type_has_id_property.cs
@@ -12,5 +12,5 @@ public class and_type_has_id_property : Specification
     void Because() => _result = ChangeSetComputor.FindIdentityProperty(typeof(given.ItemWithId));
 
     [Fact] void should_find_the_property() => _result.ShouldNotBeNull();
-    [Fact] void should_find_property_named_id() => _result!.Name.ShouldEqual("Id");
+    [Fact] void should_find_property_named_id() => _result.Name.ShouldEqual("Id");
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_concurrent_messages_are_sent.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_concurrent_messages_are_sent.cs
@@ -128,7 +128,7 @@ public class and_concurrent_messages_are_sent : given.an_observable_query_demult
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected ||
                 hubMessage.Payload is not JsonElement payload)
@@ -150,7 +150,7 @@ public class and_concurrent_messages_are_sent : given.an_observable_query_demult
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_delta_mode_first_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_delta_mode_first_emission.cs
@@ -102,7 +102,7 @@ public class and_connection_is_known_and_delta_mode_first_emission : given.an_ob
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||
@@ -129,7 +129,7 @@ public class and_connection_is_known_and_delta_mode_first_emission : given.an_ob
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_delta_mode_subsequent_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_delta_mode_subsequent_emission.cs
@@ -111,7 +111,7 @@ public class and_connection_is_known_and_delta_mode_subsequent_emission : given.
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||
@@ -138,7 +138,7 @@ public class and_connection_is_known_and_delta_mode_subsequent_emission : given.
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_enumerable_query_emits_change_set.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_enumerable_query_emits_change_set.cs
@@ -106,7 +106,7 @@ public class and_connection_is_known_and_enumerable_query_emits_change_set : giv
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||
@@ -133,7 +133,7 @@ public class and_connection_is_known_and_enumerable_query_emits_change_set : giv
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_full_mode_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_full_mode_emission.cs
@@ -111,7 +111,7 @@ public class and_connection_is_known_and_full_mode_emission : given.an_observabl
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||
@@ -138,7 +138,7 @@ public class and_connection_is_known_and_full_mode_emission : given.an_observabl
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_query_streams_results.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_query_streams_results.cs
@@ -97,7 +97,7 @@ public class and_connection_is_known_and_query_streams_results : given.an_observ
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {
@@ -116,7 +116,7 @@ public class and_connection_is_known_and_query_streams_results : given.an_observ
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(_ => _ is not null)
-                     .Select(_ => _!))
+                     .Select(_ => _))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.QueryResult ||
                 hubMessage.QueryId != QueryId ||

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_subscription_is_unauthorized.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_subscription_is_unauthorized.cs
@@ -77,7 +77,7 @@ public class and_subscription_is_unauthorized : given.an_observable_query_demult
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(m => m is not null)
-                     .Select(m => m!))
+                     .Select(m => m))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected ||
                 hubMessage.Payload is not JsonElement payload)
@@ -97,7 +97,7 @@ public class and_subscription_is_unauthorized : given.an_observable_query_demult
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
                      .Where(m => m is not null)
-                     .Select(m => m!))
+                     .Select(m => m))
         {
             if (hubMessage.Type == ObservableQueryHubMessageType.Unauthorized &&
                 hubMessage.QueryId == QueryId)

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_query_streams_results.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_query_streams_results.cs
@@ -61,7 +61,7 @@ public class and_query_streams_results : given.an_observable_query_demultiplexer
             .Returns(callInfo =>
             {
                 var data = callInfo.Arg<ArraySegment<byte>>();
-                var json = Encoding.UTF8.GetString(data.Array!, data.Offset, data.Count);
+                var json = Encoding.UTF8.GetString(data.Array, data.Offset, data.Count);
                 var hubMessage = JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
                 if (hubMessage is not null)
                 {
@@ -118,7 +118,7 @@ public class and_query_streams_results : given.an_observable_query_demultiplexer
 
     static WebSocketReceiveResult CopyToReceiveBuffer(byte[] data, ArraySegment<byte> buffer)
     {
-        Array.Copy(data, 0, buffer.Array!, buffer.Offset, data.Length);
+        Array.Copy(data, 0, buffer.Array, buffer.Offset, data.Length);
         return new WebSocketReceiveResult(data.Length, System.Net.WebSockets.WebSocketMessageType.Text, true);
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenantIdAccessor/when_getting_current/and_resolver_returns_null.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenantIdAccessor/when_getting_current/and_resolver_returns_null.cs
@@ -9,7 +9,7 @@ public class and_resolver_returns_null : given.a_tenant_id_accessor
 
     void Establish()
     {
-        _tenantIdResolver.Resolve().Returns((string)null!);
+        _tenantIdResolver.Resolve().Returns((string)null);
     }
 
     void Because() => _result = _accessor.Current;

--- a/Source/DotNET/Arc.Specs/Culture/for_CultureWebApplicationBuilderExtensions/when_using_invariant_culture.cs
+++ b/Source/DotNET/Arc.Specs/Culture/for_CultureWebApplicationBuilderExtensions/when_using_invariant_culture.cs
@@ -36,16 +36,16 @@ public class when_using_invariant_culture : Specification
         CultureInfo.DefaultThreadCurrentUICulture.ShouldEqual(CultureInfo.InvariantCulture);
 
     [Fact] void should_configure_request_localization_default_culture_to_invariant() =>
-        _options!.DefaultRequestCulture.Culture.ShouldEqual(CultureInfo.InvariantCulture);
+        _options.DefaultRequestCulture.Culture.ShouldEqual(CultureInfo.InvariantCulture);
 
     [Fact] void should_configure_supported_cultures_to_contain_only_invariant() =>
-        _options!.SupportedCultures.ShouldContainOnly(CultureInfo.InvariantCulture);
+        _options.SupportedCultures.ShouldContainOnly(CultureInfo.InvariantCulture);
 
     [Fact] void should_configure_supported_ui_cultures_to_contain_only_invariant() =>
-        _options!.SupportedUICultures.ShouldContainOnly(CultureInfo.InvariantCulture);
+        _options.SupportedUICultures.ShouldContainOnly(CultureInfo.InvariantCulture);
 
     [Fact] void should_clear_request_culture_providers() =>
-        _options!.RequestCultureProviders.ShouldBeEmpty();
+        _options.RequestCultureProviders.ShouldBeEmpty();
 
     [Fact] void should_return_web_application_builder_for_continuation() =>
         _builder.ShouldNotBeNull();

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_get/setting_current_http_request_context.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_get/setting_current_http_request_context.cs
@@ -36,7 +36,7 @@ public class setting_current_http_request_context : given.an_endpoint_mapper
         };
     }
 
-    async Task Because() => await _endpoint.RequestDelegate!(_httpContext);
+    async Task Because() => await _endpoint.RequestDelegate(_httpContext);
 
     [Fact] void should_set_current_on_the_accessor() => _accessor.Current.ShouldNotBeNull();
     [Fact] void should_set_current_to_the_same_context_passed_to_the_handler() => _accessor.Current.ShouldEqual(_contextReceivedByHandler);

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_post/setting_current_http_request_context.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreEndpointMapper/when_mapping_post/setting_current_http_request_context.cs
@@ -36,7 +36,7 @@ public class setting_current_http_request_context : given.an_endpoint_mapper
         };
     }
 
-    async Task Because() => await _endpoint.RequestDelegate!(_httpContext);
+    async Task Because() => await _endpoint.RequestDelegate(_httpContext);
 
     [Fact] void should_set_current_on_the_accessor() => _accessor.Current.ShouldNotBeNull();
     [Fact] void should_set_current_to_the_same_context_passed_to_the_handler() => _accessor.Current.ShouldEqual(_contextReceivedByHandler);

--- a/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/given/a_controller_query_performer_provider.cs
+++ b/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/given/a_controller_query_performer_provider.cs
@@ -25,7 +25,7 @@ public class a_controller_query_performer_provider : Specification
             ActionName = nameof(TestController.AllEventStores),
             ControllerName = nameof(TestController),
             ControllerTypeInfo = typeof(TestController).GetTypeInfo(),
-            MethodInfo = typeof(TestController).GetMethod(nameof(TestController.AllEventStores))!
+            MethodInfo = typeof(TestController).GetMethod(nameof(TestController.AllEventStores))
         };
 
         var descriptor2 = new ControllerActionDescriptor
@@ -33,7 +33,7 @@ public class a_controller_query_performer_provider : Specification
             ActionName = nameof(TestController.AnonymousEventStores),
             ControllerName = nameof(TestController),
             ControllerTypeInfo = typeof(TestController).GetTypeInfo(),
-            MethodInfo = typeof(TestController).GetMethod(nameof(TestController.AnonymousEventStores))!
+            MethodInfo = typeof(TestController).GetMethod(nameof(TestController.AnonymousEventStores))
         };
 
         _actionDescriptorCollectionProvider = Substitute.For<IActionDescriptorCollectionProvider>();

--- a/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/when_performing_controller_observable_query.cs
+++ b/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/when_performing_controller_observable_query.cs
@@ -40,7 +40,7 @@ public class when_performing_controller_observable_query : a_controller_query_pe
             [serviceProvider]);
     }
 
-    async Task Because() => _result = await _performer!.Perform(_queryContext);
+    async Task Because() => _result = await _performer.Perform(_queryContext);
 
     [Fact] void should_call_controller_query_method_with_argument() => _eventStores.Received(1).ObserveFor("north");
     [Fact] void should_return_subject_from_controller_query() => _result.ShouldEqual(_expectedSubject);

--- a/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/when_trying_to_get_controller_query_performer_for.cs
+++ b/Source/DotNET/Arc.Specs/Queries/ControllerBased/for_QueryPerformerProvider/when_trying_to_get_controller_query_performer_for.cs
@@ -12,5 +12,5 @@ public class when_trying_to_get_controller_query_performer_for : given.a_control
 
     [Fact] void should_find_performer() => _found.ShouldBeTrue();
     [Fact] void should_return_performer() => _performer.ShouldNotBeNull();
-    [Fact] void should_have_expected_fully_qualified_name() => _performer!.FullyQualifiedName.Value.ShouldEqual(QueryName);
+    [Fact] void should_have_expected_fully_qualified_name() => _performer.FullyQualifiedName.Value.ShouldEqual(QueryName);
 }

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/AnalyzerVerifier.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/AnalyzerVerifier.cs
@@ -34,7 +34,7 @@ public static class AnalyzerVerifier<TAnalyzer>
         var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
 
         var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer());
-        var compilationWithAnalyzers = compilation!.WithAnalyzers(analyzers);
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
         var orderedDiagnostics = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/CodeFixVerifier.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/CodeFixVerifier.cs
@@ -30,7 +30,7 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
         var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
 
         var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer());
-        var compilationWithAnalyzers = compilation!.WithAnalyzers(analyzers);
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
         var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
         var orderedDiagnostics = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
 
@@ -41,7 +41,7 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
 
         var actions = new List<CodeAction>();
         var codeFixProvider = new TCodeFix();
-        var context = new CodeFixContext(document, diagnostic!, (action, _) => actions.Add(action), CancellationToken.None);
+        var context = new CodeFixContext(document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
         await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 
         actions.ShouldNotBeEmpty();
@@ -50,11 +50,11 @@ public static class CodeFixVerifier<TAnalyzer, TCodeFix>
         var applyChanges = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
         applyChanges.ShouldNotBeNull();
 
-        var newSolution = applyChanges!.ChangedSolution;
+        var newSolution = applyChanges.ChangedSolution;
         var newDocument = newSolution.GetDocument(document.Id);
         newDocument.ShouldNotBeNull();
 
-        var newText = await newDocument!.GetTextAsync().ConfigureAwait(false);
+        var newText = await newDocument.GetTextAsync().ConfigureAwait(false);
         NormalizeWhitespace(newText.ToString()).ShouldEqual(NormalizeWhitespace(fixedSource));
     }
 

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -54,7 +54,7 @@ public static class TestProject
             MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location),
-            MetadataReference.CreateFromFile(systemRuntime!.Location),
+            MetadataReference.CreateFromFile(systemRuntime.Location),
             MetadataReference.CreateFromFile(typeof(Aggregates.AggregateRoot).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Cratis.Chronicle.Events.EventContext).Assembly.Location)
         ];

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsParameterEvaluator/when_evaluating/with_concept_member_access_on_closure.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsParameterEvaluator/when_evaluating/with_concept_member_access_on_closure.cs
@@ -27,5 +27,5 @@ public class with_concept_member_access_on_closure : Specification
     [Fact] void should_evaluate_to_constant() => _result.ShouldBeOfExactType<ConstantExpression>();
     [Fact] void should_keep_concept_type() => _result.Type.ShouldEqual(typeof(TestIdConcept));
     [Fact] void should_have_concept_value() => ((ConstantExpression)_result).Value.ShouldBeOfExactType<TestIdConcept>();
-    [Fact] void should_have_correct_underlying_value() => ((TestIdConcept)((ConstantExpression)_result).Value!).Value.ShouldEqual(_expectedId);
+    [Fact] void should_have_correct_underlying_value() => ((TestIdConcept)((ConstantExpression)_result).Value).Value.ShouldEqual(_expectedId);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsParameterEvaluator/when_evaluating/with_concept_member_access_on_constant.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsParameterEvaluator/when_evaluating/with_concept_member_access_on_constant.cs
@@ -27,5 +27,5 @@ public class with_concept_member_access_on_constant : Specification
     [Fact] void should_evaluate_to_constant() => _result.ShouldBeOfExactType<ConstantExpression>();
     [Fact] void should_keep_concept_type() => _result.Type.ShouldEqual(typeof(TestNameConcept));
     [Fact] void should_have_concept_value() => ((ConstantExpression)_result).Value.ShouldBeOfExactType<TestNameConcept>();
-    [Fact] void should_have_correct_underlying_value() => ((TestNameConcept)((ConstantExpression)_result).Value!).Value.ShouldEqual(_expectedName);
+    [Fact] void should_have_correct_underlying_value() => ((TestNameConcept)((ConstantExpression)_result).Value).Value.ShouldEqual(_expectedName);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_from_concept/with_string_concept.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_from_concept/with_string_concept.cs
@@ -13,7 +13,7 @@ public class with_string_concept : given.a_concept_as_value_converter
         _concept = new TestStringConcept("test value");
     }
 
-    void Because() => _result = (string)_stringConverter.ConvertToProvider(_concept)!;
+    void Because() => _result = (string)_stringConverter.ConvertToProvider(_concept);
 
     [Fact] void should_extract_the_underlying_string_value() => _result.ShouldEqual("test value");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_guid_value.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_guid_value.cs
@@ -13,7 +13,7 @@ public class with_guid_value : given.a_concept_as_value_converter
         _value = Guid.NewGuid();
     }
 
-    void Because() => _result = (TestGuidConcept)_guidConverter.ConvertFromProvider(_value)!;
+    void Because() => _result = (TestGuidConcept)_guidConverter.ConvertFromProvider(_value);
 
     [Fact] void should_create_concept_with_the_value() => _result.Value.ShouldEqual(_value);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_int_value.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_int_value.cs
@@ -13,7 +13,7 @@ public class with_int_value : given.a_concept_as_value_converter
         _value = 42;
     }
 
-    void Because() => _result = (TestIntConcept)_intConverter.ConvertFromProvider(_value)!;
+    void Because() => _result = (TestIntConcept)_intConverter.ConvertFromProvider(_value);
 
     [Fact] void should_create_concept_with_the_value() => _result.Value.ShouldEqual(42);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_string_value.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_ConceptAsValueConverter/when_converting_to_concept/with_string_value.cs
@@ -13,7 +13,7 @@ public class with_string_value : given.a_concept_as_value_converter
         _value = "test value";
     }
 
-    void Because() => _result = (TestStringConcept)_stringConverter.ConvertFromProvider(_value)!;
+    void Because() => _result = (TestStringConcept)_stringConverter.ConvertFromProvider(_value);
 
     [Fact] void should_create_concept_with_the_value() => _result.Value.ShouldEqual("test value");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_concept_as_keys/when_using_concept_as_key_with_lambda_syntax.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_concept_as_keys/when_using_concept_as_key_with_lambda_syntax.cs
@@ -13,9 +13,9 @@ public class when_using_concept_as_key_with_lambda_syntax : given.a_test_databas
 
     void Because()
     {
-        _entityType = _context.Model.FindEntityType(typeof(EntityWithConceptKey))!;
-        _idProperty = _entityType.FindProperty(nameof(EntityWithConceptKey.Id))!;
-        _key = _entityType.FindPrimaryKey()!;
+        _entityType = _context.Model.FindEntityType(typeof(EntityWithConceptKey));
+        _idProperty = _entityType.FindProperty(nameof(EntityWithConceptKey.Id));
+        _key = _entityType.FindPrimaryKey();
     }
 
     [Fact] void should_have_entity_type_configured() => _entityType.ShouldNotBeNull();

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_property_mapping_concepts.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_property_mapping_concepts.cs
@@ -35,8 +35,8 @@ public class when_property_mapping_concepts : given.a_test_database
     async Task Because() => _result = await _context.Products
         .FirstOrDefaultAsync(p => p.Id == new ProductId(_guidValue));
 
-    [Fact] void should_correctly_map_guid_concept_property() => _result!.Id.Value.ShouldEqual(_guidValue);
-    [Fact] void should_correctly_map_int_concept_property() => _result!.Code.Value.ShouldEqual(_codeValue);
-    [Fact] void should_correctly_map_string_concept_property() => _result!.Name.Value.ShouldEqual(_nameValue);
+    [Fact] void should_correctly_map_guid_concept_property() => _result.Id.Value.ShouldEqual(_guidValue);
+    [Fact] void should_correctly_map_int_concept_property() => _result.Code.Value.ShouldEqual(_codeValue);
+    [Fact] void should_correctly_map_string_concept_property() => _result.Name.Value.ShouldEqual(_nameValue);
     [Fact] void should_correctly_map_all_properties_together() => _result.ShouldNotBeNull();
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_guid_concept_id.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_guid_concept_id.cs
@@ -27,7 +27,7 @@ public class when_querying_by_guid_concept_id : given.a_test_database
         await _context.SaveChangesAsync();
     }
 
-    async Task Because() => _result = (await _context.Products.Where(p => p.Id == _productId).FirstOrDefaultAsync())!;
+    async Task Because() => _result = (await _context.Products.Where(p => p.Id == _productId).FirstOrDefaultAsync());
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
     [Fact] void should_have_correct_id() => _result.Id.Value.ShouldEqual(_primitiveId);

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_guid_concept_id.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_guid_concept_id.cs
@@ -27,7 +27,7 @@ public class when_querying_by_guid_concept_id : given.a_test_database
         await _context.SaveChangesAsync();
     }
 
-    async Task Because() => _result = (await _context.Products.Where(p => p.Id == _productId).FirstOrDefaultAsync());
+    async Task Because() => _result = await _context.Products.Where(p => p.Id == _productId).FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
     [Fact] void should_have_correct_id() => _result.Id.Value.ShouldEqual(_primitiveId);

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_int_concept_code.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_int_concept_code.cs
@@ -30,6 +30,6 @@ public class when_querying_by_int_concept_code : given.a_test_database
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(456);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Test Product");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(456);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Test Product");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_guid.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_guid.cs
@@ -30,6 +30,6 @@ public class when_querying_by_primitive_guid : given.a_test_database
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_id() => _result!.Id.Value.ShouldEqual(_guidValue);
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(100);
+    [Fact] void should_have_correct_id() => _result.Id.Value.ShouldEqual(_guidValue);
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(100);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_int.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_int.cs
@@ -30,6 +30,6 @@ public class when_querying_by_primitive_int : given.a_test_database
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(222);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Int Test");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(222);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Int Test");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_string.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_primitive_string.cs
@@ -30,6 +30,6 @@ public class when_querying_by_primitive_string : given.a_test_database
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(333);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("String Test Product");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(333);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("String Test Product");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_string_concept_name.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_by_string_concept_name.cs
@@ -30,6 +30,6 @@ public class when_querying_by_string_concept_name : given.a_test_database
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(789);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Unique Product Name");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(789);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Unique Product Name");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_auto_conversion_and_multiple_concept_conditions.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_auto_conversion_and_multiple_concept_conditions.cs
@@ -27,7 +27,7 @@ public class when_querying_with_auto_conversion_and_multiple_concept_conditions 
     void Because() => _result = _context.ResponsePhases.SingleOrDefault(rp => rp.Id == _missionId && rp.ResourceId == _resourceId);
 
     [Fact] void should_find_the_response_phase() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_mission_id() => _result!.Id.Value.ShouldEqual(_missionId.Value);
-    [Fact] void should_have_correct_resource_id() => _result!.ResourceId.Value.ShouldEqual(_resourceId.Value);
-    [Fact] void should_have_correct_name() => _result!.Name.ShouldEqual("Test Phase");
+    [Fact] void should_have_correct_mission_id() => _result.Id.Value.ShouldEqual(_missionId.Value);
+    [Fact] void should_have_correct_resource_id() => _result.ResourceId.Value.ShouldEqual(_resourceId.Value);
+    [Fact] void should_have_correct_name() => _result.Name.ShouldEqual("Test Phase");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_explicit_concept_cast_in_filter.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_explicit_concept_cast_in_filter.cs
@@ -38,5 +38,5 @@ public class when_querying_with_explicit_concept_cast_in_filter : given.a_respon
 #pragma warning restore IDE0004 // Remove Unnecessary Cast
 
     [Fact] void should_find_the_response_phase() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_mission_id() => _result!.Id.Value.ShouldEqual(_missionId.Value);
+    [Fact] void should_have_correct_mission_id() => _result.Id.Value.ShouldEqual(_missionId.Value);
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_mixed_concept_and_primitive_conditions.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_mixed_concept_and_primitive_conditions.cs
@@ -32,6 +32,6 @@ public class when_querying_with_mixed_concept_and_primitive_conditions : given.a
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(555);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Mixed Condition Test");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(555);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Mixed Condition Test");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_multiple_concept_conditions.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_multiple_concept_conditions.cs
@@ -32,6 +32,6 @@ public class when_querying_with_multiple_concept_conditions : given.a_test_datab
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(999);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Multi Condition Test");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(999);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Multi Condition Test");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_reverse_primitive_comparison.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_reverse_primitive_comparison.cs
@@ -30,6 +30,6 @@ public class when_querying_with_reverse_primitive_comparison : given.a_test_data
         .FirstOrDefaultAsync();
 
     [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
-    [Fact] void should_have_correct_code() => _result!.Code.Value.ShouldEqual(777);
-    [Fact] void should_have_correct_name() => _result!.Name.Value.ShouldEqual("Reverse Comparison Test");
+    [Fact] void should_have_correct_code() => _result.Code.Value.ShouldEqual(777);
+    [Fact] void should_have_correct_name() => _result.Name.Value.ShouldEqual("Reverse Comparison Test");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_postgre_sql_database.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_postgre_sql_database.cs
@@ -24,8 +24,8 @@ public class with_postgre_sql_database : given.a_json_conversion_context
     {
         var entityTypeBuilder = _modelBuilder.Entity<EntityWithJsonProperties>();
         entityTypeBuilder.ApplyJsonConversion(DatabaseType.PostgreSql);
-        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name))!;
-        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address))!;
+        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name));
+        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address));
     }
 
     [Fact] void should_set_name_column_type_to_jsonb() => _nameProperty.GetColumnType().ShouldEqual("jsonb");

--- a/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_sql_server_database.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_sql_server_database.cs
@@ -24,8 +24,8 @@ public class with_sql_server_database : given.a_json_conversion_context
     {
         var entityTypeBuilder = _modelBuilder.Entity<EntityWithJsonProperties>();
         entityTypeBuilder.ApplyJsonConversion(DatabaseType.SqlServer);
-        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name))!;
-        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address))!;
+        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name));
+        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address));
     }
 
     [Fact] void should_set_name_column_type_to_nvarchar_max() => _nameProperty.GetColumnType().ShouldEqual("nvarchar(max)");

--- a/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_sqlite_database.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Json/for_JsonConversion/when_applying_json_conversion_to_entity/with_sqlite_database.cs
@@ -24,8 +24,8 @@ public class with_sqlite_database : given.a_json_conversion_context
     {
         var entityTypeBuilder = _modelBuilder.Entity<EntityWithJsonProperties>();
         entityTypeBuilder.ApplyJsonConversion(DatabaseType.Sqlite);
-        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name))!;
-        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address))!;
+        _nameProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Name));
+        _addressProperty = entityTypeBuilder.Metadata.FindProperty(nameof(EntityWithJsonProperties.Address));
     }
 
     [Fact] void should_set_name_column_type_to_text() => _nameProperty.GetColumnType().ShouldEqual("TEXT");

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_entities_having_concepts_and_guids.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_entities_having_concepts_and_guids.cs
@@ -20,13 +20,13 @@ public class with_entities_having_concepts_and_guids : given.a_base_db_context
     void Because()
     {
         _model = GetModel(_dbContext);
-        _personEntityType = _model.FindEntityType(typeof(Person))!;
-        _companyEntityType = _model.FindEntityType(typeof(Company))!;
+        _personEntityType = _model.FindEntityType(typeof(Person));
+        _companyEntityType = _model.FindEntityType(typeof(Company));
     }
 
-    [Fact] void should_apply_conversion_to_person_id_concept() => _personEntityType.FindProperty(nameof(Person.Id))!.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_apply_conversion_to_person_name_concept() => _personEntityType.FindProperty(nameof(Person.Name))!.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_apply_conversion_to_age_concept() => _personEntityType.FindProperty(nameof(Person.Age))!.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_apply_conversion_to_person_external_id_guid() => _personEntityType.FindProperty(nameof(Person.ExternalId))!.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_apply_conversion_to_company_id_guid() => _companyEntityType.FindProperty(nameof(Company.Id))!.GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_person_id_concept() => _personEntityType.FindProperty(nameof(Person.Id)).GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_person_name_concept() => _personEntityType.FindProperty(nameof(Person.Name)).GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_age_concept() => _personEntityType.FindProperty(nameof(Person.Age)).GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_person_external_id_guid() => _personEntityType.FindProperty(nameof(Person.ExternalId)).GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_company_id_guid() => _companyEntityType.FindProperty(nameof(Company.Id)).GetValueConverter().ShouldNotBeNull();
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_json_properties.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_json_properties.cs
@@ -20,11 +20,11 @@ public class with_json_properties : given.a_base_db_context
     void Because()
     {
         _model = GetModel(_dbContext);
-        _companyEntityType = _model.FindEntityType(typeof(Company))!;
-        _metadataProperty = _companyEntityType.FindProperty(nameof(Company.Metadata))!;
+        _companyEntityType = _model.FindEntityType(typeof(Company));
+        _metadataProperty = _companyEntityType.FindProperty(nameof(Company.Metadata));
     }
 
-    [Fact] void should_apply_conversion_to_company_id_guid() => _companyEntityType.FindProperty(nameof(Company.Id))!.GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_apply_conversion_to_company_id_guid() => _companyEntityType.FindProperty(nameof(Company.Id)).GetValueConverter().ShouldNotBeNull();
     [Fact] void should_apply_json_conversion_to_metadata_property() => _metadataProperty.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_serialize_metadata_as_json() => _metadataProperty.GetValueConverter()!.ProviderClrType.ShouldEqual(typeof(string));
+    [Fact] void should_serialize_metadata_as_json() => _metadataProperty.GetValueConverter().ProviderClrType.ShouldEqual(typeof(string));
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_property_types_only_on_json_entities.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_property_types_only_on_json_entities.cs
@@ -20,8 +20,8 @@ public class with_property_types_only_on_json_entities : given.a_base_db_context
     void Because()
     {
         _model = GetModel(_dbContext);
-        _storeEntityType = _model.FindEntityType(typeof(Store))!;
-        _configurationProperty = _storeEntityType.FindProperty(nameof(Store.Configuration))!;
+        _storeEntityType = _model.FindEntityType(typeof(Store));
+        _configurationProperty = _storeEntityType.FindProperty(nameof(Store.Configuration));
     }
 
     [Fact]
@@ -48,6 +48,6 @@ public class with_property_types_only_on_json_entities : given.a_base_db_context
     }
 
     [Fact] void should_apply_json_conversion_to_configuration_property() => _configurationProperty.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_serialize_configuration_as_json() => _configurationProperty.GetValueConverter()!.ProviderClrType.ShouldEqual(typeof(string));
-    [Fact] void should_apply_conversion_to_store_id_guid() => _storeEntityType.FindProperty(nameof(Store.Id))!.GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_serialize_configuration_as_json() => _configurationProperty.GetValueConverter().ProviderClrType.ShouldEqual(typeof(string));
+    [Fact] void should_apply_conversion_to_store_id_guid() => _storeEntityType.FindProperty(nameof(Store.Id)).GetValueConverter().ShouldNotBeNull();
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_types_in_both_json_and_regular_properties.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_types_in_both_json_and_regular_properties.cs
@@ -22,15 +22,15 @@ public class with_types_in_both_json_and_regular_properties : given.a_base_db_co
     void Because()
     {
         _model = GetModel(_dbContext);
-        _organizationEntityType = _model.FindEntityType(typeof(Organization))!;
-        _locationIdProperty = _organizationEntityType.FindProperty(nameof(Organization.LocationId))!;
-        _referenceIdProperty = _organizationEntityType.FindProperty(nameof(Organization.ReferenceId))!;
-        _metadataProperty = _organizationEntityType.FindProperty(nameof(Organization.Metadata))!;
+        _organizationEntityType = _model.FindEntityType(typeof(Organization));
+        _locationIdProperty = _organizationEntityType.FindProperty(nameof(Organization.LocationId));
+        _referenceIdProperty = _organizationEntityType.FindProperty(nameof(Organization.ReferenceId));
+        _metadataProperty = _organizationEntityType.FindProperty(nameof(Organization.Metadata));
     }
 
     [Fact] void should_apply_concept_conversion_to_location_id() => _locationIdProperty.GetValueConverter().ShouldNotBeNull();
     [Fact] void should_apply_guid_conversion_to_reference_id() => _referenceIdProperty.GetValueConverter().ShouldNotBeNull();
     [Fact] void should_apply_json_conversion_to_metadata() => _metadataProperty.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_serialize_metadata_as_json() => _metadataProperty.GetValueConverter()!.ProviderClrType.ShouldEqual(typeof(string));
-    [Fact] void should_apply_conversion_to_organization_id_guid() => _organizationEntityType.FindProperty(nameof(Organization.Id))!.GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_serialize_metadata_as_json() => _metadataProperty.GetValueConverter().ProviderClrType.ShouldEqual(typeof(string));
+    [Fact] void should_apply_conversion_to_organization_id_guid() => _organizationEntityType.FindProperty(nameof(Organization.Id)).GetValueConverter().ShouldNotBeNull();
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_types_only_in_json_properties.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/when_creating_model/with_types_only_in_json_properties.cs
@@ -20,8 +20,8 @@ public class with_types_only_in_json_properties : given.a_base_db_context
     void Because()
     {
         _model = GetModel(_dbContext);
-        _departmentEntityType = _model.FindEntityType(typeof(Department))!;
-        _settingsProperty = _departmentEntityType.FindProperty(nameof(Department.Settings))!;
+        _departmentEntityType = _model.FindEntityType(typeof(Department));
+        _settingsProperty = _departmentEntityType.FindProperty(nameof(Department.Settings));
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class with_types_only_in_json_properties : given.a_base_db_context
     }
 
     [Fact] void should_apply_json_conversion_to_settings_property() => _settingsProperty.GetValueConverter().ShouldNotBeNull();
-    [Fact] void should_serialize_settings_as_json() => _settingsProperty.GetValueConverter()!.ProviderClrType.ShouldEqual(typeof(string));
-    [Fact] void should_apply_conversion_to_department_id_guid() => _departmentEntityType.FindProperty(nameof(Department.Id))!.GetValueConverter().ShouldNotBeNull();
+    [Fact] void should_serialize_settings_as_json() => _settingsProperty.GetValueConverter().ProviderClrType.ShouldEqual(typeof(string));
+    [Fact] void should_apply_conversion_to_department_id_guid() => _departmentEntityType.FindProperty(nameof(Department.Id)).GetValueConverter().ShouldNotBeNull();
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
@@ -32,7 +32,7 @@
             <SkipFileIndexTracking Condition=" '$(CratisProxiesSkipFileIndexTracking)' == 'true' ">--skip-file-index-tracking</SkipFileIndexTracking>
             <SkipIndexGeneration Condition=" '$(CratisProxiesSkipIndexGeneration)' == 'true' ">--skip-index-generation</SkipIndexGeneration>
             <UseSourceFileAsOutputFile Condition=" '$(CratisProxiesUseSourceFileAsOutputFile)' == 'true' ">--use-source-file-as-output-file</UseSourceFileAsOutputFile>
-            <AssemblyPackageMappings>@(AssemblyToPageMapping -> '--assembly-to-package=%(Assembly)=%(Package)', ' ')</AssemblyPackageMappings>
+            <AssemblyPackageMappings>@(AssemblyToPackageMapping -> '--assembly-to-package=%(Assembly)=%(Package)', ' ')</AssemblyPackageMappings>
         </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true" 

--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
@@ -32,10 +32,11 @@
             <SkipFileIndexTracking Condition=" '$(CratisProxiesSkipFileIndexTracking)' == 'true' ">--skip-file-index-tracking</SkipFileIndexTracking>
             <SkipIndexGeneration Condition=" '$(CratisProxiesSkipIndexGeneration)' == 'true' ">--skip-index-generation</SkipIndexGeneration>
             <UseSourceFileAsOutputFile Condition=" '$(CratisProxiesUseSourceFileAsOutputFile)' == 'true' ">--use-source-file-as-output-file</UseSourceFileAsOutputFile>
+            <AssemblyPackageMappings>@(AssemblyToPageMapping -> '--assembly-to-package=%(Assembly)=%(Package)', ' ')</AssemblyPackageMappings>
         </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true" 
-            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile)"
+            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(AssemblyPackageMappings)"
             WorkingDirectory="$(CratisProxyGeneratorAssemblyDirectory)" />
     </Target>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/InMemoryProxyGenerator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/InMemoryProxyGenerator.cs
@@ -51,4 +51,14 @@ public static class InMemoryProxyGenerator
     {
         return TemplateTypes.Enum(descriptor);
     }
+
+    /// <summary>
+    /// Generates a TypeScript flags enum from a descriptor, including an <c>allXxx</c> constant.
+    /// </summary>
+    /// <param name="descriptor">The flags enum descriptor.</param>
+    /// <returns>The generated TypeScript code.</returns>
+    public static string GenerateFlagsEnum(EnumDescriptor descriptor)
+    {
+        return TemplateTypes.FlagsEnum(descriptor);
+    }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
@@ -19,7 +19,7 @@ public sealed class JavaScriptRuntime : IDisposable
     /// </summary>
     public JavaScriptRuntime()
     {
-        var assemblyDir = Path.GetDirectoryName(typeof(JavaScriptRuntime).Assembly.Location)!;
+        var assemblyDir = Path.GetDirectoryName(typeof(JavaScriptRuntime).Assembly.Location);
 
         // Find workspace root by looking for directory containing node_modules
         _workspaceRoot = FindDirectoryInHierarchy(assemblyDir, "node_modules")

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/Scripts.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/Scripts.cs
@@ -17,7 +17,7 @@ public static class Scripts
     static Scripts()
     {
         // Get the directory containing the compiled assembly
-        var assemblyDir = Path.GetDirectoryName(typeof(Scripts).Assembly.Location)!;
+        var assemblyDir = Path.GetDirectoryName(typeof(Scripts).Assembly.Location);
 
         // Try to find the Scripts directory relative to the assembly location
         // In debug builds: bin/Debug/net10.0 -> go up 3 levels, then to Scenarios/Infrastructure/Scripts

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/Scripts/deserialize-query-result.js
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/Scripts/deserialize-query-result.js
@@ -1,48 +1,78 @@
-// Deserialize query result data using type fields
+// Deserialize query result data using field metadata, with derived type support.
+// This approach keeps raw primitive/special-type values (TimeSpan, Guid, etc.) so that
+// JSON.stringify produces JSON that System.Text.Json can re-deserialize correctly on the C# side.
+// For properties with derivatives (e.g. IShape → CircleShape/RectangleShape), the correct
+// derived class is instantiated so that constructor.name reflects the real type.
 try {
     var response = JSON.parse('{{ESCAPED_JSON}}');
-    
+
     if (response.data && __query.modelType && globalThis.Fields) {
-        // Helper function to deserialize an object using its type's fields
+
+        function getDerivedTypeId(cls) {
+            try {
+                return Reflect && Reflect.getOwnMetadata ? Reflect.getOwnMetadata('derivedType', cls) : undefined;
+            } catch(e) { return undefined; }
+        }
+
+        function resolveType(field, value) {
+            if (field.derivatives && field.derivatives.length > 0 && value._derivedTypeId) {
+                var id = value._derivedTypeId;
+                for (var i = 0; i < field.derivatives.length; i++) {
+                    var d = field.derivatives[i];
+                    if (d && getDerivedTypeId(d) === id) {
+                        return d;
+                    }
+                }
+            }
+            return null;
+        }
+
         function deserializeObject(data, type) {
             if (!data || !type || !globalThis.Fields) return data;
-            
+
             var fields = globalThis.Fields.getFieldsForType(type);
             if (!fields || fields.length === 0) {
+                // Type has no @field decorators (e.g. TimeSpan, Guid) — keep raw value
                 return data;
             }
-            
-            var deserialized = {};
+
+            var deserialized;
+            try { deserialized = new type(); } catch(e) { deserialized = {}; }
+
             for (var i = 0; i < fields.length; i++) {
                 var field = fields[i];
-                if (data.hasOwnProperty(field.name)) {
-                    var value = data[field.name];
-                    
-                    // Handle null/undefined
-                    if (value === null || value === undefined) {
+                if (!data.hasOwnProperty(field.name)) continue;
+                var value = data[field.name];
+
+                if (value === null || value === undefined) {
+                    deserialized[field.name] = value;
+                } else if (Array.isArray(value) && field.enumerable) {
+                    deserialized[field.name] = value.map(function(item) {
+                        if (typeof item !== 'object' || item === null) return item;
+                        var itemType = resolveType(field, item) || field.type;
+                        return itemType ? deserializeObject(item, itemType) : item;
+                    });
+                } else if (typeof value === 'object' && !Array.isArray(value)) {
+                    var resolvedType = resolveType(field, value);
+                    if (resolvedType) {
+                        deserialized[field.name] = deserializeObject(value, resolvedType);
+                    } else if (field.type) {
+                        var nestedFields = globalThis.Fields.getFieldsForType(field.type);
+                        if (nestedFields && nestedFields.length > 0) {
+                            deserialized[field.name] = deserializeObject(value, field.type);
+                        } else {
+                            deserialized[field.name] = value;
+                        }
+                    } else {
                         deserialized[field.name] = value;
                     }
-                    // Handle arrays
-                    else if (Array.isArray(value) && field.type && globalThis[field.type.name]) {
-                        deserialized[field.name] = value.map(item => 
-                            typeof item === 'object' && item !== null 
-                                ? deserializeObject(item, field.type) 
-                                : item
-                        );
-                    }
-                    // Handle nested objects
-                    else if (typeof value === 'object' && !Array.isArray(value) && field.type && globalThis[field.type.name]) {
-                        deserialized[field.name] = deserializeObject(value, field.type);
-                    }
-                    // Handle primitives
-                    else {
-                        deserialized[field.name] = value;
-                    }
+                } else {
+                    deserialized[field.name] = value;
                 }
             }
             return deserialized;
         }
-        
+
         __queryResult.data = deserializeObject(response.data, __query.modelType);
     }
 } catch(e) {

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/DerivedTypeCommands.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/DerivedTypeCommands.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Commands.ModelBound;
+
+/// <summary>
+/// A command with two properties using the same interface, each intended to receive a different derived type.
+/// </summary>
+[Command]
+public class DerivedTypeCommand
+{
+    /// <summary>
+    /// Gets or sets the first shape.
+    /// </summary>
+    public IShape? Shape1 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the second shape.
+    /// </summary>
+    public IShape? Shape2 { get; set; }
+
+    /// <summary>
+    /// Handles the command and captures the concrete types and property values that were received.
+    /// </summary>
+    /// <returns>A <see cref="DerivedTypeCommandResult"/> with the resolved type names and shape values.</returns>
+    public DerivedTypeCommandResult Handle()
+    {
+        var circle = Shape1 as CircleShape;
+        var rect = Shape2 as RectangleShape;
+        return new()
+        {
+            Shape1TypeName = Shape1?.GetType().Name ?? "null",
+            Shape2TypeName = Shape2?.GetType().Name ?? "null",
+            Shape1Radius = circle?.Radius ?? 0,
+            Shape2Width = rect?.Width ?? 0,
+            Shape2Height = rect?.Height ?? 0
+        };
+    }
+}
+
+/// <summary>
+/// Result for <see cref="DerivedTypeCommand"/> capturing the concrete type names and property values of both shapes.
+/// </summary>
+public class DerivedTypeCommandResult
+{
+    /// <summary>
+    /// Gets or sets the runtime type name of the first shape.
+    /// </summary>
+    public string Shape1TypeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the runtime type name of the second shape.
+    /// </summary>
+    public string Shape2TypeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the radius of the first shape (populated only when it is a <see cref="CircleShape"/>).
+    /// </summary>
+    public double Shape1Radius { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the second shape (populated only when it is a <see cref="RectangleShape"/>).
+    /// </summary>
+    public double Shape2Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the second shape (populated only when it is a <see cref="RectangleShape"/>).
+    /// </summary>
+    public double Shape2Height { get; set; }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_executing/with_derived_type_properties.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_executing/with_derived_type_properties.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Commands.ModelBound.when_executing;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+public class with_derived_type_properties : given.a_scenario_web_application
+{
+    CommandResult<DerivedTypeCommandResult>? _result;
+
+    void Establish() => LoadCommandProxy<DerivedTypeCommand>();
+
+    async Task Because()
+    {
+        var executionResult = await Bridge!.ExecuteCommandViaProxyAsync<DerivedTypeCommandResult>(new DerivedTypeCommand
+        {
+            Shape1 = new CircleShape { Label = "Circle", Radius = 5.0 },
+            Shape2 = new RectangleShape { Label = "Rectangle", Width = 10.0, Height = 20.0 }
+        });
+
+        _result = executionResult.Result;
+    }
+
+    [Fact] void should_return_successful_result() => _result!.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_response() => _result!.Response.ShouldNotBeNull();
+    [Fact] void should_deserialize_shape1_as_circle_shape() => _result!.Response!.Shape1TypeName.ShouldEqual("CircleShape");
+    [Fact] void should_deserialize_shape2_as_rectangle_shape() => _result!.Response!.Shape2TypeName.ShouldEqual("RectangleShape");
+    [Fact] void should_have_correct_circle_radius() => _result!.Response!.Shape1Radius.ShouldEqual(5.0);
+    [Fact] void should_have_correct_rectangle_width() => _result!.Response!.Shape2Width.ShouldEqual(10.0);
+    [Fact] void should_have_correct_rectangle_height() => _result!.Response!.Shape2Height.ShouldEqual(20.0);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_executing/with_guid_response_javascript_deserialization.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_executing/with_guid_response_javascript_deserialization.cs
@@ -24,7 +24,7 @@ public class with_guid_response_javascript_deserialization : given.a_scenario_we
     {
         // Create a raw object with Guid strings (simulating server response)
         // and deserialize it using JsonSerializer.deserializeFromInstance
-        Runtime!.Execute(
+        Runtime.Execute(
             "var __rawData = { userId: '12345678-1234-1234-1234-123456789abc', name: 'TestUser', sessionId: '87654321-4321-4321-4321-cba987654321' };" +
             "var __deserialized = globalThis.JsonSerializer.deserializeFromInstance(globalThis.GuidResponseData, __rawData);" +
             "var __fieldsForType = globalThis.Fields.getFieldsForType(globalThis.GuidResponseData);");

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_generating_proxy_for_command_with_validator_having_constructor_dependencies.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_generating_proxy_for_command_with_validator_having_constructor_dependencies.cs
@@ -26,7 +26,7 @@ public class when_generating_proxy_for_command_with_validator_having_constructor
     }
 
     [Fact] void should_generate_code() => _generatedCode.ShouldNotBeNull();
-    [Fact] void should_have_validation_rules() => _descriptor!.ValidationRules.ShouldNotBeEmpty();
+    [Fact] void should_have_validation_rules() => _descriptor.ValidationRules.ShouldNotBeEmpty();
     [Fact] void should_contain_validator_class() => _generatedCode.ShouldContain("class CommandWithValidatorDependenciesValidator");
     [Fact] void should_contain_name_validation_rule() => _generatedCode.ShouldContain("ruleFor(c => c.name)");
     [Fact] void should_contain_age_validation_rule() => _generatedCode.ShouldContain("ruleFor(c => c.age)");

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_generating_proxy_for_fluent_validated_command.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Commands/ModelBound/when_generating_proxy_for_fluent_validated_command.cs
@@ -26,7 +26,7 @@ public class when_generating_proxy_for_fluent_validated_command : Specification
     }
 
     [Fact] void should_generate_code() => _generatedCode.ShouldNotBeNull();
-    [Fact] void should_have_validation_rules() => _descriptor!.ValidationRules.ShouldNotBeEmpty();
+    [Fact] void should_have_validation_rules() => _descriptor.ValidationRules.ShouldNotBeEmpty();
     [Fact] void should_contain_validator_class() => _generatedCode.ShouldContain("class FluentValidatedCommandValidator");
     [Fact] void should_contain_name_validation_rule() => _generatedCode.ShouldContain("ruleFor(c => c.name)");
     [Fact] void should_contain_age_validation_rule() => _generatedCode.ShouldContain("ruleFor(c => c.age)");

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Identity/when_getting_identity_with_nested_complex_types.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Identity/when_getting_identity_with_nested_complex_types.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.ProxyGenerator.for_TypeExtensions;
 using Cratis.Arc.ProxyGenerator.Templates;
 
 namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Identity;
@@ -9,6 +10,7 @@ namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Identity;
 /// Specification for verifying that identity details types with nested complex types
 /// generate correct TypeScript code with proper imports and field decorators.
 /// </summary>
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
 public class when_generating_types_for_identity_details_with_nested_complex_types : Specification
 {
     string _addressTypeScript;

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/AssemblyToPackageMapping/when_generating_command_with_type_from_mapped_assembly.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/AssemblyToPackageMapping/when_generating_command_with_type_from_mapped_assembly.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.ProxyGenerator.ModelBound;
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration.AssemblyToPackageMapping;
+
+/// <summary>
+/// An external type that is treated as coming from a mapped assembly.
+/// </summary>
+public class ExternalElement
+{
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A command that uses a type from a mapped assembly.
+/// </summary>
+[Command]
+public class UpdateExternalElements
+{
+    /// <summary>
+    /// Gets or sets the elements from an external package.
+    /// </summary>
+    public IEnumerable<ExternalElement> Elements { get; set; } = [];
+
+    /// <summary>
+    /// Handles the command.
+    /// </summary>
+    public void Handle() { }
+}
+
+[Collection(Cratis.Arc.ProxyGenerator.for_TypeExtensions.AssemblyPackageMappingCollectionDefinition.Name)]
+public class when_generating_command_with_type_from_mapped_assembly : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    CommandDescriptor _descriptor = null!;
+    bool _typeScriptIsValid;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var externalAssemblyName = typeof(ExternalElement).Assembly.GetName().Name!;
+        TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>
+        {
+            [externalAssemblyName] = "@test/external"
+        });
+
+        var commandType = typeof(UpdateExternalElements).GetTypeInfo();
+        _descriptor = commandType.ToCommandDescriptor(
+            targetPath: string.Empty,
+            segmentsToSkip: 0,
+            skipCommandNameInRoute: false,
+            apiPrefix: "api",
+            [commandType]);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateCommand(_descriptor);
+
+        try
+        {
+            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
+            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
+        }
+        catch
+        {
+            _typeScriptIsValid = false;
+        }
+    }
+
+    void Destroy() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
+    [Fact] void should_import_external_element_from_mapped_package() => _generatedCode.ShouldContain("@test/external");
+    [Fact] void should_not_generate_relative_import_for_external_element() => _generatedCode.ShouldNotContain("./ExternalElement");
+    [Fact] void should_contain_elements_property() => _generatedCode.ShouldContain("elements");
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/FlagsEnums.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/FlagsEnums.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+/// <summary>
+/// Represents the edges of a UI element to which it is anchored.
+/// Multiple edges can be combined using bitwise operations.
+/// </summary>
+[Flags]
+public enum AnchorEdges
+{
+    /// <summary>
+    /// No anchoring is set.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Anchor to the top edge.
+    /// </summary>
+    Top = 1 << 0,
+
+    /// <summary>
+    /// Anchor to the right edge.
+    /// </summary>
+    Right = 1 << 1,
+
+    /// <summary>
+    /// Anchor to the bottom edge.
+    /// </summary>
+    Bottom = 1 << 2,
+
+    /// <summary>
+    /// Anchor to the left edge.
+    /// </summary>
+    Left = 1 << 3,
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
@@ -18,7 +18,7 @@ public class when_generating_command_with_validation : Specification, IDisposabl
         _runtime = new JavaScriptRuntime();
 
         var commandType = typeof(CommandWithValidation);
-        var method = commandType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode")!;
+        var method = commandType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode");
         var properties = commandType.GetProperties()
             .Select(p => p.ToPropertyDescriptor())
             .ToList();

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_flags_enum_type.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_flags_enum_type.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+public class when_generating_flags_enum_type : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    EnumDescriptor _descriptor = null!;
+    bool _typeScriptIsValid;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var enumType = typeof(AnchorEdges);
+        var members = Enum.GetValues(enumType)
+            .Cast<AnchorEdges>()
+            .Select(v => new EnumMemberDescriptor(v.ToString(), (int)v))
+            .ToList();
+
+        _descriptor = new EnumDescriptor(
+            enumType,
+            nameof(AnchorEdges),
+            members,
+            [],
+            IsFlags: true);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateFlagsEnum(_descriptor);
+
+        try
+        {
+            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
+            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
+        }
+        catch
+        {
+            _typeScriptIsValid = false;
+        }
+    }
+
+    [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
+    [Fact] void should_contain_enum_name() => _generatedCode.ShouldContain("AnchorEdges");
+    [Fact] void should_contain_none_member() => _generatedCode.ShouldContain("none");
+    [Fact] void should_contain_top_member() => _generatedCode.ShouldContain("top");
+    [Fact] void should_contain_right_member() => _generatedCode.ShouldContain("right");
+    [Fact] void should_contain_bottom_member() => _generatedCode.ShouldContain("bottom");
+    [Fact] void should_contain_left_member() => _generatedCode.ShouldContain("left");
+    [Fact] void should_contain_all_constant() => _generatedCode.ShouldContain("allAnchorEdges");
+    [Fact] void should_combine_top_in_all_constant() => _generatedCode.ShouldContain("AnchorEdges.top");
+    [Fact] void should_combine_right_in_all_constant() => _generatedCode.ShouldContain("AnchorEdges.right");
+    [Fact] void should_combine_bottom_in_all_constant() => _generatedCode.ShouldContain("AnchorEdges.bottom");
+    [Fact] void should_combine_left_in_all_constant() => _generatedCode.ShouldContain("AnchorEdges.left");
+    [Fact] void should_not_include_none_in_all_constant() => _generatedCode.ShouldNotContain("AnchorEdges.none");
+    [Fact] void should_use_bitwise_or_operator() => _generatedCode.ShouldContain("|");
+    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+
+    public void Dispose()
+    {
+        _runtime?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_query_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_query_with_validation.cs
@@ -18,7 +18,7 @@ public class when_generating_query_with_validation : Specification, IDisposable
         _runtime = new JavaScriptRuntime();
 
         var queryType = typeof(QueryWithValidation);
-        var method = queryType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode")!;
+        var method = queryType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode");
         var properties = queryType.GetProperties()
             .Select(p => p.ToPropertyDescriptor())
             .ToList();

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ControllerBased/when_performing_controller_query_for_complex_data.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ControllerBased/when_performing_controller_query_for_complex_data.cs
@@ -23,14 +23,14 @@ public class when_performing_controller_query_for_complex_data : given.a_scenari
     [Fact]
     void should_deserialize_nested_data()
     {
-        var complexItem = System.Text.Json.JsonSerializer.Deserialize<ControllerComplexItem>(_result.Data!.ToString()!, Json.Globals.JsonSerializerOptions);
+        var complexItem = System.Text.Json.JsonSerializer.Deserialize<ControllerComplexItem>(_result.Data.ToString(), Json.Globals.JsonSerializerOptions);
         complexItem.ShouldNotBeNull();
         complexItem.Nested.ShouldNotBeNull();
     }
     [Fact]
     void should_have_correct_processing_duration()
     {
-        var complexItem = System.Text.Json.JsonSerializer.Deserialize<ControllerComplexItem>(_result.Data!.ToString()!, Json.Globals.JsonSerializerOptions);
-        complexItem!.Nested!.ProcessingDuration.ShouldEqual(TimeSpan.FromSeconds(45));
+        var complexItem = System.Text.Json.JsonSerializer.Deserialize<ControllerComplexItem>(_result.Data.ToString(), Json.Globals.JsonSerializerOptions);
+        complexItem.Nested.ProcessingDuration.ShouldEqual(TimeSpan.FromSeconds(45));
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/DerivedTypeReadModels.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/DerivedTypeReadModels.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries.ModelBound;
+using Cratis.Serialization;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound;
+
+/// <summary>
+/// Interface for shapes used in derived type testing.
+/// </summary>
+public interface IShape
+{
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
+    string Label { get; set; }
+}
+
+/// <summary>
+/// A circle shape — carries a derived type identifier so the proxy generator emits <c>@derivedType</c>.
+/// </summary>
+[DerivedType("4a5b6c7d-0000-0000-0000-000000000001")]
+public class CircleShape : IShape
+{
+    /// <inheritdoc/>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the radius.
+    /// </summary>
+    public double Radius { get; set; }
+}
+
+/// <summary>
+/// A rectangle shape — carries a derived type identifier so the proxy generator emits <c>@derivedType</c>.
+/// </summary>
+[DerivedType("4a5b6c7d-0000-0000-0000-000000000002")]
+public class RectangleShape : IShape
+{
+    /// <inheritdoc/>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the width.
+    /// </summary>
+    public double Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height.
+    /// </summary>
+    public double Height { get; set; }
+}
+
+/// <summary>
+/// A read model whose <see cref="Shape"/> property uses an interface that has concrete derived types.
+/// </summary>
+[ReadModel]
+public class DerivedTypeReadModel
+{
+    /// <summary>
+    /// Gets or sets the shape.
+    /// </summary>
+    public IShape? Shape { get; set; }
+
+    /// <summary>
+    /// Gets a read model containing a circle shape.
+    /// </summary>
+    /// <returns>A <see cref="DerivedTypeReadModel"/> with a circle shape.</returns>
+    public static DerivedTypeReadModel GetWithCircleShape() => new()
+    {
+        Shape = new CircleShape { Label = "Circle", Radius = 5.0 }
+    };
+
+    /// <summary>
+    /// Gets a read model containing a rectangle shape.
+    /// </summary>
+    /// <returns>A <see cref="DerivedTypeReadModel"/> with a rectangle shape.</returns>
+    public static DerivedTypeReadModel GetWithRectangleShape() => new()
+    {
+        Shape = new RectangleShape { Label = "Rectangle", Width = 10.0, Height = 20.0 }
+    };
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_circle_shape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_circle_shape.cs
@@ -16,12 +16,12 @@ public class and_concrete_type_is_circle_shape : given.a_scenario_web_applicatio
 
     async Task Because()
     {
-        _executionResult = await Bridge!.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithCircleShape");
-        _shapeConstructorName = Runtime!.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
-        _radius = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.radius ?? 0"));
+        _executionResult = await Bridge.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithCircleShape");
+        _shapeConstructorName = Runtime.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
+        _radius = Convert.ToDouble(Runtime.Evaluate<object>("__queryResult?.data?.shape?.radius ?? 0"));
     }
 
-    [Fact] void should_return_successful_result() => _executionResult!.Result!.IsSuccess.ShouldBeTrue();
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
     [Fact] void should_deserialize_shape_as_circle_shape() => _shapeConstructorName.ShouldEqual("CircleShape");
     [Fact] void should_have_correct_radius() => _radius.ShouldEqual(5.0);
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_circle_shape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_circle_shape.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound.when_performing_query_for_read_model_with_derived_type_property;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+public class and_concrete_type_is_circle_shape : given.a_scenario_web_application
+{
+    QueryExecutionResult<DerivedTypeReadModel>? _executionResult;
+    string? _shapeConstructorName;
+    double _radius;
+
+    void Establish() => LoadQueryProxy<DerivedTypeReadModel>("GetWithCircleShape");
+
+    async Task Because()
+    {
+        _executionResult = await Bridge!.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithCircleShape");
+        _shapeConstructorName = Runtime!.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
+        _radius = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.radius ?? 0"));
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult!.Result!.IsSuccess.ShouldBeTrue();
+    [Fact] void should_deserialize_shape_as_circle_shape() => _shapeConstructorName.ShouldEqual("CircleShape");
+    [Fact] void should_have_correct_radius() => _radius.ShouldEqual(5.0);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_rectangle_shape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_rectangle_shape.cs
@@ -17,13 +17,13 @@ public class and_concrete_type_is_rectangle_shape : given.a_scenario_web_applica
 
     async Task Because()
     {
-        _executionResult = await Bridge!.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithRectangleShape");
-        _shapeConstructorName = Runtime!.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
-        _width = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.width ?? 0"));
-        _height = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.height ?? 0"));
+        _executionResult = await Bridge.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithRectangleShape");
+        _shapeConstructorName = Runtime.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
+        _width = Convert.ToDouble(Runtime.Evaluate<object>("__queryResult?.data?.shape?.width ?? 0"));
+        _height = Convert.ToDouble(Runtime.Evaluate<object>("__queryResult?.data?.shape?.height ?? 0"));
     }
 
-    [Fact] void should_return_successful_result() => _executionResult!.Result!.IsSuccess.ShouldBeTrue();
+    [Fact] void should_return_successful_result() => _executionResult.Result.IsSuccess.ShouldBeTrue();
     [Fact] void should_deserialize_shape_as_rectangle_shape() => _shapeConstructorName.ShouldEqual("RectangleShape");
     [Fact] void should_have_correct_width() => _width.ShouldEqual(10.0);
     [Fact] void should_have_correct_height() => _height.ShouldEqual(20.0);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_rectangle_shape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/ModelBound/when_performing_query_for_read_model_with_derived_type_property/and_concrete_type_is_rectangle_shape.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries.ModelBound.when_performing_query_for_read_model_with_derived_type_property;
+
+[Collection(ScenarioCollectionDefinition.Name)]
+public class and_concrete_type_is_rectangle_shape : given.a_scenario_web_application
+{
+    QueryExecutionResult<DerivedTypeReadModel>? _executionResult;
+    string? _shapeConstructorName;
+    double _width;
+    double _height;
+
+    void Establish() => LoadQueryProxy<DerivedTypeReadModel>("GetWithRectangleShape");
+
+    async Task Because()
+    {
+        _executionResult = await Bridge!.PerformQueryViaProxyAsync<DerivedTypeReadModel>("GetWithRectangleShape");
+        _shapeConstructorName = Runtime!.Evaluate<string>("__queryResult?.data?.shape?.constructor?.name");
+        _width = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.width ?? 0"));
+        _height = Convert.ToDouble(Runtime!.Evaluate<object>("__queryResult?.data?.shape?.height ?? 0"));
+    }
+
+    [Fact] void should_return_successful_result() => _executionResult!.Result!.IsSuccess.ShouldBeTrue();
+    [Fact] void should_deserialize_shape_as_rectangle_shape() => _shapeConstructorName.ShouldEqual("RectangleShape");
+    [Fact] void should_have_correct_width() => _width.ShouldEqual(10.0);
+    [Fact] void should_have_correct_height() => _height.ShouldEqual(20.0);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/given/a_scenario_web_application.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/given/a_scenario_web_application.cs
@@ -206,7 +206,26 @@ public class a_scenario_web_application : Specification, IDisposable
 
     void LoadTypesAndEnumsPass(IEnumerable<Type> types, string? saveBasePath = null)
     {
-        var typesList = types.Distinct().Where(t => !_loadedTypes.Contains(t)).ToList();
+        // Ensure types are loaded in dependency order so @field decorators receive fully-populated
+        // globalThis references. Types whose properties have derived-type annotations must come last
+        // because they reference both the base type (e.g. IShape) and the derivatives. Types that
+        // are themselves derived (carry [DerivedType]) should come first so they are in globalThis
+        // when parent types load. All others keep their original alphabetical order.
+        static bool HasPropertiesWithDerivatives(Type t) =>
+            !t.IsEnum &&
+            t.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+             .Any(p => p.PropertyType.GetDerivativeTypes().Any());
+
+        var typesList = types
+            .Distinct()
+            .Where(t => !_loadedTypes.Contains(t))
+            .OrderBy(t => t switch
+            {
+                _ when t.GetDerivedTypeId() is not null => 0,
+                _ when HasPropertiesWithDerivatives(t) => 2,
+                _ => 1
+            })
+            .ToList();
         var enums = typesList.Where(_ => _.IsEnum).ToList();
         var nonEnums = typesList.Where(_ => !_.IsEnum).ToList();
 

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_already_exists_with_different_hash.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_already_exists_with_different_hash.cs
@@ -37,7 +37,7 @@ public class and_file_already_exists_with_different_hash : Specification, IDispo
 
         var path = testType.ResolveTargetPath(0);
         _filePath = Path.Join(_tempDir, path, "ModifiedType.ts");
-        var directory = Path.GetDirectoryName(_filePath)!;
+        var directory = Path.GetDirectoryName(_filePath);
         Directory.CreateDirectory(directory);
 
         const string oldProxyContent = "export class ModifiedType { oldProperty: string; }";

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_already_exists_with_same_hash.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_already_exists_with_same_hash.cs
@@ -36,7 +36,7 @@ public class and_file_already_exists_with_same_hash : Specification, IDisposable
 
         var path = testType.ResolveTargetPath(0);
         _filePath = Path.Join(_tempDir, path, "SimpleType.ts");
-        var directory = Path.GetDirectoryName(_filePath)!;
+        var directory = Path.GetDirectoryName(_filePath);
         Directory.CreateDirectory(directory);
 
 #pragma warning disable MA0136 // Raw String contains an implicit end of line character

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_exists_with_same_hash_preserves_timestamp.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_file_exists_with_same_hash_preserves_timestamp.cs
@@ -36,7 +36,7 @@ public class and_file_exists_with_same_hash_preserves_timestamp : Specification,
 
         var path = testType.ResolveTargetPath(0);
         _filePath = Path.Join(_tempDir, path, "TimestampTestType.ts");
-        var directory = Path.GetDirectoryName(_filePath)!;
+        var directory = Path.GetDirectoryName(_filePath);
         Directory.CreateDirectory(directory);
 
 #pragma warning disable MA0136 // Raw String contains an implicit end of line character

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_fixes_import_module_paths.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_fixes_import_module_paths.cs
@@ -44,8 +44,8 @@ public class and_using_source_file_map_fixes_import_module_paths : Specification
 
         _sourceFileMap = new Dictionary<string, string>
         {
-            [descriptorType.FullName!] = "ImportingType",
-            [importedType.FullName!] = "SharedSlice"
+            [descriptorType.FullName] = "ImportingType",
+            [importedType.FullName] = "SharedSlice"
         };
 
         var path = descriptorType.ResolveTargetPath(0);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_with_multiple_descriptors_for_same_source_file.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_with_multiple_descriptors_for_same_source_file.cs
@@ -44,8 +44,8 @@ public class and_using_source_file_map_with_multiple_descriptors_for_same_source
 
         _sourceFileMap = new Dictionary<string, string>
         {
-            [firstType.FullName!] = "SharedSourceFile",
-            [secondType.FullName!] = "SharedSourceFile"
+            [firstType.FullName] = "SharedSourceFile",
+            [secondType.FullName] = "SharedSourceFile"
         };
 
         var path = firstType.ResolveTargetPath(0);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_with_single_descriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_DescriptorExtensions/when_writing_descriptors/and_using_source_file_map_with_single_descriptor.cs
@@ -35,7 +35,7 @@ public class and_using_source_file_map_with_single_descriptor : Specification, I
 
         _sourceFileMap = new Dictionary<string, string>
         {
-            [testType.FullName!] = "MySourceFile"
+            [testType.FullName] = "MySourceFile"
         };
 
         var path = testType.ResolveTargetPath(0);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_FileMetadataScanner/when_finding_orphaned_files/simulating_real_generation_flow.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_FileMetadataScanner/when_finding_orphaned_files/simulating_real_generation_flow.cs
@@ -22,7 +22,7 @@ public class simulating_real_generation_flow : Specification
 
         var fullPath = Path.Join(targetPath, path, fileName);
         var normalizedFullPath = Path.GetFullPath(fullPath);
-        var directory = Path.GetDirectoryName(normalizedFullPath)!;
+        var directory = Path.GetDirectoryName(normalizedFullPath);
         Directory.CreateDirectory(directory);
 
         var metadata = new GeneratedFileMetadata("MyApp.Commands.CreateOrder", DateTime.UtcNow);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_FileMetadataScanner/when_finding_orphaned_files/with_file_generated_using_path_join.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_FileMetadataScanner/when_finding_orphaned_files/with_file_generated_using_path_join.cs
@@ -17,7 +17,7 @@ public class with_file_generated_using_path_join : Specification
 
         const string subDir = "commands";
         _generatedFilePath = Path.Join(_tempDir, subDir, "CreateOrder.ts");
-        var directory = Path.GetDirectoryName(_generatedFilePath)!;
+        var directory = Path.GetDirectoryName(_generatedFilePath);
         Directory.CreateDirectory(directory);
 
         var metadata = new GeneratedFileMetadata("MyApp.Commands.CreateOrder", DateTime.UtcNow);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/with_hash.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/with_hash.cs
@@ -20,5 +20,5 @@ public class with_hash : Specification
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
     [Fact] void should_have_metadata() => _metadata.ShouldNotBeNull();
-    [Fact] void should_have_correct_hash() => _metadata!.ContentHash.ShouldEqual(_expectedHash);
+    [Fact] void should_have_correct_hash() => _metadata.ContentHash.ShouldEqual(_expectedHash);
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/with_valid_comment.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/with_valid_comment.cs
@@ -18,6 +18,6 @@ public class with_valid_comment : Specification
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
     [Fact] void should_have_metadata() => _metadata.ShouldNotBeNull();
-    [Fact] void should_have_correct_source_type_name() => _metadata!.SourceTypeName.ShouldEqual("MyNamespace.MyClass");
-    [Fact] void should_have_parsed_time() => _metadata!.GeneratedTime.Year.ShouldEqual(2024);
+    [Fact] void should_have_correct_source_type_name() => _metadata.SourceTypeName.ShouldEqual("MyNamespace.MyClass");
+    [Fact] void should_have_parsed_time() => _metadata.GeneratedTime.Year.ShouldEqual(2024);
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/without_hash.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_GeneratedFileMetadata/when_parsing_comment_line/without_hash.cs
@@ -14,5 +14,5 @@ public class without_hash : Specification
 
     [Fact] void should_return_true() => _result.ShouldBeTrue();
     [Fact] void should_have_metadata() => _metadata.ShouldNotBeNull();
-    [Fact] void should_have_empty_hash() => _metadata!.ContentHash.ShouldEqual(string.Empty);
+    [Fact] void should_have_empty_hash() => _metadata.ContentHash.ShouldEqual(string.Empty);
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_SourceFileResolver/when_building_type_to_source_file_map/with_assembly_that_has_pdb.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_SourceFileResolver/when_building_type_to_source_file_map/with_assembly_that_has_pdb.cs
@@ -9,6 +9,6 @@ public class with_assembly_that_has_pdb : Specification
 
     void Because() => _result = SourceFileResolver.BuildTypeToSourceFileMap(typeof(SourceFileResolver).Assembly.Location);
 
-    [Fact] void should_resolve_source_file_for_source_file_resolver() => _result.ContainsKey(typeof(SourceFileResolver).FullName!).ShouldBeTrue();
-    [Fact] void should_map_source_file_resolver_to_its_file_name() => _result[typeof(SourceFileResolver).FullName!].ShouldEqual("SourceFileResolver");
+    [Fact] void should_resolve_source_file_for_source_file_resolver() => _result.ContainsKey(typeof(SourceFileResolver).FullName).ShouldBeTrue();
+    [Fact] void should_map_source_file_resolver_to_its_file_name() => _result[typeof(SourceFileResolver).FullName].ShouldEqual("SourceFileResolver");
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/AssemblyPackageMappingCollectionDefinition.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/AssemblyPackageMappingCollectionDefinition.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+[CollectionDefinition(Name)]
+public static class AssemblyPackageMappingCollectionDefinition
+{
+    public const string Name = "AssemblyPackageMapping";
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_from_mapped_assembly/and_assembly_is_mapped.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_from_mapped_assembly/and_assembly_is_mapped.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_checking_is_from_mapped_assembly;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_assembly_is_mapped : Specification
+{
+    class TypeFromMappedAssembly
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    bool _result;
+
+    void Establish()
+    {
+        var assemblyName = typeof(TypeFromMappedAssembly).Assembly.GetName().Name!;
+        TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string> { [assemblyName] = "@test/scene" });
+    }
+
+    void Because() => _result = typeof(TypeFromMappedAssembly).IsFromMappedAssembly();
+
+    void Destroy() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_from_mapped_assembly/and_assembly_is_not_mapped.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_is_from_mapped_assembly/and_assembly_is_not_mapped.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_checking_is_from_mapped_assembly;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_assembly_is_not_mapped : Specification
+{
+    class TypeFromUnmappedAssembly
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    bool _result;
+
+    void Establish() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    void Because() => _result = typeof(TypeFromUnmappedAssembly).IsFromMappedAssembly();
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_collecting_types_involved_for_property_from_mapped_assembly/and_property_type_is_from_mapped_assembly.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_collecting_types_involved_for_property_from_mapped_assembly/and_property_type_is_from_mapped_assembly.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_collecting_types_involved_for_property_from_mapped_assembly;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_property_type_is_from_mapped_assembly : Specification
+{
+    class MappedExternalType
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    IList<Type> _typesInvolved = null!;
+    PropertyDescriptor _property = null!;
+
+    void Establish()
+    {
+        var assemblyName = typeof(MappedExternalType).Assembly.GetName().Name!;
+        TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string> { [assemblyName] = "@test/scene" });
+
+        _typesInvolved = new List<Type>();
+        _property = new PropertyDescriptor(
+            typeof(MappedExternalType),
+            "externalProperty",
+            "MappedExternalType",
+            "MappedExternalType",
+            "@test/scene",
+            false,
+            false,
+            false,
+            null);
+    }
+
+    void Because() => _property.CollectTypesInvolved(_typesInvolved);
+
+    void Destroy() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    [Fact] void should_not_add_the_mapped_type_to_types_involved() => _typesInvolved.ShouldBeEmpty();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_collecting_types_involved_for_property_from_mapped_assembly/and_type_is_from_mapped_assembly.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_collecting_types_involved_for_property_from_mapped_assembly/and_type_is_from_mapped_assembly.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_collecting_types_involved_for_property_from_mapped_assembly;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_type_is_from_mapped_assembly : Specification
+{
+    class MappedExternalType
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    IList<Type> _typesInvolved = null!;
+
+    void Establish()
+    {
+        var assemblyName = typeof(MappedExternalType).Assembly.GetName().Name!;
+        TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string> { [assemblyName] = "@test/scene" });
+
+        _typesInvolved = new List<Type>();
+    }
+
+    void Because() => typeof(MappedExternalType).CollectTypesInvolved(_typesInvolved);
+
+    void Destroy() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    [Fact] void should_not_add_the_mapped_type_to_types_involved() => _typesInvolved.ShouldBeEmpty();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_mapped_assembly_type/and_assembly_is_mapped_to_package.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_mapped_assembly_type/and_assembly_is_mapped_to_package.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_mapped_assembly_type;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_assembly_is_mapped_to_package : Specification
+{
+    class TypeFromMappedAssembly
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    TargetType _result = null!;
+
+    void Establish()
+    {
+        var assemblyName = typeof(TypeFromMappedAssembly).Assembly.GetName().Name!;
+        TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string> { [assemblyName] = "@test/scene" });
+    }
+
+    void Because() => _result = typeof(TypeFromMappedAssembly).GetTargetType();
+
+    void Destroy() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    [Fact] void should_have_the_type_name() => _result.Type.ShouldEqual("TypeFromMappedAssembly");
+    [Fact] void should_have_the_package_as_module() => _result.Module.ShouldEqual("@test/scene");
+    [Fact] void should_be_from_package() => _result.FromPackage.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_mapped_assembly_type/and_assembly_is_not_mapped.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_mapped_assembly_type/and_assembly_is_not_mapped.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_mapped_assembly_type;
+
+[Collection(AssemblyPackageMappingCollectionDefinition.Name)]
+public class and_assembly_is_not_mapped : Specification
+{
+    class TypeFromUnmappedAssembly
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    TargetType _result = null!;
+
+    void Establish() => TypeExtensions.SetAssemblyPackageMappings(new Dictionary<string, string>());
+
+    void Because() => _result = typeof(TypeFromUnmappedAssembly).GetTargetType();
+
+    [Fact] void should_have_the_type_name() => _result.Type.ShouldEqual("TypeFromUnmappedAssembly");
+    [Fact] void should_not_have_a_module() => _result.Module.ShouldEqual(string.Empty);
+    [Fact] void should_not_be_from_package() => _result.FromPackage.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_data_annotations_from_parameter.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_data_annotations_from_parameter.cs
@@ -33,7 +33,7 @@ public class when_extracting_data_annotations_from_parameter : Specification
 
     void Establish()
     {
-        var method = typeof(TestClass).GetMethod(nameof(TestClass.TestMethod), BindingFlags.Public | BindingFlags.Static)!;
+        var method = typeof(TestClass).GetMethod(nameof(TestClass.TestMethod), BindingFlags.Public | BindingFlags.Static);
         var parameters = method.GetParameters();
 
         _emailRules = ValidationRulesExtractor.ExtractDataAnnotationsFromParameter(parameters[0]);

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_method.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_method.cs
@@ -10,10 +10,10 @@ public class for_method : Specification
     MethodInfo _method;
     string? _documentation;
 
-    void Establish() => _method = typeof(SampleTypeWithDocumentation).GetMethod(nameof(SampleTypeWithDocumentation.GetValue))!;
+    void Establish() => _method = typeof(SampleTypeWithDocumentation).GetMethod(nameof(SampleTypeWithDocumentation.GetValue));
 
     void Because() => _documentation = _method.GetDocumentation();
 
     [Fact] void should_return_documentation() => _documentation.ShouldNotBeNull();
-    [Fact] void should_contain_summary() => _documentation!.ShouldContain("A method with documentation");
+    [Fact] void should_contain_summary() => _documentation.ShouldContain("A method with documentation");
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_parameter.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_parameter.cs
@@ -12,12 +12,12 @@ public class for_parameter : Specification
 
     void Establish()
     {
-        var method = typeof(SampleTypeWithDocumentation).GetMethod(nameof(SampleTypeWithDocumentation.GetValue))!;
+        var method = typeof(SampleTypeWithDocumentation).GetMethod(nameof(SampleTypeWithDocumentation.GetValue));
         _parameter = method.GetParameters()[0];
     }
 
     void Because() => _documentation = _parameter.GetDocumentation();
 
     [Fact] void should_return_documentation() => _documentation.ShouldNotBeNull();
-    [Fact] void should_contain_summary() => _documentation!.ShouldContain("A parameter with documentation");
+    [Fact] void should_contain_summary() => _documentation.ShouldContain("A parameter with documentation");
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_property.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_property.cs
@@ -10,10 +10,10 @@ public class for_property : Specification
     PropertyInfo _property;
     string? _documentation;
 
-    void Establish() => _property = typeof(SampleTypeWithDocumentation).GetProperty(nameof(SampleTypeWithDocumentation.Name))!;
+    void Establish() => _property = typeof(SampleTypeWithDocumentation).GetProperty(nameof(SampleTypeWithDocumentation.Name));
 
     void Because() => _documentation = _property.GetDocumentation();
 
     [Fact] void should_return_documentation() => _documentation.ShouldNotBeNull();
-    [Fact] void should_contain_summary() => _documentation!.ShouldContain("A property with documentation");
+    [Fact] void should_contain_summary() => _documentation.ShouldContain("A property with documentation");
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_type.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_XmlDocumentation/when_getting_documentation/for_type.cs
@@ -13,5 +13,5 @@ public class for_type : Specification
     void Because() => _documentation = _type.GetDocumentation();
 
     [Fact] void should_return_documentation() => _documentation.ShouldNotBeNull();
-    [Fact] void should_contain_summary() => _documentation!.ShouldContain("A sample type for testing XML documentation extraction");
+    [Fact] void should_contain_summary() => _documentation.ShouldContain("A sample type for testing XML documentation extraction");
 }

--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -27,6 +27,7 @@ public static class Generator
     /// <param name="apiPrefix">The API prefix to use in the route.</param>
     /// <param name="skipIndexGeneration">True to skip index.ts file generation, false to enable it.</param>
     /// <param name="useSourceFileAsOutputFile">True to group all TypeScript types from the same C# source file into a single .ts file named after the source file, false to generate one file per type.</param>
+    /// <param name="assemblyPackageMappings">Optional dictionary mapping assembly names to TypeScript package names. Types from these assemblies will be imported from the package instead of being generated locally.</param>
     /// <returns>True if successful, false if not.</returns>
     public static async Task<bool> Generate(
         string assemblyFile,
@@ -39,7 +40,8 @@ public static class Generator
         bool skipQueryNameInRoute = false,
         string apiPrefix = "api",
         bool skipIndexGeneration = false,
-        bool useSourceFileAsOutputFile = false)
+        bool useSourceFileAsOutputFile = false,
+        IReadOnlyDictionary<string, string>? assemblyPackageMappings = null)
     {
         assemblyFile = Path.GetFullPath(assemblyFile);
         if (!File.Exists(assemblyFile))
@@ -55,6 +57,7 @@ public static class Generator
 
         var overallStopwatch = Stopwatch.StartNew();
 
+        TypeExtensions.SetAssemblyPackageMappings(assemblyPackageMappings ?? new Dictionary<string, string>());
         TypeExtensions.InitializeProjectAssemblies(assemblyFile, message, errorMessage);
 
         var commands = new List<CommandDescriptor>();
@@ -107,10 +110,10 @@ public static class Generator
         typesInvolved = [.. typesInvolved.Distinct()];
         var enums = typesInvolved.Where(_ => _.IsEnum).ToList();
 
-        var typeDescriptors = typesInvolved.Where(_ => !enums.Contains(_)).ToList().ConvertAll(_ => _.ToTypeDescriptor(outputPath, segmentsToSkip));
+        var typeDescriptors = typesInvolved.Where(_ => !enums.Contains(_) && !_.IsFromMappedAssembly()).ToList().ConvertAll(_ => _.ToTypeDescriptor(outputPath, segmentsToSkip));
         await typeDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Type, directories, segmentsToSkip, "types", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
 
-        var enumDescriptors = enums.ConvertAll(_ => _.ToEnumDescriptor());
+        var enumDescriptors = enums.Where(_ => !_.IsFromMappedAssembly()).ToList().ConvertAll(_ => _.ToEnumDescriptor());
         await enumDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Enum, directories, segmentsToSkip, "enums", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
 
         // Flush deferred content to disk, comparing final merged hashes against original files

--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -110,8 +110,17 @@ public static class Generator
         var typeDescriptors = typesInvolved.Where(_ => !enums.Contains(_)).ToList().ConvertAll(_ => _.ToTypeDescriptor(outputPath, segmentsToSkip));
         await typeDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Type, directories, segmentsToSkip, "types", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
 
-        var enumDescriptors = enums.ConvertAll(_ => _.ToEnumDescriptor());
-        await enumDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Enum, directories, segmentsToSkip, "enums", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
+        var regularEnumDescriptors = enums
+            .Where(_ => !Attribute.IsDefined(_, typeof(FlagsAttribute)))
+            .ToList()
+            .ConvertAll(_ => _.ToEnumDescriptor());
+        await regularEnumDescriptors.Write(outputPath, typesInvolved, TemplateTypes.Enum, directories, segmentsToSkip, "enums", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
+
+        var flagsEnumDescriptors = enums
+            .Where(_ => Attribute.IsDefined(_, typeof(FlagsAttribute)))
+            .ToList()
+            .ConvertAll(_ => _.ToEnumDescriptor());
+        await flagsEnumDescriptors.Write(outputPath, typesInvolved, TemplateTypes.FlagsEnum, directories, segmentsToSkip, "flags enums", message, errorMessage, generatedFiles, descriptorOrigins, sourceFileMap, pendingContent);
 
         // Flush deferred content to disk, comparing final merged hashes against original files
         if (pendingContent is { Count: > 0 })

--- a/Source/DotNET/Tools/ProxyGenerator/Program.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Program.cs
@@ -24,9 +24,8 @@ var skipIndexGeneration = args.Any(_ => _ == "--skip-index-generation");
 var useSourceFileAsOutputFile = args.Any(_ => _ == "--use-source-file-as-output-file");
 
 var assemblyPackageMappings = new Dictionary<string, string>();
-foreach (var arg in args.Where(_ => _.StartsWith("--assembly-to-package=")))
+foreach (var mapping in args.Where(_ => _.StartsWith("--assembly-to-package=")).Select(_ => _["--assembly-to-package=".Length..]))
 {
-    var mapping = arg["--assembly-to-package=".Length..];
     var separatorIndex = mapping.IndexOf('=');
     if (separatorIndex > 0)
     {

--- a/Source/DotNET/Tools/ProxyGenerator/Program.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Program.cs
@@ -9,7 +9,7 @@ Console.WriteLine("Cratis Proxy Generator\n");
 if (args.Length < 2)
 {
     Console.WriteLine("Usage: ");
-    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file]");
+    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file] [--assembly-to-package=<Assembly>=<Package>]...");
     return 1;
 }
 var assemblyFile = Normalize(Path.GetFullPath(args[0]));
@@ -23,6 +23,17 @@ var apiPrefix = apiPrefixArg is null ? "api" : apiPrefixArg.Split('=')[^1];
 var skipIndexGeneration = args.Any(_ => _ == "--skip-index-generation");
 var useSourceFileAsOutputFile = args.Any(_ => _ == "--use-source-file-as-output-file");
 
+var assemblyPackageMappings = new Dictionary<string, string>();
+foreach (var arg in args.Where(_ => _.StartsWith("--assembly-to-package=")))
+{
+    var mapping = arg["--assembly-to-package=".Length..];
+    var separatorIndex = mapping.IndexOf('=');
+    if (separatorIndex > 0)
+    {
+        assemblyPackageMappings[mapping[..separatorIndex]] = mapping[(separatorIndex + 1)..];
+    }
+}
+
 Console.WriteLine("\nParameters:");
 Console.WriteLine($"Assembly: '{assemblyFile}'");
 Console.WriteLine($"Output path: '{outputPath}'");
@@ -33,6 +44,14 @@ Console.WriteLine($"Skip query name in route: {skipQueryNameInRoute}");
 Console.WriteLine($"API prefix: {apiPrefix}");
 Console.WriteLine($"Skip index generation: {skipIndexGeneration}");
 Console.WriteLine($"Use source file as output file: {useSourceFileAsOutputFile}");
+if (assemblyPackageMappings.Count > 0)
+{
+    Console.WriteLine("Assembly-to-package mappings:");
+    foreach (var (assembly, package) in assemblyPackageMappings)
+    {
+        Console.WriteLine($"  {assembly} -> {package}");
+    }
+}
 Console.WriteLine();
 
 var result = await Generator.Generate(
@@ -46,5 +65,6 @@ var result = await Generator.Generate(
     skipQueryNameInRoute,
     apiPrefix,
     skipIndexGeneration,
-    useSourceFileAsOutputFile);
+    useSourceFileAsOutputFile,
+    assemblyPackageMappings);
 return result ? 0 : 1;

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -76,6 +76,11 @@ public static class PropertyExtensions
 
         var targetType = propertyType.GetTargetType();
 
+        var derivativeTypes = propertyType.GetDerivativeTypes().ToList();
+        var derivatives = derivativeTypes.Count > 0
+            ? string.Join(", ", derivativeTypes.Select(t => t.GetTargetType().Constructor))
+            : string.Empty;
+
         return new(
             propertyType,
             name,
@@ -85,6 +90,7 @@ public static class PropertyExtensions
             isEnumerable,
             isNullable,
             propertyType.IsAPrimitiveType(),
-            documentation);
+            documentation,
+            derivatives);
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/EnumDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/EnumDescriptor.cs
@@ -10,10 +10,23 @@ namespace Cratis.Arc.ProxyGenerator.Templates;
 /// <param name="Name">Name of the enum.</param>
 /// <param name="Values">The values on the enum.</param>
 /// <param name="TypesInvolved">Additional types involved.</param>
+/// <param name="IsFlags">Whether the enum is decorated with <see cref="FlagsAttribute"/>. Defaults to <see langword="false"/>.</param>
 /// <param name="Documentation">JSDoc documentation for the enum.</param>
 public record EnumDescriptor(
     Type Type,
     string Name,
     IEnumerable<EnumMemberDescriptor> Values,
     IEnumerable<Type> TypesInvolved,
-    string? Documentation = null) : IDescriptor;
+    bool IsFlags = false,
+    string? Documentation = null) : IDescriptor
+{
+    /// <summary>
+    /// Gets the expression combining all non-zero flag values with bitwise OR, e.g. <c>MyEnum.a | MyEnum.b</c>.
+    /// Only meaningful when <see cref="IsFlags"/> is <see langword="true"/>.
+    /// </summary>
+    public string AllFlagsExpression => string.Join(
+        " | ",
+        Values
+            .Where(v => Convert.ToInt64(v.Value) != 0)
+            .Select(v => $"{Name}.{v.Name.ToCamelCase()}"));
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/FlagsEnum.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/FlagsEnum.hbs
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  **DO NOT EDIT** - This file is an automatically generated file.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line header/header
+{{#if Documentation}}
+/**
+ * {{Documentation}}
+ */
+{{/if}}
+export enum {{Name}} {
+    {{#Values}}
+    {{camelcase Name}} = {{Value}},
+    {{/Values}}
+}
+
+export const all{{Name}} = {{AllFlagsExpression}};

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/PropertyDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/PropertyDescriptor.cs
@@ -15,6 +15,7 @@ namespace Cratis.Arc.ProxyGenerator.Templates;
 /// <param name="IsNullable">Whether or not the property is nullable or not.</param>
 /// <param name="isPrimitive">Whether or not the property is a primitive type.</param>
 /// <param name="Documentation">JSDoc documentation for the property.</param>
+/// <param name="Derivatives">Comma-separated TypeScript constructor names for derived types, or empty string if none.</param>
 public record PropertyDescriptor(
     Type OriginalType,
     string Name,
@@ -24,4 +25,5 @@ public record PropertyDescriptor(
     bool IsEnumerable,
     bool IsNullable,
     bool isPrimitive,
-    string? Documentation);
+    string? Documentation,
+    string Derivatives = "");

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
@@ -26,6 +26,12 @@ public static class TemplateTypes
     public static readonly HandlebarsTemplate<object, object> Enum = Handlebars.Compile(GetTemplate("Enum"));
 
     /// <summary>
+    /// The template for a flags enum — an enum decorated with <see cref="FlagsAttribute"/>.
+    /// Includes an <c>allXxx</c> constant that combines all non-zero member values with bitwise OR.
+    /// </summary>
+    public static readonly HandlebarsTemplate<object, object> FlagsEnum = Handlebars.Compile(GetTemplate("FlagsEnum"));
+
+    /// <summary>
     /// The template for a command.
     /// </summary>
     public static readonly HandlebarsTemplate<object, object> Command = Handlebars.Compile(GetTemplate("Command"));

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/Type.hbs
@@ -5,7 +5,11 @@
 /* eslint-disable sort-imports */
 // eslint-disable-next-line header/header
 {{#if Properties}}
-import { field } from '@cratis/fundamentals';
+import { field{{#if DerivedTypeId}}, derivedType{{/if}} } from '@cratis/fundamentals';
+{{else}}
+{{#if DerivedTypeId}}
+import { derivedType } from '@cratis/fundamentals';
+{{/if}}
 {{/if}}
 {{#Imports}}
 import { {{{Type}}} } from '{{Module}}';
@@ -16,6 +20,9 @@ import { {{{Type}}} } from '{{Module}}';
  * {{Documentation}}
  */
 {{/if}}
+{{#if DerivedTypeId}}
+@derivedType('{{DerivedTypeId}}')
+{{/if}}
 export class {{Name}} {
     {{#Properties}}
     {{#if Documentation}}
@@ -25,14 +32,22 @@ export class {{Name}} {
      */
     {{/if}}
     {{#if IsEnumerable}}
+    {{#if Derivatives}}
+    @field({{Constructor}}, true, [{{Derivatives}}])
+    {{else}}
     @field({{Constructor}}, true)
+    {{/if}}
     {{#if IsNullable}}
     {{camelcase Name}}?: {{{Type}}}[];
     {{else}}
     {{camelcase Name}}!: {{{Type}}}[];
     {{/if}}
     {{else}}
+    {{#if Derivatives}}
+    @field({{Constructor}}, false, [{{Derivatives}}])
+    {{else}}
     @field({{Constructor}})
+    {{/if}}
     {{#if IsNullable}}
     {{camelcase Name}}?: {{{Type}}};
     {{else}}

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TypeDescriptor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TypeDescriptor.cs
@@ -12,10 +12,12 @@ namespace Cratis.Arc.ProxyGenerator.Templates;
 /// <param name="Imports">Additional import statements.</param>
 /// <param name="TypesInvolved">Collection of types involved in the command.</param>
 /// <param name="Documentation">JSDoc documentation for the type.</param>
+/// <param name="DerivedTypeId">The derived type identifier GUID string if this type carries a <c>DerivedTypeAttribute</c>, otherwise null.</param>
 public record TypeDescriptor(
     Type Type,
     string Name,
     IEnumerable<PropertyDescriptor> Properties,
     IOrderedEnumerable<ImportStatement> Imports,
     IEnumerable<Type> TypesInvolved,
-    string? Documentation = null) : IDescriptor;
+    string? Documentation = null,
+    string? DerivedTypeId = null) : IDescriptor;

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -103,11 +103,8 @@ public static class TypeExtensions
     /// </summary>
     /// <param name="type">Type to check.</param>
     /// <returns>True if the type is from a mapped assembly, false otherwise.</returns>
-    public static bool IsFromMappedAssembly(this Type type)
-    {
-        var assemblyName = type.Assembly.GetName().Name;
-        return assemblyName is not null && _assemblyPackageMappings.ContainsKey(assemblyName);
-    }
+    public static bool IsFromMappedAssembly(this Type type) =>
+        type.Assembly.GetName().Name is { } name && _assemblyPackageMappings.ContainsKey(name);
 
     /// <summary>
     /// Initialize the project assemblies.

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -415,11 +415,21 @@ public static class TypeExtensions
         }
 
         imports.AddRange(typesInvolved.GetImports(targetPath, type.ResolveTargetPath(segmentsToSkip), segmentsToSkip));
+
+        var derivativeConstructorNames = new HashSet<string>(
+            propertyDescriptors
+                .Where(pd => !string.IsNullOrEmpty(pd.Derivatives))
+                .SelectMany(pd => pd.Derivatives.Split(", ")));
+
         imports = [.. imports
                     .DistinctBy(_ => _.Type)
-                    .Where(_ => propertyDescriptors.Exists(pd => TypeNameIsReferenced(pd.Type, _.Type)) && _.OriginalType != type)];
+                    .Where(_ =>
+                        (propertyDescriptors.Exists(pd => TypeNameIsReferenced(pd.Type, _.Type)) ||
+                         derivativeConstructorNames.Contains(_.Type))
+                        && _.OriginalType != type)];
 
         var documentation = type.GetDocumentation();
+        var derivedTypeId = type.GetDerivedTypeId();
 
         return new TypeDescriptor(
             type,
@@ -427,7 +437,8 @@ public static class TypeExtensions
             propertyDescriptors,
             imports.ToOrderedImports(),
             typesInvolved,
-            documentation);
+            documentation,
+            derivedTypeId);
     }
 
     /// <summary>
@@ -557,6 +568,11 @@ public static class TypeExtensions
     {
         if (typesInvolved.Contains(property.OriginalType) || property.OriginalType.IsAPrimitiveType() || property.OriginalType.IsConcept() || property.OriginalType.IsKnownType()) return;
         typesInvolved.Add(property.OriginalType);
+        foreach (var derivativeType in property.OriginalType.GetDerivativeTypes())
+        {
+            derivativeType.CollectTypesInvolved(typesInvolved);
+        }
+
         foreach (var subProperty in property.OriginalType.GetPropertyDescriptors().Where(_ => !_.OriginalType.IsKnownType()))
         {
             CollectTypesInvolved(subProperty, typesInvolved);
@@ -589,6 +605,11 @@ public static class TypeExtensions
     {
         if (typesInvolved.Contains(type) || type.IsAPrimitiveType() || type.IsConcept() || type.IsKnownType()) return;
         typesInvolved.Add(type);
+        foreach (var derivativeType in type.GetDerivativeTypes())
+        {
+            derivativeType.CollectTypesInvolved(typesInvolved);
+        }
+
         foreach (var subProperty in type.GetPropertyDescriptors().Where(_ => !_.OriginalType.IsKnownType()))
         {
             CollectTypesInvolved(subProperty, typesInvolved);
@@ -816,6 +837,48 @@ public static class TypeExtensions
     }
 
     /// <summary>
+    /// Get the derived type identifier for a type if it has a <c>DerivedTypeAttribute</c>.
+    /// </summary>
+    /// <param name="type"><see cref="Type"/> to check.</param>
+    /// <returns>The derived type identifier string, or null if the type is not decorated.</returns>
+    public static string? GetDerivedTypeId(this Type type)
+    {
+        var attr = type.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "Cratis.Serialization.DerivedTypeAttribute");
+
+        if (attr is null) return null;
+
+        return attr.ConstructorArguments.Count > 0
+            ? attr.ConstructorArguments[0].Value?.ToString()
+            : null;
+    }
+
+    /// <summary>
+    /// Get all non-abstract types that derive from or implement the given type and carry a <c>DerivedTypeAttribute</c>.
+    /// </summary>
+    /// <param name="baseType">Base type to find derivatives of.</param>
+    /// <returns>Collection of derivative types.</returns>
+    public static IEnumerable<Type> GetDerivativeTypes(this Type baseType)
+    {
+        if (baseType.IsAPrimitiveType() || baseType.IsConcept() || baseType.IsEnum)
+        {
+            return [];
+        }
+
+        var assembliesToSearch = Assemblies.Any()
+            ? Assemblies
+            : AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic);
+
+        return assembliesToSearch
+            .SelectMany(a => { try { return a.GetTypes(); } catch { return []; } })
+            .Where(t => t != baseType &&
+                        !t.IsAbstract &&
+                        !t.IsInterface &&
+                        t.GetDerivedTypeId() is not null &&
+                        t.IsAssignableToBaseType(baseType));
+    }
+
+    /// <summary>
     /// Check if a type is a well-known type that should be ignored as a response type.
     /// </summary>
     /// <param name="type"><see cref="Type"/> to check.</param>
@@ -938,6 +1001,23 @@ public static class TypeExtensions
 
         var aspNetCore = _metadataLoadContext.LoadFromAssemblyName("Microsoft.AspNetCore.Mvc.Core");
         _controllerBaseType = aspNetCore.GetType("Microsoft.AspNetCore.Mvc.ControllerBase")!;
+    }
+
+    static bool IsAssignableToBaseType(this Type type, Type baseType)
+    {
+        var baseFullName = baseType.FullName;
+        if (string.IsNullOrEmpty(baseFullName)) return false;
+
+        if (type.GetInterfaces().Any(i => i.FullName == baseFullName)) return true;
+
+        var current = type.BaseType;
+        while (current is not null && current.FullName != typeof(object).FullName)
+        {
+            if (current.FullName == baseFullName) return true;
+            current = current.BaseType;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -79,6 +79,8 @@ public static class TypeExtensions
         "Cratis.Arc.Authorization.AuthorizationResult"
     ];
 
+    static Dictionary<string, string> _assemblyPackageMappings = [];
+
     static MetadataAssemblyResolver? _assemblyResolver;
     static MetadataLoadContext? _metadataLoadContext;
 
@@ -86,6 +88,26 @@ public static class TypeExtensions
     /// Gets all assemblies gathered from the <see cref="InitializeProjectAssemblies(string, Action{string}, Action{string})"/> method.
     /// </summary>
     public static IEnumerable<Assembly> Assemblies { get; private set; } = [];
+
+    /// <summary>
+    /// Sets the assembly-to-package mappings used to map types from specific assemblies to external TypeScript packages.
+    /// </summary>
+    /// <param name="mappings">Dictionary mapping assembly names to package names.</param>
+    public static void SetAssemblyPackageMappings(IReadOnlyDictionary<string, string> mappings)
+    {
+        _assemblyPackageMappings = new Dictionary<string, string>(mappings);
+    }
+
+    /// <summary>
+    /// Check if a type is from a mapped assembly and should be imported from a configured package rather than generated locally.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <returns>True if the type is from a mapped assembly, false otherwise.</returns>
+    public static bool IsFromMappedAssembly(this Type type)
+    {
+        var assemblyName = type.Assembly.GetName().Name;
+        return assemblyName is not null && _assemblyPackageMappings.ContainsKey(assemblyName);
+    }
 
     /// <summary>
     /// Initialize the project assemblies.
@@ -360,6 +382,11 @@ public static class TypeExtensions
             typeName = typeName[..backtickIndex];
         }
 
+        if (_assemblyPackageMappings.TryGetValue(type.Assembly.GetName().Name!, out var packageName))
+        {
+            return new TargetType(type, typeName, typeName, packageName, FromPackage: true);
+        }
+
         return new TargetType(type, typeName, typeName);
     }
 
@@ -555,7 +582,7 @@ public static class TypeExtensions
     /// <remarks>It skips any types already added to the collection passed to it.</remarks>
     public static void CollectTypesInvolved(this PropertyDescriptor property, IList<Type> typesInvolved)
     {
-        if (typesInvolved.Contains(property.OriginalType) || property.OriginalType.IsAPrimitiveType() || property.OriginalType.IsConcept() || property.OriginalType.IsKnownType()) return;
+        if (typesInvolved.Contains(property.OriginalType) || property.OriginalType.IsAPrimitiveType() || property.OriginalType.IsConcept() || property.OriginalType.IsKnownType() || property.OriginalType.IsFromMappedAssembly()) return;
         typesInvolved.Add(property.OriginalType);
         foreach (var subProperty in property.OriginalType.GetPropertyDescriptors().Where(_ => !_.OriginalType.IsKnownType()))
         {
@@ -571,7 +598,7 @@ public static class TypeExtensions
     /// <remarks>It skips any types already added to the collection passed to it.</remarks>
     public static void CollectTypesInvolved(this RequestParameterDescriptor parameter, IList<Type> typesInvolved)
     {
-        if (typesInvolved.Contains(parameter.OriginalType) || parameter.OriginalType.IsKnownType()) return;
+        if (typesInvolved.Contains(parameter.OriginalType) || parameter.OriginalType.IsKnownType() || parameter.OriginalType.IsFromMappedAssembly()) return;
         typesInvolved.Add(parameter.OriginalType);
         foreach (var subProperty in parameter.OriginalType.GetPropertyDescriptors().Where(_ => !_.OriginalType.IsKnownType()))
         {
@@ -587,7 +614,7 @@ public static class TypeExtensions
     /// <remarks>It skips any types already added to the collection passed to it.</remarks>
     public static void CollectTypesInvolved(this Type type, IList<Type> typesInvolved)
     {
-        if (typesInvolved.Contains(type) || type.IsAPrimitiveType() || type.IsConcept() || type.IsKnownType()) return;
+        if (typesInvolved.Contains(type) || type.IsAPrimitiveType() || type.IsConcept() || type.IsKnownType() || type.IsFromMappedAssembly()) return;
         typesInvolved.Add(type);
         foreach (var subProperty in type.GetPropertyDescriptors().Where(_ => !_.OriginalType.IsKnownType()))
         {

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -870,7 +870,17 @@ public static class TypeExtensions
             : AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic);
 
         return assembliesToSearch
-            .SelectMany(a => { try { return a.GetTypes(); } catch { return []; } })
+            .SelectMany(a =>
+            {
+                try
+                {
+                    return a.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    return ex.Types.Where(t => t is not null).Cast<Type>();
+                }
+            })
             .Where(t => t != baseType &&
                         !t.IsAbstract &&
                         !t.IsInterface &&

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -496,8 +496,9 @@ public static class TypeExtensions
         var values = Enum.GetValuesAsUnderlyingType(type).Cast<int>();
         var names = Enum.GetNames(type);
         var members = values.Select((value, index) => new EnumMemberDescriptor(names[index], value)).ToArray();
+        var isFlags = Attribute.IsDefined(type, typeof(FlagsAttribute));
         var documentation = type.GetDocumentation();
-        return new EnumDescriptor(type, type.Name, members, [], documentation);
+        return new EnumDescriptor(type, type.Name, members, [], isFlags, documentation);
     }
 
     /// <summary>


### PR DESCRIPTION
## Added

- Support for derived types (polymorphic shapes) in proxy generation — commands and queries that use a base type with derived subtypes now generate correct TypeScript union types
- `[Flags]` enum support — enums decorated with `[Flags]` are generated using a dedicated template that emits an `allXxx` constant combining all non-zero members with bitwise OR, e.g. `export const allAnchorEdges = AnchorEdges.top | AnchorEdges.right | AnchorEdges.bottom | AnchorEdges.left`