### PR TITLE
Add SubdomainTenantIdResolver with header fallback

### DIFF
--- a/Documentation/backend/tenancy/resolvers.md
+++ b/Documentation/backend/tenancy/resolvers.md
@@ -43,6 +43,21 @@ builder.AddCratisArcCore(options =>
 
 Default claim type: `tenant_id`
 
+### Subdomain Resolver
+
+Resolves the tenant ID from the first segment of the request hostname. When the hostname has no subdomain (a single segment), it falls back to the configured HTTP header.
+
+```csharp
+builder.AddCratisArcCore(options =>
+{
+    options.UseSubdomainTenancy("X-Tenant-ID");
+});
+```
+
+A request to `acme.myapp.com` resolves the tenant as `acme`. A request to `myapp.com` falls back to the `X-Tenant-ID` header. This pattern is useful for SaaS applications where each tenant is routed through its own subdomain.
+
+Default fallback header: `x-cratis-tenant-id`
+
 ### Development Resolver
 
 Uses a fixed tenant ID for local development.

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/given/a_subdomain_tenant_id_resolver.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/given/a_subdomain_tenant_id_resolver.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Tenancy.for_SubdomainTenantIdResolver.given;
+
+public class a_subdomain_tenant_id_resolver : Specification
+{
+    protected SubdomainTenantIdResolver _resolver;
+    protected IHttpRequestContextAccessor _httpRequestContextAccessor;
+    protected IOptions<ArcOptions> _options;
+    protected IHttpRequestContext _context;
+    protected Dictionary<string, string> _headers;
+
+    void Establish()
+    {
+        _httpRequestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
+        _options = Substitute.For<IOptions<ArcOptions>>();
+        _context = Substitute.For<IHttpRequestContext>();
+        _headers = [];
+
+        var arcOptions = new ArcOptions();
+        arcOptions.UseHeaderTenancy("X-Tenant-Id");
+        _options.Value.Returns(arcOptions);
+
+        _context.Headers.Returns(_headers);
+        _httpRequestContextAccessor.Current.Returns(_context);
+
+        _resolver = new SubdomainTenantIdResolver(_httpRequestContextAccessor, _options);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_context_is_null.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_context_is_null.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_SubdomainTenantIdResolver.when_resolving;
+
+public class and_context_is_null : given.a_subdomain_tenant_id_resolver
+{
+    string _result;
+
+    void Establish() => _httpRequestContextAccessor.Current.Returns(_ => null);
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_empty_string() => _result.ShouldEqual(string.Empty);
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_no_subdomain.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_no_subdomain.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_SubdomainTenantIdResolver.when_resolving;
+
+public class and_request_has_no_subdomain : given.a_subdomain_tenant_id_resolver
+{
+    string _result;
+
+    void Establish()
+    {
+        _context.Host.Returns("localhost");
+        _headers["X-Tenant-Id"] = "header-tenant";
+    }
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_fallback_to_tenant_header() => _result.ShouldEqual("header-tenant");
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_no_subdomain_and_no_header.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_no_subdomain_and_no_header.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_SubdomainTenantIdResolver.when_resolving;
+
+public class and_request_has_no_subdomain_and_no_header : given.a_subdomain_tenant_id_resolver
+{
+    string _result;
+
+    void Establish() => _context.Host.Returns("localhost");
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_empty_string() => _result.ShouldEqual(string.Empty);
+}

--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_subdomain.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_SubdomainTenantIdResolver/when_resolving/and_request_has_subdomain.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_SubdomainTenantIdResolver.when_resolving;
+
+public class and_request_has_subdomain : given.a_subdomain_tenant_id_resolver
+{
+    string _result;
+
+    void Establish() => _context.Host.Returns("acme.localhost");
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_resolve_tenant_id_from_subdomain() => _result.ShouldEqual("acme");
+}

--- a/Source/DotNET/Arc.Core/Http/HttpListenerRequestContext.cs
+++ b/Source/DotNET/Arc.Core/Http/HttpListenerRequestContext.cs
@@ -36,6 +36,9 @@ public class HttpListenerRequestContext(HttpListenerContext context, IServicePro
     public IReadOnlyDictionary<string, string> Cookies { get; } = ParseCookies(context.Request.Cookies);
 
     /// <inheritdoc/>
+    public string Host => context.Request.UserHostName?.Split(':')[0] ?? string.Empty;
+
+    /// <inheritdoc/>
     public string Path => context.Request.Url?.AbsolutePath ?? string.Empty;
 
     /// <inheritdoc/>

--- a/Source/DotNET/Arc.Core/Http/IHttpRequestContext.cs
+++ b/Source/DotNET/Arc.Core/Http/IHttpRequestContext.cs
@@ -26,6 +26,11 @@ public interface IHttpRequestContext
     IReadOnlyDictionary<string, string> Cookies { get; }
 
     /// <summary>
+    /// Gets the request host (without port).
+    /// </summary>
+    string Host { get; }
+
+    /// <summary>
     /// Gets the request path.
     /// </summary>
     string Path { get; }

--- a/Source/DotNET/Arc.Core/Tenancy/SubdomainTenantIdResolver.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/SubdomainTenantIdResolver.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+using Cratis.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Tenancy;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantIdResolver"/> that resolves the tenant ID from the request
+/// subdomain, with the configured HTTP header as fallback.
+/// </summary>
+/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/>.</param>
+/// <param name="options">The <see cref="IOptions{TOptions}"/>.</param>
+[IgnoreConvention]
+public class SubdomainTenantIdResolver(IHttpRequestContextAccessor httpRequestContextAccessor, IOptions<ArcOptions> options) : ITenantIdResolver
+{
+    /// <inheritdoc/>
+    public string Resolve()
+    {
+        var context = httpRequestContextAccessor.Current;
+        if (context is null)
+        {
+            return string.Empty;
+        }
+
+        var host = context.Host;
+        if (!string.IsNullOrWhiteSpace(host))
+        {
+            var segments = host.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length > 1)
+            {
+                return segments[0];
+            }
+        }
+
+        var headerName = options.Value.Tenancy.HttpHeader;
+        if (string.IsNullOrWhiteSpace(headerName))
+        {
+            return string.Empty;
+        }
+
+        return context.Headers.TryGetValue(headerName, out var tenantId) ? tenantId : string.Empty;
+    }
+}

--- a/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
@@ -71,4 +71,20 @@ public static class TenancyOptionsExtensions
         }
         return options;
     }
+
+    /// <summary>
+    /// Configure tenancy to resolve the tenant ID from the request subdomain, with the HTTP header as fallback.
+    /// </summary>
+    /// <param name="options">The <see cref="ArcOptions"/> to configure.</param>
+    /// <param name="fallbackHeaderName">Optional header name used as fallback. Defaults to 'X-Tenant-ID'.</param>
+    /// <returns>The <see cref="ArcOptions"/> for continuation.</returns>
+    public static ArcOptions UseSubdomainTenancy(this ArcOptions options, string? fallbackHeaderName = null)
+    {
+        options.Tenancy.ResolverType = TenantResolverType.Subdomain;
+        if (fallbackHeaderName is not null)
+        {
+            options.Tenancy.HttpHeader = fallbackHeaderName;
+        }
+        return options;
+    }
 }

--- a/Source/DotNET/Arc.Core/Tenancy/TenantResolverType.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenantResolverType.cs
@@ -26,5 +26,10 @@ public enum TenantResolverType
     /// <summary>
     /// Use a fixed tenant ID for development purposes.
     /// </summary>
-    Development = 3
+    Development = 3,
+
+    /// <summary>
+    /// Resolve tenant ID from the request subdomain, with HTTP header as fallback.
+    /// </summary>
+    Subdomain = 4
 }

--- a/Source/DotNET/Arc/Http/AspNetCoreHttpRequestContext.cs
+++ b/Source/DotNET/Arc/Http/AspNetCoreHttpRequestContext.cs
@@ -32,6 +32,9 @@ public class AspNetCoreHttpRequestContext(HttpContext httpContext) : IHttpReques
         kvp => kvp.Value);
 
     /// <inheritdoc/>
+    public string Host => httpContext.Request.Host.Host;
+
+    /// <inheritdoc/>
     public string Path => httpContext.Request.Path;
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Added
- New `SubdomainTenantIdResolver` that extracts the tenant ID from the first segment of the request hostname (e.g. `acme.myapp.com` → `acme`), with the configured HTTP header as fallback when no subdomain is present
- `TenantResolverType.Subdomain` enum value
- `UseSubdomainTenancy()` extension method on `ArcOptions`
- `Host` property on `IHttpRequestContext` and both implementations