### PR TITLE
Add SharpCompress compression library to MongoDB module

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
+    <PackageVersion Include="SharpCompress" Version="0.48.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="castle.core" Version="5.2.1" />

--- a/Source/DotNET/MongoDB/MongoDB.csproj
+++ b/Source/DotNET/MongoDB/MongoDB.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
         <PackageReference Include="Snappier" />
+        <PackageReference Include="SharpCompress" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Arc.Core/Arc.Core.csproj" />


### PR DESCRIPTION
## Added

- SharpCompress 0.48.0 compression library for archive and compression handling in the MongoDB integration layer