### PR TITLE
Bump dependencies and fix proxy generator circular imports

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.22.13" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.22.13" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.22.13" />
+    <PackageVersion Include="Cratis.Chronicle" Version="15.25.5" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.25.5" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.25.5" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.8.2" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.8.2" />
     <!-- MAUI -->
@@ -34,8 +34,8 @@
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.8.0" />
-    <PackageVersion Include="SharpCompress" Version="0.48.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="castle.core" Version="5.2.1" />
@@ -57,7 +57,7 @@
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.70" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.78" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
@@ -65,13 +65,13 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.5.1" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8-9.props" Condition=" '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' " />
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -76,11 +76,11 @@ public static class PropertyExtensions
 
         var targetType = propertyType.GetTargetType();
 
-        var derivativeTypes = propertyType.GetDerivativeTypes().ToList();
-        var derivatives = derivativeTypes.Count > 0
-            ? string.Join(", ", derivativeTypes.Select(t => t.GetTargetType().Constructor))
-            : string.Empty;
-
+        // Derivatives are intentionally omitted here. The @derivedType decorator registers each
+        // subtype with all ancestors at decoration time, so JsonSerializer discovers them via
+        // DerivedType.getDerivedTypesFor() without any explicit imports. Emitting a derivatives
+        // list would require the parent type to import each subtype, creating circular dependencies
+        // when those subtypes extend the parent type.
         return new(
             propertyType,
             name,
@@ -90,7 +90,6 @@ public static class PropertyExtensions
             isEnumerable,
             isNullable,
             propertyType.IsAPrimitiveType(),
-            documentation,
-            derivatives);
+            documentation);
     }
 }

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -490,18 +490,7 @@ public static class TypeExtensions
         var typesInvolved = new List<Type>();
 
         var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).ToList();
-        var propertyDescriptors = properties
-            .ConvertAll(_ => _.ToPropertyDescriptor())
-            .ConvertAll(pd =>
-            {
-                // Strip derivatives that descend from the type being generated — importing them would create a circular dependency.
-                if (string.IsNullOrEmpty(pd.Derivatives)) return pd;
-                var filtered = string.Join(", ", pd.OriginalType
-                    .GetDerivativeTypes()
-                    .Where(t => !t.IsAssignableToBaseType(type))
-                    .Select(t => t.GetTargetType().Constructor));
-                return pd with { Derivatives = filtered };
-            });
+        var propertyDescriptors = properties.ConvertAll(_ => _.ToPropertyDescriptor());
         List<ImportStatement> imports = [];
 
         foreach (var property in propertyDescriptors)

--- a/Source/JavaScript/Arc/package.json
+++ b/Source/JavaScript/Arc/package.json
@@ -64,6 +64,6 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "^7.7.3"
+        "@cratis/fundamentals": "^7.9.2"
     }
 }


### PR DESCRIPTION
## Fixed
- Proxy generator no longer emits a derivatives import list on property descriptors, eliminating circular imports when subtypes extend the parent type being generated. The `@derivedType` decorator handles subtype registration at decoration time, making the explicit list unnecessary.

## Changed
- Cratis.Chronicle* 15.22.13 → 15.25.5
- MongoDB.Driver 3.8.0 → 3.8.1
- SharpCompress 0.48.0 → 1.0.0
- Meziantou.Analyzer 3.0.70 → 3.0.78
- Microsoft.ClearScript.V8* 7.5.0 → 7.5.1
- @cratis/fundamentals ^7.7.3 → ^7.9.2