### PR TITLE
Fix command context generic event source ids

### DIFF
--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandContextExtensions/when_checking_has_event_source_id/with_subclass_of_generic_event_source_id_in_response.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandContextExtensions/when_checking_has_event_source_id/with_subclass_of_generic_event_source_id_in_response.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandContextExtensions.when_checking_has_event_source_id;
+
+public class with_subclass_of_generic_event_source_id_in_response : given.a_command_context
+{
+    bool _result;
+
+    void Establish() => _commandContext = _commandContext with { Response = new TypedId(Guid.NewGuid()) };
+
+    void Because() => _result = _commandContext.HasEventSourceId();
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+
+    record TypedId(Guid Value) : EventSourceId<Guid>(Value);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandContextExtensions/when_getting_event_source_id/from_subclass_of_generic_event_source_id_in_response.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandContextExtensions/when_getting_event_source_id/from_subclass_of_generic_event_source_id_in_response.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandContextExtensions.when_getting_event_source_id;
+
+public class from_subclass_of_generic_event_source_id_in_response : given.a_command_context
+{
+    TypedId _typedEventSourceId;
+    EventSourceId _result;
+
+    void Establish()
+    {
+        _typedEventSourceId = new(Guid.NewGuid());
+        _commandContext = _commandContext with { Response = _typedEventSourceId };
+    }
+
+    void Because() => _result = _commandContext.GetEventSourceId();
+
+    [Fact] void should_return_the_event_source_id_from_response() => _result.ShouldEqual((EventSourceId)_typedEventSourceId);
+
+    record TypedId(Guid Value) : EventSourceId<Guid>(Value);
+}

--- a/Source/DotNET/Chronicle/Commands/CommandContextExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/CommandContextExtensions.cs
@@ -18,7 +18,7 @@ public static class CommandContextExtensions
     /// <param name="commandContext">The command context to check.</param>
     /// <returns>True if the command context has an event source id, false otherwise.</returns>
     public static bool HasEventSourceId(this CommandContext commandContext) =>
-        commandContext.Response is EventSourceId ||
+        (commandContext.Response is not null && EventSourceExtensions.IsEventSourceIdValue(commandContext.Response)) ||
         (commandContext.Values.TryGetValue(WellKnownCommandContextKeys.EventSourceId, out var value) && value is EventSourceId);
 
     /// <summary>
@@ -29,9 +29,9 @@ public static class CommandContextExtensions
     /// <exception cref="MissingEventSourceIdInCommandContext">Thrown when the event source id is missing in the command context.</exception>
     public static EventSourceId GetEventSourceId(this CommandContext commandContext)
     {
-        if (commandContext.Response is EventSourceId eventSourceIdResponse)
+        if (commandContext.Response is not null && EventSourceExtensions.IsEventSourceIdValue(commandContext.Response))
         {
-            return eventSourceIdResponse;
+            return EventSourceExtensions.ToEventSourceId(commandContext.Response);
         }
 
         if (commandContext.Values.TryGetValue(WellKnownCommandContextKeys.EventSourceId, out var value) && value is EventSourceId eventSourceId)

--- a/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
@@ -88,17 +88,20 @@ public static class EventSourceExtensions
         return eventSourceId;
     }
 
-    static bool IsGenericEventSourceIdType(Type? type)
-    {
-        if (type is null) return false;
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEventSourceIdDefinition) return true;
-        return IsGenericEventSourceIdType(type.BaseType);
-    }
-
-    static bool IsEventSourceIdValue(object? value) =>
+    /// <summary>
+    /// Determines whether the given value is an <see cref="EventSourceId"/> or a generic <see cref="EventSourceId{T}"/> subtype.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns>True if the value is an event source ID; otherwise, false.</returns>
+    internal static bool IsEventSourceIdValue(object? value) =>
         value is EventSourceId || (value is not null && IsGenericEventSourceIdType(value.GetType()));
 
-    static EventSourceId ToEventSourceId(object value)
+    /// <summary>
+    /// Converts a value to an <see cref="EventSourceId"/>, handling direct instances, generic <see cref="EventSourceId{T}"/> subtypes via their implicit operator, and falling back to <see cref="object.ToString"/>.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>The corresponding <see cref="EventSourceId"/>.</returns>
+    internal static EventSourceId ToEventSourceId(object value)
     {
         if (value is EventSourceId esId)
         {
@@ -125,5 +128,12 @@ public static class EventSourceExtensions
         }
 
         return value.ToString()!;
+    }
+
+    static bool IsGenericEventSourceIdType(Type? type)
+    {
+        if (type is null) return false;
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == _genericEventSourceIdDefinition) return true;
+        return IsGenericEventSourceIdType(type.BaseType);
     }
 }


### PR DESCRIPTION
## Fixed
- Preserve event source IDs when command responses return generic `EventSourceId<T>` values.
- Add regression specs for command context event source ID detection and conversion from generic response values.
