### PR TITLE
Add trace logging for read model interceptor

### DIFF
--- a/Source/DotNET/Chronicle/ReadModels/ReadModelInterceptor.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelInterceptor.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Arc.Queries;
 using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Chronicle.ReadModels;
 
@@ -11,8 +12,18 @@ namespace Cratis.Arc.Chronicle.ReadModels;
 /// </summary>
 /// <typeparam name="TReadModel">Type of read model to intercept.</typeparam>
 /// <param name="readModels">The <see cref="IReadModels"/> used to release (decrypt) encrypted PII properties.</param>
-public class ReadModelInterceptor<TReadModel>(IReadModels readModels) : IInterceptReadModel<TReadModel>
+/// <param name="logger">The <see cref="ILogger"/> used for diagnostics.</param>
+public class ReadModelInterceptor<TReadModel>(IReadModels readModels, ILogger<ReadModelInterceptor<TReadModel>> logger) : IInterceptReadModel<TReadModel>
 {
     /// <inheritdoc/>
-    public Task<TReadModel> Intercept(TReadModel readModel) => readModels.Release(readModel);
+    public async Task<TReadModel> Intercept(TReadModel readModel)
+    {
+        logger.InterceptingReadModel(typeof(TReadModel).FullName ?? typeof(TReadModel).Name);
+
+        var releasedReadModel = await readModels.Release(readModel);
+
+        logger.InterceptedReadModel(typeof(TReadModel).FullName ?? typeof(TReadModel).Name);
+
+        return releasedReadModel;
+    }
 }

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelInterceptorLogging.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelInterceptorLogging.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Chronicle.ReadModels;
+
+internal static partial class ReadModelInterceptorLogging
+{
+    [LoggerMessage(LogLevel.Trace, "Intercepting read model release for type '{ReadModelType}'")]
+    internal static partial void InterceptingReadModel(this ILogger logger, string readModelType);
+
+    [LoggerMessage(LogLevel.Trace, "Intercepted read model release for type '{ReadModelType}'")]
+    internal static partial void InterceptedReadModel(this ILogger logger, string readModelType);
+}


### PR DESCRIPTION
## Changed
- Add trace-level start/end logging around read model release interception in Chronicle.