### PR TITLE
Fix FluentValidationFilter to traverse collection elements during validation

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_collection_properties.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_collection_properties.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentValidation;
-
 namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
 
 public class with_collection_properties : given.a_fluent_validation_filter
@@ -15,9 +13,6 @@ public class with_collection_properties : given.a_fluent_validation_filter
         var items = new[] { new Item("Item1"), new Item("Item2") };
         _command = new CommandWithCollection("CommandName", items);
         _context = new CommandContext(_correlationId, typeof(CommandWithCollection), _command, [], new());
-
-        // No validators found for any type
-        _discoverableValidators.TryGet(Arg.Any<Type>(), out Arg.Any<IValidator>()).Returns(false);
     }
 
     async Task Because() => _result = await _filter.OnExecution(_context);
@@ -28,8 +23,6 @@ public class with_collection_properties : given.a_fluent_validation_filter
     [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
     [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
     [Fact] void should_not_have_validation_results() => _result.ValidationResults.ShouldBeEmpty();
-    [Fact] void should_attempt_to_get_validator_for_command() => _discoverableValidators.Received(1).TryGet(typeof(CommandWithCollection), out Arg.Any<IValidator>());
-    [Fact] void should_attempt_to_get_validator_for_array() => _discoverableValidators.Received(1).TryGet(typeof(Item[]), out Arg.Any<IValidator>());
 
     record CommandWithCollection(string Name, Item[] Items);
     record Item(string Name);

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_as_direct_property.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_as_direct_property.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_concept_as_direct_property : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new CommandWithConcept(new Rate(decimal.Zero));
+        _context = new CommandContext(_correlationId, typeof(CommandWithConcept), command, [], new());
+
+        var rateValidator = new RateValidator();
+        _discoverableValidators.TryGet(typeof(Rate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = rateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_surface_the_concept_validation_error() =>
+        _result.ValidationResults.ShouldContain(vr => vr.Message == "Rate must be positive");
+
+    record Rate(decimal Value) : ConceptAs<decimal>(Value);
+    record CommandWithConcept(Rate Rate);
+
+    class RateValidator : ConceptValidator<Rate>
+    {
+        public RateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_as_property_on_nested_record.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_as_property_on_nested_record.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_concept_as_property_on_nested_record : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new CommandWithNestedConcept(new NestedRecord(new HourlyRate(50m)));
+        _context = new CommandContext(_correlationId, typeof(CommandWithNestedConcept), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_have_no_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record NestedRecord(HourlyRate Rate);
+    record CommandWithNestedConcept(NestedRecord Nested);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_validator_failing_on_nested_record.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_concept_validator_failing_on_nested_record.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_concept_validator_failing_on_nested_record : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new CommandWithNestedConcept(new NestedRecord(new HourlyRate(decimal.Zero)));
+        _context = new CommandContext(_correlationId, typeof(CommandWithNestedConcept), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_have_one_validation_result() => _result.ValidationResults.Count().ShouldEqual(1);
+    [Fact] void should_surface_the_concept_error_message() =>
+        _result.ValidationResults.ShouldContain(vr => vr.Message == "Hourly rate must be positive");
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record NestedRecord(HourlyRate Rate);
+    record CommandWithNestedConcept(NestedRecord Nested);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_invalid_concept_inside_array_of_nested_records.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_invalid_concept_inside_array_of_nested_records.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_invalid_concept_inside_array_of_nested_records : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new SendCommand([new CandidateSend(new HourlyRate(decimal.Zero))]);
+        _context = new CommandContext(_correlationId, typeof(SendCommand), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_surface_the_concept_validation_error() =>
+        _result.ValidationResults.ShouldContain(vr => vr.Message == "Hourly rate must be positive");
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record CandidateSend(HourlyRate CustomerHourlyRate);
+    record SendCommand(CandidateSend[] Candidates);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_list_of_nested_records_containing_invalid_concept.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_list_of_nested_records_containing_invalid_concept.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_list_of_nested_records_containing_invalid_concept : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new SendCommand([new CandidateSend(new HourlyRate(decimal.Zero))]);
+        _context = new CommandContext(_correlationId, typeof(SendCommand), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_surface_the_concept_validation_error() =>
+        _result.ValidationResults.ShouldContain(vr => vr.Message == "Hourly rate must be positive");
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record CandidateSend(HourlyRate CustomerHourlyRate);
+    record SendCommand(List<CandidateSend> Candidates);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_multiple_invalid_concepts_in_array.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_multiple_invalid_concepts_in_array.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_multiple_invalid_concepts_in_array : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new SendCommand([
+            new CandidateSend(new HourlyRate(decimal.Zero)),
+            new CandidateSend(new HourlyRate(decimal.Zero))
+        ]);
+        _context = new CommandContext(_correlationId, typeof(SendCommand), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_surface_an_error_for_each_invalid_concept() =>
+        _result.ValidationResults.Count().ShouldEqual(2);
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record CandidateSend(HourlyRate CustomerHourlyRate);
+    record SendCommand(CandidateSend[] Candidates);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_null_element_in_array.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_null_element_in_array.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_null_element_in_array : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new SendCommand([null, new CandidateSend(new HourlyRate(50m))]);
+        _context = new CommandContext(_correlationId, typeof(SendCommand), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_have_no_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record CandidateSend(HourlyRate CustomerHourlyRate);
+    record SendCommand(CandidateSend?[] Candidates);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_valid_concepts_in_array.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_valid_concepts_in_array.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_valid_concepts_in_array : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new SendCommand([
+            new CandidateSend(new HourlyRate(50m)),
+            new CandidateSend(new HourlyRate(100m))
+        ]);
+        _context = new CommandContext(_correlationId, typeof(SendCommand), command, [], new());
+
+        var hourlyRateValidator = new HourlyRateValidator();
+        _discoverableValidators.TryGet(typeof(HourlyRate), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = hourlyRateValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_have_no_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+
+    record HourlyRate(decimal Value) : ConceptAs<decimal>(Value);
+    record CandidateSend(HourlyRate CustomerHourlyRate);
+    record SendCommand(CandidateSend[] Candidates);
+
+    class HourlyRateValidator : ConceptValidator<HourlyRate>
+    {
+        public HourlyRateValidator() =>
+            RuleFor(x => x.Value).GreaterThan(0m).WithMessage("Hourly rate must be positive");
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -55,16 +55,25 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
             instanceType != typeof(DateTime) &&
             instanceType != typeof(DateTimeOffset) &&
             instanceType != typeof(Guid) &&
-            instanceType != typeof(decimal) &&
-            !instanceType.IsArray &&
-            !typeof(System.Collections.IEnumerable).IsAssignableFrom(instanceType))
+            instanceType != typeof(decimal))
         {
-            foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            if (instanceType.IsArray || typeof(System.Collections.IEnumerable).IsAssignableFrom(instanceType))
             {
-                var propertyValue = property.GetValue(instance);
-                if (propertyValue is not null)
+                foreach (var element in (System.Collections.IEnumerable)instance)
                 {
-                    commandResult.MergeWith(await Validate(context, propertyValue));
+                    if (element is null) continue;
+                    commandResult.MergeWith(await Validate(context, element));
+                }
+            }
+            else
+            {
+                foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    var propertyValue = property.GetValue(instance);
+                    if (propertyValue is not null)
+                    {
+                        commandResult.MergeWith(await Validate(context, propertyValue));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Fixed

- `ConceptValidator<T>` rules on types nested inside array or `IEnumerable` collection properties are now correctly applied by `FluentValidationFilter`. Previously, traversal stopped at the collection itself so validators on element types were silently skipped.