### PR TITLE
Fix concept query rewriting for rebuilt unary expressions

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -23,7 +23,7 @@ on:
         - info
         - warning
         - debug
-  pull_request:
+  pull_request_target:
     branches:
       - "**"
     paths:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,7 +12,7 @@ env:
   DOTNET10_VERSION: "10.0.x"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
     branches:
       - "**"

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/ProductTypes.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/ProductTypes.cs
@@ -25,12 +25,20 @@ public record ProductName(string Value) : ConceptAs<string>(Value)
     public static implicit operator ProductName(string value) => new(value);
 }
 
+public record ProductSequenceNumber(ulong Value) : ConceptAs<ulong>(Value)
+{
+    public static readonly ProductSequenceNumber First = new(0UL);
+    public static implicit operator ProductSequenceNumber(ulong value) => new(value);
+    public static implicit operator ulong(ProductSequenceNumber sn) => sn.Value;
+}
+
 public class Product
 {
     public ProductId Id { get; set; } = ProductId.NotSet;
     public ProductCode Code { get; set; } = null!;
     public ProductName Name { get; set; } = null!;
     public decimal Price { get; set; }
+    public ProductSequenceNumber ProductSequenceNumber { get; set; } = ProductSequenceNumber.First;
 }
 
 public record CategoryId(Guid Value) : ConceptAs<Guid>(Value)
@@ -70,6 +78,9 @@ public class ProductDbContext(DbContextOptions<ProductDbContext> options) : DbCo
                 entity.Property(e => e.Name).IsRequired().HasConversion(
                     v => v.Value,
                     v => new ProductName(v));
+                entity.Property(e => e.ProductSequenceNumber).HasConversion(
+                    v => v.Value,
+                    v => new ProductSequenceNumber(v));
             })
             .Entity<Category>(entity =>
             {

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_int_concept_range_comparison.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_int_concept_range_comparison.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Arc.EntityFrameworkCore.Concepts.for_querying_with_concepts;
+
+[Collection(nameof(ConceptAsQueryingCollection))]
+public class when_querying_with_int_concept_range_comparison : given.a_test_database
+{
+    Product _first;
+    Product _second;
+    Product _third;
+    ProductCode _minCode;
+    IEnumerable<Product> _result = [];
+
+    async Task Establish()
+    {
+        _minCode = new ProductCode(200);
+        _first = new Product { Id = ProductId.New(), Code = new ProductCode(100), Name = new ProductName("First") };
+        _second = new Product { Id = ProductId.New(), Code = new ProductCode(200), Name = new ProductName("Second") };
+        _third = new Product { Id = ProductId.New(), Code = new ProductCode(300), Name = new ProductName("Third") };
+        await _context.Products.AddRangeAsync(_first, _second, _third);
+        await _context.SaveChangesAsync();
+    }
+
+    async Task Because() => _result = await _context.Products
+        .Where(p => p.Code >= _minCode)
+        .ToListAsync();
+
+    [Fact] void should_return_two_products() => _result.Count().ShouldEqual(2);
+    [Fact] void should_not_include_the_first_product() => _result.ShouldNotContain(p => p.Code == _first.Code);
+    [Fact] void should_include_the_second_product() => _result.ShouldContain(p => p.Code == _second.Code);
+    [Fact] void should_include_the_third_product() => _result.ShouldContain(p => p.Code == _third.Code);
+}

--- a/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_ulong_concept_equality.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Concepts/for_querying_with_concepts/when_querying_with_ulong_concept_equality.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Arc.EntityFrameworkCore.Concepts.for_querying_with_concepts;
+
+[Collection(nameof(ConceptAsQueryingCollection))]
+public class when_querying_with_ulong_concept_equality : given.a_test_database
+{
+    Product _product;
+    ProductSequenceNumber _targetSequence;
+    Product? _result;
+
+    async Task Establish()
+    {
+        _targetSequence = new ProductSequenceNumber(1UL);
+        _product = new Product { Id = ProductId.New(), Code = new ProductCode(42), Name = new ProductName("Test"), ProductSequenceNumber = _targetSequence };
+        await _context.Products.AddAsync(_product);
+        await _context.SaveChangesAsync();
+    }
+
+    async Task Because() => _result = await _context.Products
+        .Where(p => p.ProductSequenceNumber == _targetSequence)
+        .FirstOrDefaultAsync();
+
+    [Fact] void should_find_the_product() => _result.ShouldNotBeNull();
+    [Fact] void should_have_correct_sequence_number() => _result!.ProductSequenceNumber.Value.ShouldEqual(1UL);
+}

--- a/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsExpressionRewriter.cs
+++ b/Source/DotNET/EntityFrameworkCore/Concepts/ConceptAsExpressionRewriter.cs
@@ -109,7 +109,17 @@ public class ConceptAsExpressionRewriter : ExpressionVisitor
 
         if (visitedOperand != node.Operand)
         {
-            return Expression.MakeUnary(node.NodeType, visitedOperand, node.Type, node.Method);
+            var method = node.Method;
+            if (method is not null)
+            {
+                var parameters = method.GetParameters();
+                if (parameters.Length > 0 && parameters[0].ParameterType != visitedOperand.Type)
+                {
+                    method = null;
+                }
+            }
+
+            return Expression.MakeUnary(node.NodeType, visitedOperand, node.Type, method);
         }
 
         return base.VisitUnary(node);


### PR DESCRIPTION
## Fixed
- Fix Entity Framework Core concept queries when rebuilt unary expressions would otherwise preserve an incompatible conversion method.
- Add regression coverage for int-backed range comparisons and ulong-backed equality filters in concept queries.