### PR TITLE
Stop leaking ProxyGenerator.Build reference into Cratis assembly

### DIFF
--- a/Source/DotNET/Cratis/Cratis.csproj
+++ b/Source/DotNET/Cratis/Cratis.csproj
@@ -13,7 +13,7 @@
         <ProjectReference Include="../Arc/Arc.csproj" />
         <ProjectReference Include="../Chronicle/Chronicle.csproj" />
         <ProjectReference Include="../Swagger/Swagger.csproj" />
-        <ProjectReference Include="../Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj" />
+        <ProjectReference Include="../Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj" ReferenceOutputAssembly="false" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Cratis.Chronicle.AspNetCore" />


### PR DESCRIPTION
## Fixed
- Cratis NuGet package no longer leaks the build-tool assembly `Cratis.Arc.ProxyGenerator.Build` as a compile-time reference, fixing runtime `FileNotFoundException` in consumer apps where Fundamentals' source-generated `GeneratedTypeDiscoveryProvider.SelfBindings` referenced types from that assembly.