### PR TITLE
Adding missing subdomain resolver for service registration

### DIFF
--- a/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
+++ b/Source/DotNET/Arc.Core/HostBuilderExtensions.cs
@@ -87,6 +87,7 @@ public static class HostBuilderExtensions
             var options = sp.GetRequiredService<IOptions<ArcOptions>>();
             return options.Value.Tenancy.ResolverType switch
             {
+                TenantResolverType.Subdomain => ActivatorUtilities.GetServiceOrCreateInstance<SubdomainTenantIdResolver>(sp),
                 TenantResolverType.Header => ActivatorUtilities.GetServiceOrCreateInstance<HeaderTenantIdResolver>(sp),
                 TenantResolverType.Query => ActivatorUtilities.GetServiceOrCreateInstance<QueryTenantIdResolver>(sp),
                 TenantResolverType.Claim => ActivatorUtilities.GetServiceOrCreateInstance<ClaimTenantIdResolver>(sp),


### PR DESCRIPTION
## Fixed

- Adding missing activation for the tenant resolver for Sub domains.
