### PR TITLE
Fix NRE in ProxyGenerator when property type implements non-generic IEnumerable

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithNonGenericEnumerableProperty.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/TypeWithNonGenericEnumerableProperty.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions;
+
+// This type intentionally implements only the non-generic IEnumerable to reproduce the bug
+// where GetEnumerableElementType() returns null for types without IEnumerable<T>.
+#pragma warning disable CA1010
+public class NonGenericEnumerable : IEnumerable
+#pragma warning restore CA1010
+{
+    public IEnumerator GetEnumerator() => throw new NotSupportedException();
+}
+
+public class TypeWithNonGenericEnumerableProperty
+{
+    public NonGenericEnumerable Items { get; set; } = new();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_non_generic_enumerable_property.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_PropertyExtensions/when_converting_property_to_descriptor/with_non_generic_enumerable_property.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_PropertyExtensions.when_converting_property_to_descriptor;
+
+public class with_non_generic_enumerable_property : Specification
+{
+    PropertyInfo _property = null!;
+    Exception _error = null!;
+    PropertyDescriptor _result = null!;
+
+    void Establish() => _property = typeof(TypeWithNonGenericEnumerableProperty).GetProperty(nameof(TypeWithNonGenericEnumerableProperty.Items))!;
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _result = _property.ToPropertyDescriptor());
+    }
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_have_correct_name() => _result.Name.ShouldEqual("Items");
+    [Fact] void should_not_be_enumerable() => _result.IsEnumerable.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/PropertyExtensions.cs
@@ -70,7 +70,15 @@ public static class PropertyExtensions
             isEnumerable = propertyType.IsEnumerable();
             if (isEnumerable)
             {
-                propertyType = propertyType.GetEnumerableElementType();
+                var elementType = propertyType.GetEnumerableElementType();
+                if (elementType is null)
+                {
+                    isEnumerable = false;
+                }
+                else
+                {
+                    propertyType = elementType;
+                }
             }
         }
 

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -384,7 +384,7 @@ public static class TypeExtensions
     /// <returns>The effective element type to use for proxy generation and type collection.</returns>
     public static Type GetDictionaryEffectiveValueType(this Type valueType) =>
         valueType.IsEnumerable() && !valueType.IsDictionary()
-            ? valueType.GetEnumerableElementType()
+            ? valueType.GetEnumerableElementType() ?? valueType
             : valueType;
 
     /// <summary>


### PR DESCRIPTION
## Fixed
- ProxyGenerator no longer throws `NullReferenceException` when scanning read model types whose properties implement only the non-generic `IEnumerable` (without `IEnumerable<T>`). (#2221)