### PR TITLE
Fix runtime FileNotFoundException from ProxyGenerator.Build leak in Cratis.dll

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Cratis.Chronicle" Version="15.30.0" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.30.0" />
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.30.0" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.9.16" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.9.16" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.10.3" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.10.3" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
@@ -41,8 +41,8 @@
     <PackageVersion Include="castle.core" Version="5.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.6.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="snappier" Version="1.3.1" />
     <!-- Roslyn-->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
@@ -56,7 +56,7 @@
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.85" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.93" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Source/DotNET/Cratis/Cratis.csproj
+++ b/Source/DotNET/Cratis/Cratis.csproj
@@ -14,7 +14,13 @@
         <ProjectReference Include="../Arc/Arc.csproj" />
         <ProjectReference Include="../Chronicle/Chronicle.csproj" />
         <ProjectReference Include="../Swagger/Swagger.csproj" />
-        <ProjectReference Include="../Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj" />
+        <!-- Hides the build-time tool from the global namespace of Cratis.dll's compilation while
+             preserving its package dependency in the published nuspec. Without an alias, the type-discovery
+             source generator bakes typeof() references to the build helper's public types into the published
+             Cratis.dll, which then fail with FileNotFoundException at runtime in consuming applications
+             because the build helper's DLL is not deployed to the runtime output. -->
+        <ProjectReference Include="../Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj"
+                          Aliases="ProxyGeneratorBuild" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Cratis.Chronicle.AspNetCore" />


### PR DESCRIPTION
## Fixed
- `Cratis.dll` no longer leaks `typeof()` references to the build-time `ProxyGenerator.Build` helper, which caused `FileNotFoundException` at runtime in consuming applications.

## Changed
- Bumped `Cratis.Fundamentals` and `Cratis.Metrics.Roslyn` from `7.9.16` to `7.10.3`.
- Bumped `Testcontainers.MsSql` and `Testcontainers.PostgreSql` from `4.11.0` to `4.12.0`.
- Bumped `Meziantou.Analyzer` from `3.0.85` to `3.0.93`.