### PR TITLE
Upgrading Chronicle

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.30.0" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.30.0" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.30.0" />
+    <PackageVersion Include="Cratis.Chronicle" Version="15.31.2" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.31.2" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.31.2" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.10.3" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.10.3" />
     <!-- MAUI -->


### PR DESCRIPTION
## Fixed

- Upgrading Chronicle with fixes for .NET8/9/10 differentiation on versions for some `Microsoft.Extensions.*` packages
