### PR TITLE
Fix DialogWrapper remount on every parent render in useDialog

### DIFF
--- a/Source/JavaScript/Arc.React/dialogs/useDialog.tsx
+++ b/Source/JavaScript/Arc.React/dialogs/useDialog.tsx
@@ -4,13 +4,13 @@
 import { DialogContext, DialogContextContent } from './DialogContext';
 import { DialogResponse } from './DialogResponse';
 import { DialogResult } from './DialogResult';
-import { useCallback, useRef, useState, ComponentType, FC, useMemo } from 'react';
+import { useCallback, useRef, useState, ComponentType, FC, ReactElement, useMemo } from 'react';
 import { ShowDialog } from './ShowDialog';
 
 /**
  * Use a dialog component in you application. This hook manages the visibility and properties of the dialog.
  * @param DialogComponent The dialog component to use.
- * @returns A tuple containing the wrapped dialog component and a function to show the dialog. 
+ * @returns A tuple containing the wrapped dialog component and a function to show the dialog.
  * The wrapped dialog component will receive the properties passed to it, excluding the `closeDialog` property.
  */
 export function useDialog<TResponse = object, TProps = object>(
@@ -40,16 +40,28 @@ export function useDialog<TResponse = object, TProps = object>(
         return new DialogContextContent(dialogProps!, closeDialog);
     }, [dialogProps, closeDialog]);
 
-    const DialogWrapper: FC<TProps> = (extraProps) => {
-        return visible ? (
+    // Capture the latest render in a ref so DialogWrapper's identity stays stable across renders
+    // while still reflecting current state. Without this, every parent re-render produced a fresh
+    // DialogWrapper function — React would treat each render as a new component type and unmount
+    // the dialog subtree on every render, which caused PrimeReact (and other portal-based dialogs)
+    // to leak portals or visibly remount on each parent update.
+    const renderRef = useRef<(extraProps: TProps) => ReactElement | null>(() => null);
+    renderRef.current = (extraProps: TProps) => visible
+        ? (
             <DialogContext.Provider value={dialogContextValue.current as unknown as DialogContextContent<object, object>}>
                 <DialogComponent
                     {...extraProps}
                     {...(dialogProps as TProps)}
                     closeDialog={closeDialog} />
             </DialogContext.Provider>
-        ) : null;
-    };
+        )
+        : null;
+
+    const DialogWrapper = useMemo<FC<TProps>>(() => {
+        const Component: FC<TProps> = (extraProps) => renderRef.current(extraProps);
+        Component.displayName = `DialogWrapper(${DialogComponent.displayName ?? DialogComponent.name ?? 'Anonymous'})`;
+        return Component;
+    }, [DialogComponent]);
 
     return [DialogWrapper, showDialog, dialogContextValue.current];
 }


### PR DESCRIPTION
## Fixed
- Dialogs created via `useDialog` no longer remount on every render of the hosting component. The wrapper component now has a stable identity, preventing portal leaks and visible remounts with PrimeReact and other portal-based dialogs.