### PR TITLE
Add useOnMessage and useSendMessage React messenger hooks

### DIFF
--- a/Documentation/frontend/react/messaging.md
+++ b/Documentation/frontend/react/messaging.md
@@ -14,6 +14,66 @@ export const Details = () => {
 };
 ```
 
+## Subscribing — `useOnMessage`
+
+`useOnMessage` subscribes to messages of a given type from the nearest messenger for
+the lifetime of the component. The subscription is cleaned up automatically on unmount,
+and the callback does not need to be wrapped in `useCallback` — the latest reference is
+always invoked.
+
+```tsx
+import { useOnMessage } from '@cratis/arc.react/messaging';
+
+class UserSelected {
+    constructor(readonly userId: string) {
+    }
+}
+
+export const UserDetails = () => {
+    useOnMessage(UserSelected, message => {
+        console.log('Selected user:', message.userId);
+    });
+    return null;
+};
+```
+
+### Filtering
+
+An optional filter narrows on message content without re-subscribing. The filter receives
+the actual typed message and tells the hook whether the consumer is interested:
+
+```tsx
+useOnMessage(
+    UserSelected,
+    message => console.log('Selected admin:', message.userId),
+    message => message.role === 'admin'
+);
+```
+
+## Publishing — `useSendMessage`
+
+`useSendMessage` returns a stable function that publishes to the nearest messenger.
+Use it when a component needs to send messages without holding a reference to the
+messenger itself:
+
+```tsx
+import { useSendMessage } from '@cratis/arc.react/messaging';
+
+class UserSelected {
+    constructor(readonly userId: string) {
+    }
+}
+
+export const UserList = () => {
+    const send = useSendMessage();
+    return (
+        <button onClick={() => send(new UserSelected('42'))}>
+            Select user
+        </button>
+    );
+};
+```
+
 ## Scoped messenger hierarchy
 
 Use `<MessengerScope>` to create a nested messenger:
@@ -29,7 +89,8 @@ export const Page = () => (
 );
 ```
 
-`useMessenger()` resolves the nearest scope first, then falls back to the Arc root messenger.
+`useMessenger()`, `useOnMessage`, and `useSendMessage` all resolve the nearest scope
+first, then fall back to the Arc root messenger.
 
 By default:
 

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_callback_changes_between_renders.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_callback_changes_between_renders.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useState } from 'react';
+import { act, render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when callback changes between renders', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let firstReceived: MessageToSend[];
+    let secondReceived: MessageToSend[];
+    let triggerRerender: () => void;
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        firstReceived = [];
+        secondReceived = [];
+
+        const Subscriber = () => {
+            const [version, setVersion] = useState(0);
+            triggerRerender = () => setVersion(v => v + 1);
+            const callback = version === 0
+                ? (message: MessageToSend) => firstReceived.push(message)
+                : (message: MessageToSend) => secondReceived.push(message);
+            useOnMessage(MessageToSend, callback);
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Subscriber />
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new MessageToSend('first'));
+        act(() => triggerRerender());
+        rootMessenger.publish(new MessageToSend('second'));
+    });
+
+    it('should invoke the initial callback while it is current', () => {
+        firstReceived.length.should.equal(1);
+        firstReceived[0].content.should.equal('first');
+    });
+
+    it('should invoke the latest callback after a re-render without re-subscribing', () => {
+        secondReceived.length.should.equal(1);
+        secondReceived[0].content.should.equal('second');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_component_unmounts.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_component_unmounts.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when component unmounts', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+
+        const Subscriber = () => {
+            useOnMessage(MessageToSend, message => received.push(message));
+            return null;
+        };
+
+        const result = render(
+            <ArcContext.Provider value={rootConfig}>
+                <Subscriber />
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new MessageToSend('before unmount'));
+        result.unmount();
+        rootMessenger.publish(new MessageToSend('after unmount'));
+    });
+
+    it('should receive messages published before unmount', () => {
+        received.length.should.equal(1);
+    });
+
+    it('should not receive messages after unmount', () => {
+        received[0].content.should.equal('before unmount');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_filter_rejects_message.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_filter_rejects_message.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when filter rejects message', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+    let filteredArguments: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+        filteredArguments = [];
+
+        const Subscriber = () => {
+            useOnMessage(
+                MessageToSend,
+                message => received.push(message),
+                message => {
+                    filteredArguments.push(message);
+                    return message.content === 'wanted';
+                }
+            );
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Subscriber />
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new MessageToSend('unwanted'));
+        rootMessenger.publish(new MessageToSend('wanted'));
+    });
+
+    it('should call filter for every published message of the type', () => {
+        filteredArguments.length.should.equal(2);
+    });
+
+    it('should pass the typed message into the filter', () => {
+        filteredArguments[0].content.should.equal('unwanted');
+        filteredArguments[1].content.should.equal('wanted');
+    });
+
+    it('should only invoke callback for messages the filter accepts', () => {
+        received.length.should.equal(1);
+        received[0].content.should.equal('wanted');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_publishing_matching_message.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_publishing_matching_message.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when publishing matching message', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+
+        const Subscriber = () => {
+            useOnMessage(MessageToSend, message => received.push(message));
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Subscriber />
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new MessageToSend('forty two'));
+    });
+
+    it('should invoke callback with the message', () => {
+        received.length.should.equal(1);
+    });
+
+    it('should pass the published message content through', () => {
+        received[0].content.should.equal('forty two');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_publishing_message_of_different_type.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_publishing_message_of_different_type.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+class UnrelatedMessage {
+    constructor(readonly value: number) {
+    }
+}
+
+describe('when publishing message of different type', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+
+        const Subscriber = () => {
+            useOnMessage(MessageToSend, message => received.push(message));
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Subscriber />
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new UnrelatedMessage(42));
+    });
+
+    it('should not invoke callback for non-matching type', () => {
+        received.length.should.equal(0);
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_used_within_scope.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useOnMessage/when_used_within_scope.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { MessengerScope } from '../MessengerScope';
+import { useOnMessage } from '../useOnMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when used within scope', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+
+        const Subscriber = () => {
+            useOnMessage(MessageToSend, message => received.push(message));
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <MessengerScope>
+                    <Subscriber />
+                </MessengerScope>
+            </ArcContext.Provider>
+        );
+
+        rootMessenger.publish(new MessageToSend('from root'));
+    });
+
+    it('should receive messages trickled down from the root messenger', () => {
+        received.length.should.equal(1);
+        received[0].content.should.equal('from root');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_messenger_is_unchanged.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_messenger_is_unchanged.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React, { useState } from 'react';
+import { act, render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useSendMessage } from '../useSendMessage';
+
+describe('when messenger is unchanged across renders', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let captured: Array<(message: object) => void>;
+    let triggerRerender: () => void;
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        captured = [];
+
+        const Sender = () => {
+            const [, setVersion] = useState(0);
+            triggerRerender = () => setVersion(v => v + 1);
+            const send = useSendMessage();
+            captured.push(send);
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Sender />
+            </ArcContext.Provider>
+        );
+
+        act(() => triggerRerender());
+    });
+
+    it('should return the same function reference across renders', () => {
+        captured.length.should.be.greaterThan(1);
+        captured[0].should.equal(captured[captured.length - 1]);
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_sending_from_within_scope.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_sending_from_within_scope.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { MessengerScope } from '../MessengerScope';
+import { useMessenger } from '../useMessenger';
+import { useSendMessage } from '../useSendMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when sending from within scope', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let receivedAtRoot: MessageToSend[];
+    let receivedAtScope: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        receivedAtRoot = [];
+        receivedAtScope = [];
+
+        rootMessenger.subscribe(MessageToSend, message => receivedAtRoot.push(message));
+
+        const ScopedSubscriber = () => {
+            const messenger = useMessenger();
+            messenger.subscribe(MessageToSend, message => receivedAtScope.push(message));
+            const send = useSendMessage();
+            send(new MessageToSend('scoped'));
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <MessengerScope>
+                    <ScopedSubscriber />
+                </MessengerScope>
+            </ArcContext.Provider>
+        );
+    });
+
+    it('should publish to the scope messenger', () => {
+        receivedAtScope.length.should.equal(1);
+    });
+
+    it('should not bubble to the root messenger by default', () => {
+        receivedAtRoot.length.should.equal(0);
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_sending_message.tsx
+++ b/Source/JavaScript/Arc.React/messaging/for_useSendMessage/when_sending_message.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IMessenger, Messenger } from '@cratis/arc/messaging';
+import { ArcConfiguration, ArcContext } from '../../ArcContext';
+import { useSendMessage } from '../useSendMessage';
+
+class MessageToSend {
+    constructor(readonly content: string) {
+    }
+}
+
+describe('when sending message', () => {
+    let rootMessenger: IMessenger;
+    let rootConfig: ArcConfiguration;
+    let received: MessageToSend[];
+
+    beforeEach(() => {
+        rootMessenger = new Messenger();
+        rootConfig = {
+            microservice: 'test-microservice',
+            messenger: rootMessenger
+        };
+        received = [];
+
+        rootMessenger.subscribe(MessageToSend, message => received.push(message));
+
+        const Sender = () => {
+            const send = useSendMessage();
+            send(new MessageToSend('hello'));
+            return null;
+        };
+
+        render(
+            <ArcContext.Provider value={rootConfig}>
+                <Sender />
+            </ArcContext.Provider>
+        );
+    });
+
+    it('should publish the message to the nearest messenger', () => {
+        received.length.should.equal(1);
+    });
+
+    it('should pass the message content through unchanged', () => {
+        received[0].content.should.equal('hello');
+    });
+});

--- a/Source/JavaScript/Arc.React/messaging/index.ts
+++ b/Source/JavaScript/Arc.React/messaging/index.ts
@@ -3,3 +3,5 @@
 
 export * from './MessengerScope';
 export * from './useMessenger';
+export * from './useOnMessage';
+export * from './useSendMessage';

--- a/Source/JavaScript/Arc.React/messaging/useOnMessage.ts
+++ b/Source/JavaScript/Arc.React/messaging/useOnMessage.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { useEffect, useRef } from 'react';
+import { useMessenger } from './useMessenger';
+
+/**
+ * Subscribes to messages of type {@link TMessage} from the nearest {@link MessengerScope}
+ * (or the Arc root messenger) for the lifetime of the calling component.
+ * The subscription is automatically cleaned up on unmount.
+ *
+ * The callback does not need to be wrapped in `useCallback` — a ref is used internally
+ * so stale-closure issues are avoided without forcing the caller to memoize.
+ *
+ * @param type Constructor of the message type to subscribe to.
+ * @param callback Invoked whenever a matching message is published and the filter (if any) accepts it.
+ * @param filter Optional predicate invoked with the actual typed message; only when it returns `true`
+ *               will {@link callback} be invoked. Useful for narrowing on message content
+ *               without re-subscribing.
+ */
+export const useOnMessage = <TMessage extends object>(
+    type: Constructor<TMessage>,
+    callback: (message: TMessage) => void,
+    filter?: (message: TMessage) => boolean
+): void => {
+    const messenger = useMessenger();
+    const callbackRef = useRef(callback);
+    callbackRef.current = callback;
+    const filterRef = useRef(filter);
+    filterRef.current = filter;
+
+    useEffect(() => {
+        const subscription = messenger.subscribe(type, message => {
+            if (filterRef.current && !filterRef.current(message)) {
+                return;
+            }
+            callbackRef.current(message);
+        });
+        return () => subscription.unsubscribe();
+    }, [messenger, type]);
+};

--- a/Source/JavaScript/Arc.React/messaging/useSendMessage.ts
+++ b/Source/JavaScript/Arc.React/messaging/useSendMessage.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { useMemo } from 'react';
+import { useMessenger } from './useMessenger';
+
+/**
+ * Returns a stable function for publishing messages to the nearest {@link MessengerScope}
+ * (or the Arc root messenger when no local scope is present).
+ *
+ * Use {@link useOnMessage} for subscribing inside components.
+ *
+ * @returns A function that publishes the supplied message to the resolved messenger.
+ */
+export const useSendMessage = (): (<TMessage extends object>(message: TMessage) => void) => {
+    const messenger = useMessenger();
+    return useMemo(() => messenger.publish.bind(messenger), [messenger]);
+};


### PR DESCRIPTION
## Added
- `useOnMessage` React hook that subscribes to messages of a given type from the nearest `MessengerScope`, with an optional filter predicate that receives the typed message and decides whether the consumer is interested.
- `useSendMessage` React hook that returns a stable function for publishing messages to the nearest `MessengerScope`.