### PR TITLE
Fix read model DbContext auto-registration on iOS NativeAOT

### DIFF
--- a/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
+++ b/Source/DotNET/EntityFrameworkCore/DbContextServiceCollectionExtensions.cs
@@ -108,9 +108,10 @@ public static class DbContextServiceCollectionExtensions
     /// <param name="assemblies">The assemblies to scan for DbContext types.</param>
     /// <returns>A collection of filtered DbContext types.</returns>
     static IEnumerable<Type> DiscoverAndFilterDbContextTypes<TDbContext>(Assembly[] assemblies)
-        where TDbContext : class => Types.Types.Instance
-            .FindMultiple<TDbContext>()
-            .Where(t => assemblies.Contains(t.Assembly) &&
-                       t.IsPublic &&
+        where TDbContext : class => assemblies
+            .SelectMany(a => a.GetExportedTypes())
+            .Where(t => typeof(TDbContext).IsAssignableFrom(t) &&
+                       t.IsClass &&
+                       !t.IsAbstract &&
                        !t.HasAttribute<IgnoreAutoRegistrationAttribute>());
 }


### PR DESCRIPTION
## Fixed
- Fixed read model DbContext auto-registration failing on iOS NativeAOT by scanning the provided assemblies directly instead of relying on `Types.Types.Instance` discovery (#2255).
- This regression is observed from v20.10.10, where reverted AOT safeguards exposed a `DependencyContext`-dependent discovery path that can return no DbContext types on iOS, causing startup resolution failures (#2255).
- Also prevents silent type-loss when multiple DbContext types share the same class name in different namespaces (#2255).