### PR TITLE
Add observable query diagnostics

### DIFF
--- a/Documentation/backend/introspection/queries.md
+++ b/Documentation/backend/introspection/queries.md
@@ -14,7 +14,7 @@ Each item includes:
 
 - `name`: Query name.
 - `namespace`: Namespace derived from the mapped location.
-- `route`: The resolved query route.
+- `route`: The resolved query route, built with the same route helper used by the runtime query mapper. It honors the configured route prefix and `SegmentsToSkipForRoute` value.
 - `type`: Fully qualified query type name.
 - `documentationSummary`: Summary text from type metadata when available.
 

--- a/Documentation/frontend/react/arc.md
+++ b/Documentation/frontend/react/arc.md
@@ -36,6 +36,7 @@ The `<Arc />` component provides centralized configuration for all commands and 
 | queryConnectionCount | Number | Number of observable query hub connection slots |
 | observableQueryTransferMode | `ObservableQueryTransferMode` | Transfer mode used by `useChangeStream` |
 | queryCacheRetentionMs | Number | How long (ms) to keep query data in cache after the last subscriber unmounts — defaults to `30000` |
+| observableQueryDiagnostics | `IObservableQueryDiagnostics` | Live diagnostics stream for query cache, transport, and ownership state |
 
 Example:
 
@@ -133,6 +134,12 @@ export const App = () => {
 ## Query Configuration
 
 Query-related Arc configuration (transport, direct mode, connection count, transfer mode, and headers) is documented in [Queries Configuration](./queries/configuration.md).
+
+## Observable Query Diagnostics
+
+Arc exposes a diagnostics service through `ArcContext.observableQueryDiagnostics` for tooling and internal dashboards. The service provides both a snapshot API and a live observable stream for the current query cache, transport, and ownership state.
+
+See [Observable Query Diagnostics](./queries/observable-query-diagnostics.md) for usage examples.
 
 ## HTTP Headers Callback
 

--- a/Documentation/frontend/react/queries/index.md
+++ b/Documentation/frontend/react/queries/index.md
@@ -12,6 +12,7 @@ This page is an overview of capabilities. Detailed behavior is documented on the
 | Core query usage | `use()` patterns, arguments, and `QueryResultWithState` | [Core Query Usage](./usage.md) |
 | Paging and sorting | `useWithPaging`, page/sort callbacks, and paging metadata | [Paging](./paging.md) |
 | Observable streams | Real-time subscriptions, transport selection, and direct mode | [Observable Queries](./observable-queries.md) |
+| Diagnostics | Live snapshots for cache, transport, and ownership state | [Observable Query Diagnostics](./observable-query-diagnostics.md) |
 | Suspense integration | `useSuspense()` with query boundaries and error boundaries | [Suspense Queries](./suspense-queries.md) |
 | Conditional execution | `when(condition)` patterns for safe query activation | [Conditional Queries](./conditional-queries.md) |
 | Change deltas | `useChangeStream()` and transfer-mode behavior | [Change Stream](./change-stream.md) |

--- a/Documentation/frontend/react/queries/observable-query-diagnostics.md
+++ b/Documentation/frontend/react/queries/observable-query-diagnostics.md
@@ -1,0 +1,80 @@
+# Observable Query Diagnostics
+
+Observable query diagnostics give you a live view into the query subsystem from React. They are useful when you need to build developer tools, inspect cache behavior, or show the current transport state in an internal dashboard.
+
+The diagnostics service is exposed through `ArcContext` as `observableQueryDiagnostics`. It provides two ways to read the current state:
+
+- `getSnapshot()` for a point-in-time read.
+- `snapshots$` for a live stream of updates.
+
+## What the snapshot contains
+
+Each snapshot includes:
+
+- transport configuration
+- multiplexer connection state
+- cache state and cache size
+- ownership information for hooks that opted into tracking
+- a health summary
+
+This is intentionally diagnostic data, not application state. Use it for tooling, not for rendering core business screens.
+
+## Watching snapshots from React
+
+Subscribe to `snapshots$` when you want live updates.
+
+```tsx
+import { useContext, useEffect, useState } from 'react';
+import { ArcContext } from '@cratis/arc.react';
+import { ObservableQueryDiagnosticsSnapshot } from '@cratis/arc/queries';
+
+export const QueryDiagnosticsPanel = () => {
+    const arc = useContext(ArcContext);
+    const [snapshot, setSnapshot] = useState<ObservableQueryDiagnosticsSnapshot | undefined>();
+
+    useEffect(() => {
+        const diagnostics = arc.observableQueryDiagnostics;
+        if (!diagnostics) {
+            return;
+        }
+
+        setSnapshot(diagnostics.getSnapshot());
+
+        const subscription = diagnostics.snapshots$.subscribe(setSnapshot);
+        return () => subscription.unsubscribe();
+    }, [arc.observableQueryDiagnostics]);
+
+    if (!snapshot) {
+        return <p>No diagnostics available.</p>;
+    }
+
+    return (
+        <dl>
+            <dt>Connected</dt>
+            <dd>{snapshot.health.allQueriesConnected ? 'Yes' : 'No'}</dd>
+            <dt>Tracked queries</dt>
+            <dd>{snapshot.cache.entryCount}</dd>
+            <dt>Owners</dt>
+            <dd>{Object.keys(snapshot.ownership.ownersByQueryKey).length}</dd>
+        </dl>
+    );
+};
+```
+
+## Tracking ownership
+
+The query hooks can optionally tag a cache entry with a human-readable owner label. This lets diagnostics show which component is responsible for each tracked query instance.
+
+Use the optional `owner` argument on `useQuery()` or `useObservableQuery()` when you want that metadata to appear in the snapshot.
+
+```tsx
+const [result] = useObservableQuery(MyObservableQuery, args, sorting, true, 'OrdersPage');
+```
+
+If you omit the owner, the diagnostics stream still works. You just get the connection and cache information without ownership labels.
+
+## Related pages
+
+- [Observable Queries](./observable-queries.md)
+- [Observable Query Multiplexing](./observable-query-multiplexing.md)
+- [Query Instance Caching](./query-instance-caching.md)

--- a/Documentation/frontend/react/queries/toc.yml
+++ b/Documentation/frontend/react/queries/toc.yml
@@ -8,6 +8,8 @@
   href: paging.md
 - name: Observable Queries
   href: observable-queries.md
+- name: Observable Query Diagnostics
+  href: observable-query-diagnostics.md
 - name: Suspense Queries
   href: suspense-queries.md
 - name: Conditional Queries

--- a/Source/DotNET/Arc.Core.Specs/Introspection/for_IntrospectionService/when_building_metadata/with_skipped_namespace_segments.cs
+++ b/Source/DotNET/Arc.Core.Specs/Introspection/for_IntrospectionService/when_building_metadata/with_skipped_namespace_segments.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Queries;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Introspection.for_IntrospectionService.when_building_metadata;
+
+public class with_skipped_namespace_segments : Specification
+{
+    IReadOnlyList<CommandIntrospectionMetadata> _commands = [];
+    IReadOnlyList<QueryIntrospectionMetadata> _queries = [];
+
+    void Establish()
+    {
+        var commandHandler = Substitute.For<ICommandHandler>();
+        commandHandler.Location.Returns(["Cratis", "Arc", "Features", "Orders"]);
+        commandHandler.CommandType.Returns(typeof(CreateOrder));
+        commandHandler.AllowsAnonymousAccess.Returns(true);
+
+        var queryPerformer = Substitute.For<IQueryPerformer>();
+        queryPerformer.Location.Returns(["Cratis", "Arc", "Features", "Orders"]);
+        queryPerformer.Name.Returns(new QueryName("ListOrders"));
+        queryPerformer.FullyQualifiedName.Returns(new FullyQualifiedQueryName("Cratis.Arc.Features.Orders.ListOrders"));
+        queryPerformer.Type.Returns(typeof(ListOrders));
+        queryPerformer.ReadModelType.Returns(typeof(object));
+        queryPerformer.Parameters.Returns(QueryParameters.Empty);
+        queryPerformer.AllowsAnonymousAccess.Returns(true);
+        queryPerformer.SupportsPaging.Returns(false);
+
+        var commandProviders = Substitute.For<ICommandHandlerProviders>();
+        commandProviders.Handlers.Returns([commandHandler]);
+
+        var queryProviders = Substitute.For<IQueryPerformerProviders>();
+        queryProviders.Performers.Returns([queryPerformer]);
+
+        var options = Options.Create(new ApiEndpointOptions
+        {
+            RoutePrefix = "api",
+            SegmentsToSkipForRoute = 2,
+            IncludeCommandNameInRoute = true,
+            IncludeQueryNameInRoute = false,
+        });
+
+        var service = new IntrospectionService(commandProviders, queryProviders, options);
+
+        _commands = service.Commands;
+        _queries = service.Queries;
+    }
+
+    [Fact] void should_build_command_route_using_skipped_namespace_segments() => _commands.Single().Route.ShouldEqual("/api/features/orders/create-order");
+    [Fact] void should_build_query_route_using_skipped_namespace_segments() => _queries.Single().Route.ShouldEqual("/api/features/orders");
+
+    public record CreateOrder;
+    public record ListOrders;
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
@@ -37,7 +37,7 @@ public static class CommandEndpointMapper
                 options.IncludeCommandNameInRoute,
                 location,
                 handlersByNamespace);
-            var url = EndpointRouteHelper.BuildRouteUrl(options, location, handler.CommandType.Name, includeCommandName);
+            var url = EndpointRouteHelper.BuildRouteUrl(options, handler.Location, options.SegmentsToSkipForRoute, handler.CommandType.Name, includeCommandName);
 
             MapCommandEndpoint(
                 mapper,

--- a/Source/DotNET/Arc.Core/Http/EndpointRouteHelper.cs
+++ b/Source/DotNET/Arc.Core/Http/EndpointRouteHelper.cs
@@ -15,6 +15,7 @@ public static class EndpointRouteHelper
     /// </summary>
     /// <param name="options">The <see cref="ApiEndpointOptions"/>.</param>
     /// <param name="location">The namespace segments for the endpoint.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
     /// <param name="endpointName">The name of the endpoint (command type name or query name).</param>
     /// <param name="includeNameInRoute">Whether to include the endpoint name as the last route segment.</param>
     /// <returns>A sanitized, kebab-cased, lowercase route URL.</returns>
@@ -22,11 +23,12 @@ public static class EndpointRouteHelper
     public static string BuildRouteUrl(
         ApiEndpointOptions options,
         IEnumerable<string> location,
+        int segmentsToSkip,
         string endpointName,
         bool includeNameInRoute)
     {
         var prefix = options.RoutePrefix.Trim('/');
-        var segments = location.Select(segment => segment.ToKebabCase());
+        var segments = location.Skip(segmentsToSkip).Select(segment => segment.ToKebabCase());
         var baseUrl = $"/{prefix}/{string.Join('/', segments)}";
 
         var typeName = includeNameInRoute ? endpointName : string.Empty;

--- a/Source/DotNET/Arc.Core/Introspection/IntrospectionService.cs
+++ b/Source/DotNET/Arc.Core/Introspection/IntrospectionService.cs
@@ -49,7 +49,7 @@ public class IntrospectionService(
                 options.IncludeCommandNameInRoute,
                 location,
                 handlersByNamespace);
-            var route = EndpointRouteHelper.BuildRouteUrl(options, location, handler.CommandType.Name, includeCommandName);
+            var route = EndpointRouteHelper.BuildRouteUrl(options, handler.Location, options.SegmentsToSkipForRoute, handler.CommandType.Name, includeCommandName);
 
             return new CommandIntrospectionMetadata(
                 handler.CommandType.Name,
@@ -74,7 +74,7 @@ public class IntrospectionService(
                 options.IncludeQueryNameInRoute,
                 location,
                 performersByNamespace);
-            var route = EndpointRouteHelper.BuildRouteUrl(options, location, performer.Name.ToString(), includeQueryName);
+            var route = EndpointRouteHelper.BuildRouteUrl(options, performer.Location, options.SegmentsToSkipForRoute, performer.Name.ToString(), includeQueryName);
 
             return new QueryIntrospectionMetadata(
                 performer.Name.ToString(),

--- a/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
@@ -47,7 +47,7 @@ public static class QueryEndpointMapper
                 options.IncludeQueryNameInRoute,
                 location,
                 performersByNamespace);
-            var url = EndpointRouteHelper.BuildRouteUrl(options, location, performer.Name.ToString(), includeQueryName);
+            var url = EndpointRouteHelper.BuildRouteUrl(options, performer.Location, options.SegmentsToSkipForRoute, performer.Name.ToString(), includeQueryName);
 
             if (!registeredUrls.Add(url)) continue;
 

--- a/Source/JavaScript/Arc.React/Arc.tsx
+++ b/Source/JavaScript/Arc.React/Arc.tsx
@@ -8,6 +8,7 @@ import { ArcConfiguration, ArcContext } from './ArcContext';
 import { GetHttpHeaders, Globals, ObservableQueryTransferMode } from '@cratis/arc';
 import { QueryTransportMethod, QueryInstanceCache } from '@cratis/arc/queries';
 import { resetSharedMultiplexer } from '@cratis/arc/queries';
+import { ObservableQueryDiagnostics, getSharedMultiplexer } from '@cratis/arc/queries';
 import { Messenger } from '@cratis/arc/messaging';
 import { QueryInstanceCacheContext } from './queries/QueryInstanceCacheContext';
 import { MessengerScopeContext } from './messaging/MessengerScopeContext';
@@ -75,6 +76,15 @@ export const Arc = (props: ArcProps) => {
     // effects are about to re-acquire.
     const queryInstanceCache = useRef(new QueryInstanceCache(props.queryCacheRetentionMs ?? Globals.queryCacheRetentionMs));
 
+    const observableQueryDiagnostics = useRef(new ObservableQueryDiagnostics(
+        queryInstanceCache.current,
+        () => getSharedMultiplexer(),
+        () => ({
+            queryTransportMethod: props.queryTransportMethod ?? QueryTransportMethod.ServerSentEvents,
+            queryDirectMode: props.queryDirectMode ?? false,
+        }),
+    ));
+
     const reconnectQueries = useCallback(() => {
         queryInstanceCache.current.teardownAllSubscriptions();
         resetSharedMultiplexer();
@@ -96,6 +106,7 @@ export const Arc = (props: ArcProps) => {
         queryCacheRetentionMs: props.queryCacheRetentionMs ?? Globals.queryCacheRetentionMs,
         queryVersion,
         reconnectQueries,
+        observableQueryDiagnostics: observableQueryDiagnostics.current,
     };
 
     Bindings.initialize(

--- a/Source/JavaScript/Arc.React/ArcContext.ts
+++ b/Source/JavaScript/Arc.React/ArcContext.ts
@@ -3,6 +3,7 @@
 
 import { GetHttpHeaders, ObservableQueryTransferMode, Globals } from '@cratis/arc';
 import { QueryTransportMethod } from '@cratis/arc/queries';
+import type { IObservableQueryDiagnostics } from '@cratis/arc/queries';
 import { IMessenger, Messenger } from '@cratis/arc/messaging';
 import React from 'react';
 
@@ -54,6 +55,13 @@ export interface ArcConfiguration {
      * (cookies, headers).
      */
     reconnectQueries?: () => void;
+    /**
+     * Diagnostics service that exposes live snapshots of observable query state.
+     * Consumers can call {@link IObservableQueryDiagnostics.getSnapshot} to retrieve
+     * a point-in-time view, or {@link IObservableQueryDiagnostics.subscribe} to be
+     * notified whenever a new snapshot is produced.
+     */
+    observableQueryDiagnostics?: IObservableQueryDiagnostics;
 }
 
 export const ArcContext = React.createContext<ArcConfiguration>({

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -109,7 +109,9 @@ function hasAllRequiredArguments(requiredRequestParameters: string[], args?: obj
     });
 }
 
-function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled: boolean = true):
+function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled?: boolean, owner?: string):
+    [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize];
+function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize] {
     const [currentPaging, setCurrentPaging] = useState<Paging>(paging ?? Paging.noPaging);
     const [currentSorting, setCurrentSorting] = useState<Sorting>(sorting ?? Sorting.none);
@@ -117,6 +119,8 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
     const queryCache = useContext(QueryInstanceCacheContext);
     const queryScope = useQueryScope();
     const cacheKeyRef = useRef<string>('');
+    const ownerRef = useRef<string | undefined>(owner);
+    ownerRef.current = owner;
 
     const queryInstance = useMemo(() => {
         // Create the instance first to read queryName, which is a hardcoded fully-qualified
@@ -171,7 +175,7 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
 
         queryCache.acquire(key);
 
-        if (!isEnabled || !hasAllRequiredArgumentsSet) {
+        if (isEnabled === false || !hasAllRequiredArgumentsSet) {
             return () => {
                 queryCache.release(key);
             };
@@ -273,14 +277,16 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
             });
         }
 
+        arc.observableQueryDiagnostics?.beginTracking(key, ownerRef.current ?? '');
         return () => {
+            arc.observableQueryDiagnostics?.endTracking(key);
             queryCache.removeListener(key, listener);
             queryCache.release(key);
         };
     }, effectDeps);
 
     return [
-        !isEnabled ? QueryResultWithState.empty(queryInstance.defaultValue) : result,
+        isEnabled === false ? QueryResultWithState.empty(queryInstance.defaultValue) : result,
         async (sorting: Sorting) => {
             setCurrentSorting(sorting);
         },
@@ -303,9 +309,11 @@ function useObservableQueryInternal<TDataType, TQuery extends IObservableQueryFo
  * @param isEnabled Optional: Whether the query should subscribe. Defaults to true. When false, the hook is a no-op and returns an empty result.
  * @returns Tuple of {@link QueryResultWithState} and a {@link PerformQuery} delegate.
  */
-export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled: boolean = true):
+export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled?: boolean):
+    [QueryResultWithState<TDataType>, SetSorting];
+export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, SetSorting] {
-    const [result, setSorting] = useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, Paging.noPaging, args, isEnabled);
+    const [result, setSorting] = useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, Paging.noPaging, args, isEnabled, owner);
     return [result, setSorting];
 }
 
@@ -321,7 +329,9 @@ export function useObservableQuery<TDataType, TQuery extends IObservableQueryFor
  * @param isEnabled Optional: Whether the query should subscribe. Defaults to true. When false, the hook is a no-op and returns an empty result.
  * @returns Tuple of {@link QueryResultWithState} and paging/sorting controls.
  */
-export function useObservableQueryWithPaging<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled: boolean = true):
+export function useObservableQueryWithPaging<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled?: boolean):
+    [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize];
+export function useObservableQueryWithPaging<TDataType, TQuery extends IObservableQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, SetSorting, SetPage, SetPageSize] {
-    return useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, paging, args, isEnabled);
+    return useObservableQueryInternal<TDataType, TQuery, TArguments>(query, sorting, paging, args, isEnabled, owner);
 }

--- a/Source/JavaScript/Arc.React/queries/useQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useQuery.ts
@@ -19,7 +19,9 @@ export type PerformQuery<TArguments = object> = (args?: TArguments) => Promise<v
 
 type QueryPerformer<TQuery extends IQueryFor<TDataType>, TDataType, TArguments = object> = (performer: TQuery, args?: TArguments) => Promise<QueryResult<TDataType>>;
 
-function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, performer: QueryPerformer<TQuery, TDataType, TArguments>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled: boolean = true):
+function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, performer: QueryPerformer<TQuery, TDataType, TArguments>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled?: boolean, owner?: string):
+    [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting, SetPage, SetPageSize];
+function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, performer: QueryPerformer<TQuery, TDataType, TArguments>, sorting?: Sorting, paging?: Paging, args?: TArguments, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting, SetPage, SetPageSize] {
     const [currentPaging, setCurrentPaging] = useState<Paging>(paging ?? Paging.noPaging);
     const [currentSorting, setCurrentSorting] = useState<Sorting>(sorting ?? Sorting.none);
@@ -28,6 +30,8 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
     const queryScope = useQueryScope();
     const queryCache = useContext(QueryInstanceCacheContext);
     const cacheKeyRef = useRef<string>('');
+    const ownerRef = useRef<string | undefined>(owner);
+    ownerRef.current = owner;
 
     const queryInstance = useMemo(() => {
         // Create the instance first to read queryName, which is a hardcoded fully-qualified
@@ -87,20 +91,22 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
 
         queryCache.acquire(key);
 
-        if (!isEnabled) {
+        if (isEnabled === false) {
             return () => {
                 queryCache.release(key);
             };
         }
         queryExecutor(args);
 
+        arc.observableQueryDiagnostics?.beginTracking(key, ownerRef.current ?? '');
         return () => {
+            arc.observableQueryDiagnostics?.endTracking(key);
             queryCache.release(key);
         };
     }, [...argumentsDependency, ...[currentPaging, currentSorting, isEnabled]]);
 
     return [
-        !isEnabled ? QueryResultWithState.empty(queryInstance.defaultValue) : result!,
+        isEnabled === false ? QueryResultWithState.empty(queryInstance.defaultValue) : result!,
         async (args?: TArguments) => {
             setResult(QueryResultWithState.fromQueryResult(result!, true));
             await queryExecutor(args);
@@ -127,9 +133,11 @@ function useQueryInternal<TDataType, TQuery extends IQueryFor<TDataType>, TArgum
  * @param isEnabled Optional: Whether the query should be executed. Defaults to true. When false, the hook is a no-op and returns an empty result.
  * @returns Tuple of {@link QueryResultWithState}, a {@link PerformQuery} delegate, and a {@link SetSorting} delegate.
  */
-export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled: boolean = true):
+export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled?: boolean):
+    [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting];
+export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, args?: TArguments, sorting?: Sorting, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting] {
-    const [result, perform, setSorting] = useQueryInternal(query, async (queryInstance: TQuery, actualArgs?: TArguments) => await queryInstance.perform(actualArgs!), sorting, undefined, args, isEnabled);
+    const [result, perform, setSorting] = useQueryInternal(query, async (queryInstance: TQuery, actualArgs?: TArguments) => await queryInstance.perform(actualArgs!), sorting, undefined, args, isEnabled, owner);
     return [result, perform, setSorting];
 }
 
@@ -145,7 +153,9 @@ export function useQuery<TDataType, TQuery extends IQueryFor<TDataType>, TArgume
  * @param isEnabled Optional: Whether the query should be executed. Defaults to true. When false, the hook is a no-op and returns an empty result.
  * @returns Tuple of {@link QueryResult} and a {@link PerformQuery} delegate.
  */
-export function useQueryWithPaging<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled: boolean = true):
+export function useQueryWithPaging<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled?: boolean):
+    [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting, SetPage, SetPageSize];
+export function useQueryWithPaging<TDataType, TQuery extends IQueryFor<TDataType>, TArguments = object>(query: Constructor<TQuery>, paging: Paging, args?: TArguments, sorting?: Sorting, isEnabled?: boolean, owner?: string):
     [QueryResultWithState<TDataType>, PerformQuery<TArguments>, SetSorting, SetPage, SetPageSize] {
-    return useQueryInternal(query, async (queryInstance: TQuery, actualArgs?: TArguments) => await queryInstance.perform(actualArgs!), sorting, paging, args, isEnabled);
+    return useQueryInternal(query, async (queryInstance: TQuery, actualArgs?: TArguments) => await queryInstance.perform(actualArgs!), sorting, paging, args, isEnabled, owner);
 }

--- a/Source/JavaScript/Arc/queries/IObservableQueryDiagnostics.ts
+++ b/Source/JavaScript/Arc/queries/IObservableQueryDiagnostics.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Observable } from 'rxjs';
+import { ObservableQueryDiagnosticsSnapshot } from './ObservableQueryDiagnosticsSnapshot';
+
+/**
+ * Contract for the observable query diagnostics service.
+ *
+ * The service aggregates runtime state from the query cache, the multiplexer connection pool,
+ * and (optionally) component ownership maps into a single snapshot. Snapshots can be polled
+ * via {@link getSnapshot} or observed through {@link snapshots$}.
+ */
+export interface IObservableQueryDiagnostics {
+    /**
+     * Returns the current diagnostics snapshot.
+     */
+    getSnapshot(): ObservableQueryDiagnosticsSnapshot;
+
+    /**
+     * Stream of diagnostics snapshots.
+     */
+    readonly snapshots$: Observable<ObservableQueryDiagnosticsSnapshot>;
+
+    /**
+     * Associates a human-readable owner label with a cache key.
+     * Used by opt-in hook options (`owner?: string`) to identify which component
+     * is using which query instance.
+     * @param cacheKey The cache key to tag.
+     * @param owner A descriptive label for the owning component (e.g. component name).
+     */
+    beginTracking(cacheKey: string, owner: string): void;
+
+    /**
+     * Removes the ownership association for the given cache key.
+     * Should be called when the component unmounts or the query hook cleans up.
+     * @param cacheKey The cache key to un-tag.
+     */
+    endTracking(cacheKey: string): void;
+}

--- a/Source/JavaScript/Arc/queries/IObservableQueryHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/IObservableQueryHubConnection.ts
@@ -20,6 +20,11 @@ export interface IObservableQueryHubConnection {
     readonly queryCount: number;
 
     /**
+     * Gets whether the physical connection is currently established.
+     */
+    readonly isConnected: boolean;
+
+    /**
      * Gets the latency of the last ping/pong sequence in milliseconds.
      */
     readonly lastPingLatency: number;

--- a/Source/JavaScript/Arc/queries/ObservableQueryDiagnostics.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryDiagnostics.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Observable, Subject } from 'rxjs';
+import { QueryInstanceCache } from './QueryInstanceCache';
+import { ObservableQueryMultiplexer } from './ObservableQueryMultiplexer';
+import { IObservableQueryDiagnostics } from './IObservableQueryDiagnostics';
+import {
+    ObservableQueryDiagnosticsSnapshot,
+    MultiplexerDiagnostics,
+    TransportDiagnostics,
+    HealthDiagnostics,
+    OwnershipDiagnostics,
+} from './ObservableQueryDiagnosticsSnapshot';
+
+/**
+ * Implements the {@link IObservableQueryDiagnostics} contract by collecting live state from
+ * the {@link QueryInstanceCache} and the shared {@link ObservableQueryMultiplexer}.
+ */
+export class ObservableQueryDiagnostics implements IObservableQueryDiagnostics {
+    private readonly _snapshots = new Subject<ObservableQueryDiagnosticsSnapshot>();
+    private readonly _ownersByKey = new Map<string, string>();
+
+    /**
+     * Initializes a new instance of {@link ObservableQueryDiagnostics}.
+     * @param _cache The {@link QueryInstanceCache} whose state will be reflected.
+     * @param _getMultiplexer Factory that returns the current shared multiplexer, or {@code undefined}.
+     * @param _getTransportConfig Factory that returns the current transport diagnostics.
+     */
+    constructor(
+        private readonly _cache: QueryInstanceCache,
+        private readonly _getMultiplexer: () => ObservableQueryMultiplexer | undefined,
+        private readonly _getTransportConfig: () => TransportDiagnostics,
+    ) {}
+
+    /**
+     * Stream of diagnostics snapshots.
+     */
+    get snapshots$(): Observable<ObservableQueryDiagnosticsSnapshot> {
+        return this._snapshots.asObservable();
+    }
+
+    /** @inheritdoc */
+    getSnapshot(): ObservableQueryDiagnosticsSnapshot {
+        const snapshot = this._createSnapshot();
+        this._publishSnapshot(snapshot);
+        return snapshot;
+    }
+
+    /** @inheritdoc */
+    beginTracking(cacheKey: string, owner: string): void {
+        this._ownersByKey.set(cacheKey, owner);
+        this._publishSnapshot(this._createSnapshot());
+    }
+
+    /** @inheritdoc */
+    endTracking(cacheKey: string): void {
+        this._ownersByKey.delete(cacheKey);
+        this._publishSnapshot(this._createSnapshot());
+    }
+
+    private _buildMultiplexerDiagnostics(): MultiplexerDiagnostics {
+        const mux = this._getMultiplexer();
+        if (!mux) {
+            return {
+                isConnected: false,
+                configuredConnectionCount: 0,
+                effectiveConnectionCount: 0,
+                activeConnectionCount: 0,
+                connections: [],
+            };
+        }
+
+        const connections = mux.getConnectionsSnapshot();
+        const activeConnectionCount = connections.filter(c => c.isConnected).length;
+
+        return {
+            isConnected: activeConnectionCount > 0,
+            configuredConnectionCount: connections.length,
+            effectiveConnectionCount: connections.length,
+            activeConnectionCount,
+            connections,
+        };
+    }
+
+    private _createSnapshot(): ObservableQueryDiagnosticsSnapshot {
+        const transport = this._getTransportConfig();
+        const multiplexer = this._buildMultiplexerDiagnostics();
+        const cache = this._cache.getDiagnosticsSnapshot();
+
+        const ownersByQueryKey: Record<string, string> = {};
+        const queriesByOwner: Record<string, string[]> = {};
+
+        for (const [key, owner] of this._ownersByKey) {
+            ownersByQueryKey[key] = owner;
+            if (!queriesByOwner[owner]) {
+                queriesByOwner[owner] = [];
+            }
+            queriesByOwner[owner].push(key);
+        }
+
+        const ownership: OwnershipDiagnostics = { ownersByQueryKey, queriesByOwner };
+
+        const disconnectedQueryCount = multiplexer.connections.filter(c => !c.isConnected).length;
+        const health: HealthDiagnostics = {
+            allQueriesConnected: multiplexer.isConnected && cache.healthy,
+            disconnectedQueryCount,
+        };
+
+        return {
+            health,
+            transport,
+            multiplexer,
+            cache,
+            ownership,
+            timestamp: new Date().toISOString(),
+        };
+    }
+
+    private _publishSnapshot(snapshot: ObservableQueryDiagnosticsSnapshot): void {
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('cratis:observable-query-diagnostics', { detail: snapshot }));
+        }
+
+        this._snapshots.next(snapshot);
+    }
+}

--- a/Source/JavaScript/Arc/queries/ObservableQueryDiagnosticsSnapshot.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryDiagnosticsSnapshot.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Describes the state of a single physical hub connection in the multiplexer.
+ */
+export interface MultiplexerConnectionState {
+    /** Zero-based slot index in the connection pool. */
+    index: number;
+    /** Whether the connection is currently established and receiving messages. */
+    isConnected: boolean;
+    /** Number of active query subscriptions routed through this connection. */
+    queryCount: number;
+}
+
+/**
+ * Multiplexer transport diagnostics.
+ */
+export interface MultiplexerDiagnostics {
+    /** Whether at least one connection in the pool is currently connected. */
+    isConnected: boolean;
+    /** Number of physical connections configured (from Arc props). */
+    configuredConnectionCount: number;
+    /** Number of connections actually created after SSE cap logic. */
+    effectiveConnectionCount: number;
+    /** Number of connections that are currently connected. */
+    activeConnectionCount: number;
+    /** Per-connection state for the current pool. */
+    connections: MultiplexerConnectionState[];
+}
+
+/**
+ * A single entry in the query instance cache.
+ */
+export interface CacheEntryDiagnostics {
+    /** The full cache key (type name + serialized args). */
+    key: string;
+    /** Query name parsed from the key prefix. */
+    queryName: string;
+    /** Number of components currently holding a reference to this entry. */
+    subscriberCount: number;
+    /** Number of result listeners registered on this entry. */
+    listenerCount: number;
+    /** Whether an active server subscription has been established. */
+    subscribed: boolean;
+    /** Whether a cached result has been received at least once. */
+    hasResult: boolean;
+    /** Estimated size of the cached result in bytes (JSON.stringify length, 0 on error). */
+    estimatedBytes: number;
+}
+
+/**
+ * Query instance cache diagnostics.
+ */
+export interface CacheDiagnostics {
+    /** Whether all subscribed entries are connected (no entry has subscriberCount > 0 but subscribed == false). */
+    healthy: boolean;
+    /** Total number of entries in the cache (including unsubscribed retention entries). */
+    entryCount: number;
+    /** Total estimated size of all cached results in bytes. */
+    estimatedBytes: number;
+    /** Per-entry diagnostics. */
+    entries: CacheEntryDiagnostics[];
+}
+
+/**
+ * Transport configuration diagnostics.
+ */
+export interface TransportDiagnostics {
+    /** The configured query transport method (e.g. ServerSentEvents or WebSocket). */
+    queryTransportMethod: string;
+    /** Whether direct per-query connections are used instead of the multiplexer hub. */
+    queryDirectMode: boolean;
+}
+
+/**
+ * Overall health summary.
+ */
+export interface HealthDiagnostics {
+    /** True when every entry with active subscribers is also subscribed. */
+    allQueriesConnected: boolean;
+    /** Number of entries that have subscribers but are not currently subscribed. */
+    disconnectedQueryCount: number;
+}
+
+/**
+ * Ownership map entry.
+ */
+export interface OwnershipDiagnostics {
+    /** Map of cache key → owner label (populated by opt-in owner tagging). */
+    ownersByQueryKey: Record<string, string>;
+    /** Map of owner label → cache keys. */
+    queriesByOwner: Record<string, string[]>;
+}
+
+/**
+ * A point-in-time snapshot of observable query diagnostics.
+ */
+export interface ObservableQueryDiagnosticsSnapshot {
+    /** Overall health summary. */
+    health: HealthDiagnostics;
+    /** Transport configuration. */
+    transport: TransportDiagnostics;
+    /** Multiplexer connection pool state. */
+    multiplexer: MultiplexerDiagnostics;
+    /** Query instance cache state. */
+    cache: CacheDiagnostics;
+    /** Opt-in component ownership mapping. */
+    ownership: OwnershipDiagnostics;
+    /** UTC timestamp when this snapshot was taken. */
+    timestamp: string;
+}

--- a/Source/JavaScript/Arc/queries/ObservableQueryMultiplexer.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryMultiplexer.ts
@@ -6,6 +6,7 @@ import { IObservableQueryHubConnection } from './IObservableQueryHubConnection';
 import { DataReceived } from './ObservableQueryConnection';
 import { SubscriptionRequest } from './WebSocketHubConnection';
 import { Globals } from '../Globals';
+import { MultiplexerConnectionState } from './ObservableQueryDiagnosticsSnapshot';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -137,6 +138,18 @@ export class ObservableQueryMultiplexer {
 
         return request;
     }
+
+    /**
+     * Returns a snapshot of the per-connection state for diagnostics.
+     * @returns An array describing each slot in the connection pool.
+     */
+    getConnectionsSnapshot(): MultiplexerConnectionState[] {
+        return this._connections.map((conn, index) => ({
+            index,
+            isConnected: conn.isConnected,
+            queryCount: conn.queryCount,
+        }));
+    }
 }
 
 /**
@@ -216,4 +229,11 @@ export function resetSharedMultiplexer(): void {
     _sharedMultiplexer?.dispose();
     _sharedMultiplexer = undefined;
     _sharedMultiplexerKey = '';
+}
+
+/**
+ * Returns the current shared multiplexer instance, or {@code undefined} if none has been created yet.
+ */
+export function getSharedMultiplexer(): ObservableQueryMultiplexer | undefined {
+    return _sharedMultiplexer;
 }

--- a/Source/JavaScript/Arc/queries/QueryInstanceCache.ts
+++ b/Source/JavaScript/Arc/queries/QueryInstanceCache.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { QueryResultWithState } from './QueryResultWithState';
+import { CacheDiagnostics, CacheEntryDiagnostics } from './ObservableQueryDiagnosticsSnapshot';
 
 /**
  * Represents a key that uniquely identifies a query instance in the cache, based on the query type name and its serialized arguments.
@@ -359,5 +360,51 @@ export class QueryInstanceCache {
             clearTimeout(this._pendingDispose);
             this._pendingDispose = undefined;
         }
+    }
+
+    /**
+     * Returns a diagnostics snapshot of the current cache state.
+     * @returns A {@link CacheDiagnostics} describing all entries.
+     */
+    getDiagnosticsSnapshot(): CacheDiagnostics {
+        const entries: CacheEntryDiagnostics[] = [];
+        let totalBytes = 0;
+        let unhealthyCount = 0;
+
+        for (const [key, entry] of this._entries) {
+            const colonIndex = key.indexOf('::');
+            const queryName = colonIndex >= 0 ? key.substring(0, colonIndex) : key;
+
+            let estimatedBytes = 0;
+            try {
+                if (entry.lastResult !== undefined) {
+                    estimatedBytes = JSON.stringify(entry.lastResult).length;
+                }
+            } catch {
+                // Ignore serialization errors
+            }
+
+            if (entry.subscriberCount > 0 && !entry.subscribed) {
+                unhealthyCount++;
+            }
+
+            totalBytes += estimatedBytes;
+            entries.push({
+                key,
+                queryName,
+                subscriberCount: entry.subscriberCount,
+                listenerCount: entry.listeners.size,
+                subscribed: entry.subscribed,
+                hasResult: entry.lastResult !== undefined,
+                estimatedBytes,
+            });
+        }
+
+        return {
+            healthy: unhealthyCount === 0,
+            entryCount: this._entries.size,
+            estimatedBytes: totalBytes,
+            entries,
+        };
     }
 }

--- a/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
@@ -84,6 +84,11 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
     }
 
     /** @inheritdoc */
+    get isConnected(): boolean {
+        return this._connectionId !== undefined && this._eventSource?.readyState === EventSource.OPEN;
+    }
+
+    /** @inheritdoc */
     get lastPingLatency(): number {
         return this._lastPongLatency;
     }

--- a/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
@@ -99,6 +99,13 @@ export class WebSocketHubConnection {
     }
 
     /**
+     * Gets whether the WebSocket connection is currently open.
+     */
+    get isConnected(): boolean {
+        return this._socket?.readyState === WebSocket.OPEN;
+    }
+
+    /**
      * Gets the latency of the last ping/pong sequence in milliseconds.
      */
     get lastPingLatency(): number {

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryDiagnostics/when_tracking_owners.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryDiagnostics/when_tracking_owners.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'vitest';
+import { ObservableQueryDiagnostics, QueryInstanceCache } from '../../queries';
+
+describe('when tracking query owners', () => {
+    it('should publish diagnostics snapshots through an observable', () => {
+        const diagnostics = new ObservableQueryDiagnostics(
+            new QueryInstanceCache(0),
+            () => undefined,
+            () => ({ queryTransportMethod: 'ServerSentEvents', queryDirectMode: false })
+        );
+
+        const snapshots: string[] = [];
+        diagnostics.snapshots$.subscribe(snapshot => snapshots.push(JSON.stringify(snapshot.ownership)));
+
+        diagnostics.beginTracking('cache-key', 'OrdersPage');
+        snapshots.should.have.lengthOf(1);
+        snapshots[0].should.contain('cache-key');
+        snapshots[0].should.contain('OrdersPage');
+
+        diagnostics.endTracking('cache-key');
+        snapshots.should.have.lengthOf(2);
+        snapshots[1].should.equal('{"ownersByQueryKey":{},"queriesByOwner":{}}');
+    });
+});

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_a_changed_cache_key.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_a_changed_cache_key.ts
@@ -20,7 +20,8 @@ describe('when getting or creating with a changed cache key', () => {
                 lastPingLatency: 0,
                 averageLatency: 0,
                 subscribe: () => {},
-                unsubscribe: () => {},
+                    isConnected: false,
+                    unsubscribe: () => {},
                 dispose: () => { disposedConnectionCount++; },
             };
         };

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_a_new_cache_key.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_a_new_cache_key.ts
@@ -14,7 +14,7 @@ describe('when getting or creating with a new cache key', () => {
         factoryCallCount = 0;
         const factory = (): IObservableQueryHubConnection => {
             factoryCallCount++;
-            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
+            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, isConnected: false, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
         };
         multiplexer = getOrCreateMultiplexer(factory, 'test-key', 1);
     });

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_an_explicit_size.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_an_explicit_size.ts
@@ -14,7 +14,7 @@ describe('when getting or creating with an explicit size', () => {
         factoryCallCount = 0;
         const factory = (): IObservableQueryHubConnection => {
             factoryCallCount++;
-            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
+            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, isConnected: false, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
         };
         multiplexer = getOrCreateMultiplexer(factory, 'test-key', 3);
     });

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_the_same_cache_key.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryMultiplexer/when_getting_or_creating/with_the_same_cache_key.ts
@@ -15,7 +15,7 @@ describe('when getting or creating with the same cache key', () => {
         factoryCallCount = 0;
         const factory = (): IObservableQueryHubConnection => {
             factoryCallCount++;
-            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
+            return { queryCount: 0, lastPingLatency: 0, averageLatency: 0, isConnected: false, subscribe: () => {}, unsubscribe: () => {}, dispose: () => {} };
         };
         first = getOrCreateMultiplexer(factory, 'test-key', 1);
         second = getOrCreateMultiplexer(factory, 'test-key', 1);

--- a/Source/JavaScript/Arc/queries/index.ts
+++ b/Source/JavaScript/Arc/queries/index.ts
@@ -35,4 +35,7 @@ export * from './QueryInstanceCache';
 export * from './IQueryProvider';
 export * from './QueryProvider';
 export * from './QueryValidator';
+export * from './IObservableQueryDiagnostics';
+export * from './ObservableQueryDiagnostics';
+export * from './ObservableQueryDiagnosticsSnapshot';
 import '../validation';


### PR DESCRIPTION
## Added
- Expose live observable query diagnostics through ArcContext with RxJS snapshot streaming.

## Changed
- Route command, query, and introspection metadata through the shared route helper so skipped namespace segments stay consistent.

## Fixed
- Introspection route metadata now reflects the same route prefix and skipped namespace segments as runtime endpoint mapping.