### PR TITLE
Allow named floating-point literals in Arc JSON defaults

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_Value_being_a_plain_number.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_Value_being_a_plain_number.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Arc.for_JsonSerializerOptionsConfiguration.when_doing_a_roundtrip_serialization;
+
+public class with_Value_being_a_plain_number : Specification
+{
+    JsonSerializerOptions _options;
+    string _json;
+    double _deserialized;
+
+    void Establish() => _options = new JsonSerializerOptions().ConfigureArcDefaults();
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(42.5, _options);
+        _deserialized = JsonSerializer.Deserialize<double>(_json, _options);
+    }
+
+    [Fact] void should_serialize_as_a_plain_number() => _json.ShouldEqual("42.5");
+    [Fact] void should_round_trip_the_value() => _deserialized.ShouldEqual(42.5);
+}

--- a/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_NaN.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_NaN.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Arc.for_JsonSerializerOptionsConfiguration.when_doing_a_roundtrip_serialization;
+
+public class with_value_being_NaN : Specification
+{
+    JsonSerializerOptions _options;
+    string _json;
+    double _deserialized;
+
+    void Establish() => _options = new JsonSerializerOptions().ConfigureArcDefaults();
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(double.NaN, _options);
+        _deserialized = JsonSerializer.Deserialize<double>(_json, _options);
+    }
+
+    [Fact] void should_round_trip_nan() => double.IsNaN(_deserialized).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_negative_infinity.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_negative_infinity.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Arc.for_JsonSerializerOptionsConfiguration.when_doing_a_roundtrip_serialization;
+
+public class with_value_being_negative_infinity : Specification
+{
+    JsonSerializerOptions _options;
+    string _json;
+    double _deserialized;
+
+    void Establish() => _options = new JsonSerializerOptions().ConfigureArcDefaults();
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(double.NegativeInfinity, _options);
+        _deserialized = JsonSerializer.Deserialize<double>(_json, _options);
+    }
+
+    [Fact] void should_round_trip_negative_infinity() => double.IsNegativeInfinity(_deserialized).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_positive_infinity.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_JsonSerializerOptionsConfiguration/when_doing_a_roundtrip_serialization/with_value_being_positive_infinity.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Arc.for_JsonSerializerOptionsConfiguration.when_doing_a_roundtrip_serialization;
+
+public class with_value_being_positive_infinity : Specification
+{
+    JsonSerializerOptions _options;
+    string _json;
+    double _deserialized;
+
+    void Establish() => _options = new JsonSerializerOptions().ConfigureArcDefaults();
+
+    void Because()
+    {
+        _json = JsonSerializer.Serialize(double.PositiveInfinity, _options);
+        _deserialized = JsonSerializer.Deserialize<double>(_json, _options);
+    }
+
+    [Fact] void should_round_trip_positive_infinity() => double.IsPositiveInfinity(_deserialized).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core/JsonSerializerOptionsConfiguration.cs
+++ b/Source/DotNET/Arc.Core/JsonSerializerOptionsConfiguration.cs
@@ -23,6 +23,7 @@ public static class JsonSerializerOptionsConfiguration
     {
         options.PropertyNamingPolicy = AcronymFriendlyJsonCamelCaseNamingPolicy.Instance;
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        options.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals;
 
         options.Converters.Add(new EnumConverterFactory());
         options.Converters.Add(new EnumerableConceptAsJsonConverterFactory());


### PR DESCRIPTION
## Changed

- Configure Arc JSON defaults to allow named floating-point literals so `double` values such as `Infinity`, `-Infinity`, and `NaN` can be serialized and deserialized consistently.
