### PR TITLE
Fix open generic read model interceptors

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/given/a_read_model_interceptors.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/given/a_read_model_interceptors.cs
@@ -33,6 +33,31 @@ public class a_read_model_interceptors : Specification
         }
     }
 
+    public class GenericReadModelInterceptor<TReadModel> : IInterceptReadModel<TReadModel>
+    {
+        public List<TReadModel> InterceptedItems { get; } = [];
+
+        public Task<TReadModel> Intercept(TReadModel readModel)
+        {
+            InterceptedItems.Add(readModel);
+            return Task.FromResult(readModel);
+        }
+    }
+
+    public class ServiceRegisteredGenericReadModelInterceptorState
+    {
+        public List<object> InterceptedItems { get; } = [];
+    }
+
+    public class ServiceRegisteredGenericReadModelInterceptor<TReadModel>(ServiceRegisteredGenericReadModelInterceptorState state) : IInterceptReadModel<TReadModel>
+    {
+        public Task<TReadModel> Intercept(TReadModel readModel)
+        {
+            state.InterceptedItems.Add(readModel!);
+            return Task.FromResult(readModel);
+        }
+    }
+
     public record OtherReadModel(int Count);
 
     public class OtherReadModelInterceptor : IInterceptReadModel<OtherReadModel>

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_discovered_and_service_registered_open_generic_interceptor.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_discovered_and_service_registered_open_generic_interceptor.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptors.when_intercepting;
+
+public class with_discovered_and_service_registered_open_generic_interceptor : given.a_read_model_interceptors
+{
+    ServiceRegisteredGenericReadModelInterceptorState _state;
+    TestReadModel _item;
+
+    void Establish()
+    {
+        _item = new TestReadModel("hello");
+        _state = new();
+
+        var types = Substitute.For<ITypes>();
+        types.FindMultiple(typeof(IInterceptReadModel<>)).Returns([typeof(ServiceRegisteredGenericReadModelInterceptor<>)]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_state);
+        services.AddTransient(typeof(IInterceptReadModel<>), typeof(ServiceRegisteredGenericReadModelInterceptor<>));
+        _serviceProvider = services.BuildServiceProvider();
+
+        _interceptors = new ReadModelInterceptors(types);
+    }
+
+    async Task Because() => await _interceptors.Intercept(typeof(TestReadModel), [_item], _serviceProvider);
+
+    [Fact] void should_only_call_interceptor_once() => _state.InterceptedItems.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_interceptor_for_different_type.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_interceptor_for_different_type.cs
@@ -7,6 +7,7 @@ public class with_interceptor_for_different_type : given.a_read_model_intercepto
 {
     OtherReadModelInterceptor _otherInterceptor;
     TestReadModel _item;
+    IEnumerable<object> _result;
 
     void Establish()
     {
@@ -20,7 +21,8 @@ public class with_interceptor_for_different_type : given.a_read_model_intercepto
         _interceptors = new ReadModelInterceptors(types);
     }
 
-    async Task Because() => await _interceptors.Intercept(typeof(TestReadModel), [_item], _serviceProvider);
+    async Task Because() => _result = await _interceptors.Intercept(typeof(TestReadModel), [_item], _serviceProvider);
 
-    [Fact] void should_not_call_service_provider() => _serviceProvider.DidNotReceive().GetService(Arg.Any<Type>());
+    [Fact] void should_not_resolve_unmatched_interceptor() => _serviceProvider.DidNotReceive().GetService(typeof(OtherReadModelInterceptor));
+    [Fact] void should_return_original_item() => _result.ShouldContain(_item);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_no_interceptors_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_no_interceptors_registered.cs
@@ -7,11 +7,13 @@ public class with_no_interceptors_registered : Specification
 {
     ReadModelInterceptors _interceptors;
     IServiceProvider _serviceProvider;
+    object _item;
     bool _threw;
     IEnumerable<object> _result;
 
     void Establish()
     {
+        _item = new object();
         var types = Substitute.For<ITypes>();
         types.FindMultiple(typeof(IInterceptReadModel<>)).Returns([]);
         _serviceProvider = Substitute.For<IServiceProvider>();
@@ -23,7 +25,7 @@ public class with_no_interceptors_registered : Specification
         _threw = false;
         try
         {
-            _result = await _interceptors.Intercept(typeof(object), [new object()], _serviceProvider);
+            _result = await _interceptors.Intercept(typeof(object), [_item], _serviceProvider);
         }
         catch
         {
@@ -32,6 +34,5 @@ public class with_no_interceptors_registered : Specification
     }
 
     [Fact] void should_not_throw() => _threw.ShouldBeFalse();
-    [Fact] void should_not_call_service_provider() => _serviceProvider.DidNotReceive().GetService(Arg.Any<Type>());
-    [Fact] void should_return_original_items() => _result.ShouldNotBeNull();
+    [Fact] void should_return_original_item() => _result.ShouldContain(_item);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_open_generic_interceptor.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_open_generic_interceptor.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptors.when_intercepting;
+
+public class with_open_generic_interceptor : given.a_read_model_interceptors
+{
+    GenericReadModelInterceptor<TestReadModel> _interceptorInstance;
+    TestReadModel _item;
+    IEnumerable<object> _result;
+
+    void Establish()
+    {
+        _item = new TestReadModel("hello");
+        _interceptorInstance = new GenericReadModelInterceptor<TestReadModel>();
+
+        var types = Substitute.For<ITypes>();
+        types.FindMultiple(typeof(IInterceptReadModel<>)).Returns([typeof(GenericReadModelInterceptor<>)]);
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _serviceProvider.GetService(typeof(GenericReadModelInterceptor<TestReadModel>)).Returns(_interceptorInstance);
+
+        _interceptors = new ReadModelInterceptors(types);
+    }
+
+    async Task Because() => _result = await _interceptors.Intercept(typeof(TestReadModel), [_item], _serviceProvider);
+
+    [Fact] void should_call_interceptor_with_item() => _interceptorInstance.InterceptedItems.ShouldContain(_item);
+    [Fact] void should_call_interceptor_once() => _interceptorInstance.InterceptedItems.Count.ShouldEqual(1);
+    [Fact] void should_return_the_intercepted_item() => _result.ShouldContain(_item);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_service_registered_open_generic_interceptor.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_service_registered_open_generic_interceptor.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptors.when_intercepting;
+
+public class with_service_registered_open_generic_interceptor : given.a_read_model_interceptors
+{
+    ServiceRegisteredGenericReadModelInterceptorState _state;
+    TestReadModel _item;
+    IEnumerable<object> _result;
+
+    void Establish()
+    {
+        _item = new TestReadModel("hello");
+        _state = new();
+
+        var types = Substitute.For<ITypes>();
+        types.FindMultiple(typeof(IInterceptReadModel<>)).Returns([]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_state);
+        services.AddTransient(typeof(IInterceptReadModel<>), typeof(ServiceRegisteredGenericReadModelInterceptor<>));
+        _serviceProvider = services.BuildServiceProvider();
+
+        _interceptors = new ReadModelInterceptors(types);
+    }
+
+    async Task Because() => _result = await _interceptors.Intercept(typeof(TestReadModel), [_item], _serviceProvider);
+
+    [Fact] void should_call_interceptor_with_item() => _state.InterceptedItems.ShouldContain(_item);
+    [Fact] void should_call_interceptor_once() => _state.InterceptedItems.Count.ShouldEqual(1);
+    [Fact] void should_return_the_intercepted_item() => _result.ShouldContain(_item);
+}

--- a/Source/DotNET/Arc.Core/Queries/ReadModelInterceptors.cs
+++ b/Source/DotNET/Arc.Core/Queries/ReadModelInterceptors.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Reflection;
 using Cratis.DependencyInjection;
 using Cratis.Types;
@@ -13,33 +14,44 @@ namespace Cratis.Arc.Queries;
 /// </summary>
 /// <remarks>
 /// Discovers all <see cref="IInterceptReadModel{TReadModel}"/> implementations via <see cref="ITypes"/> at startup.
-/// Interceptors do not need to be registered in the DI container — the framework creates them automatically,
-/// resolving any constructor dependencies from the provided <see cref="IServiceProvider"/>.
+/// Interceptors can also be registered in the DI container as <see cref="IInterceptReadModel{TReadModel}"/> services.
 /// </remarks>
 /// <param name="types"><see cref="ITypes"/> used to discover interceptor implementations.</param>
 [Singleton]
 public class ReadModelInterceptors(ITypes types) : IReadModelInterceptors
 {
-    readonly Dictionary<Type, InterceptorEntry> _cache = BuildCache(types);
+    readonly InterceptorCache _cache = BuildCache(types);
+    readonly ConcurrentDictionary<Type, IReadOnlyList<InterceptorEntry>> _entriesByReadModelType = new();
+    readonly ConcurrentDictionary<Type, ServiceInterceptorEntry> _serviceEntriesByReadModelType = new();
 
     /// <inheritdoc/>
     public async Task<IEnumerable<object>> Intercept(Type readModelType, IEnumerable<object> items, IServiceProvider serviceProvider)
     {
-        if (!_cache.TryGetValue(readModelType, out var entry))
+        var entries = _entriesByReadModelType.GetOrAdd(readModelType, BuildEntriesFor);
+        var serviceEntry = _serviceEntriesByReadModelType.GetOrAdd(readModelType, CreateServiceEntry);
+        var serviceInterceptors = GetServiceInterceptors(serviceEntry, serviceProvider);
+        if (entries.Count == 0 && serviceInterceptors.Count == 0)
         {
             return items;
         }
 
-        return await Task.WhenAll(items.Select(item => InterceptItem(item, entry, serviceProvider)));
+        return await Task.WhenAll(items.Select(item => InterceptItem(item, entries, serviceInterceptors, serviceEntry, serviceProvider)));
     }
 
-    static Dictionary<Type, InterceptorEntry> BuildCache(ITypes types)
+    static InterceptorCache BuildCache(ITypes types)
     {
         var interceptorTypes = types.FindMultiple(typeof(IInterceptReadModel<>));
         var map = new Dictionary<Type, (List<Type> Types, MethodInfo? Method, PropertyInfo? ResultProperty)>();
+        var openGenericInterceptorTypes = new List<Type>();
 
         foreach (var interceptorType in interceptorTypes)
         {
+            if (interceptorType.IsGenericTypeDefinition)
+            {
+                openGenericInterceptorTypes.Add(interceptorType);
+                continue;
+            }
+
             var interceptorInterface = interceptorType
                 .GetInterfaces()
                 .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IInterceptReadModel<>));
@@ -61,24 +73,126 @@ public class ReadModelInterceptors(ITypes types) : IReadModelInterceptors
             entry.Types.Add(interceptorType);
         }
 
-        return map.ToDictionary(
+        var concreteInterceptors = map.ToDictionary(
             kvp => kvp.Key,
             kvp => new InterceptorEntry(kvp.Value.Types, kvp.Value.Method!, kvp.Value.ResultProperty!));
+
+        return new(concreteInterceptors, openGenericInterceptorTypes);
     }
 
-    async Task<object> InterceptItem(object item, InterceptorEntry entry, IServiceProvider serviceProvider)
+    static bool TryCreateOpenGenericEntry(Type openGenericInterceptorType, Type readModelType, out InterceptorEntry entry)
+    {
+        entry = default;
+
+        if (!openGenericInterceptorType.IsGenericTypeDefinition ||
+            openGenericInterceptorType.GetGenericArguments().Length != 1)
+        {
+            return false;
+        }
+
+        Type interceptorType;
+        try
+        {
+            interceptorType = openGenericInterceptorType.MakeGenericType(readModelType);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        var interceptorInterface = interceptorType
+            .GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IInterceptReadModel<>));
+
+        if (interceptorInterface is null)
+        {
+            return false;
+        }
+
+        var method = interceptorInterface.GetMethod(nameof(IInterceptReadModel<object>.Intercept));
+        var resultProperty = method!.ReturnType.GetProperty("Result");
+
+        entry = new([interceptorType], method, resultProperty!);
+        return true;
+    }
+
+    static ServiceInterceptorEntry CreateServiceEntry(Type readModelType)
+    {
+        var serviceType = typeof(IInterceptReadModel<>).MakeGenericType(readModelType);
+        var enumerableServiceType = typeof(IEnumerable<>).MakeGenericType(serviceType);
+        var method = serviceType.GetMethod(nameof(IInterceptReadModel<object>.Intercept));
+        var resultProperty = method!.ReturnType.GetProperty("Result");
+
+        return new(enumerableServiceType, method, resultProperty!);
+    }
+
+    static IReadOnlyList<object> GetServiceInterceptors(ServiceInterceptorEntry entry, IServiceProvider serviceProvider)
+    {
+        if (serviceProvider.GetService(entry.EnumerableServiceType) is not System.Collections.IEnumerable interceptors)
+        {
+            return [];
+        }
+
+        return [.. interceptors.Cast<object>()];
+    }
+
+    IReadOnlyList<InterceptorEntry> BuildEntriesFor(Type readModelType)
+    {
+        var entries = new List<InterceptorEntry>();
+
+        if (_cache.ConcreteInterceptors.TryGetValue(readModelType, out var concreteEntry))
+        {
+            entries.Add(concreteEntry);
+        }
+
+        foreach (var openGenericInterceptorType in _cache.OpenGenericInterceptorTypes)
+        {
+            if (TryCreateOpenGenericEntry(openGenericInterceptorType, readModelType, out var entry))
+            {
+                entries.Add(entry);
+            }
+        }
+
+        return entries;
+    }
+
+    async Task<object> InterceptItem(
+        object item,
+        IEnumerable<InterceptorEntry> entries,
+        IReadOnlyList<object> serviceInterceptors,
+        ServiceInterceptorEntry serviceEntry,
+        IServiceProvider serviceProvider)
     {
         var current = item;
-        foreach (var interceptorType in entry.InterceptorTypes)
+        var invokedInterceptorTypes = new HashSet<Type>();
+
+        foreach (var entry in entries)
         {
-            var interceptor = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, interceptorType);
-            var task = (Task)entry.InterceptMethod.Invoke(interceptor, [current])!;
+            foreach (var interceptorType in entry.InterceptorTypes)
+            {
+                var interceptor = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, interceptorType);
+                var task = (Task)entry.InterceptMethod.Invoke(interceptor, [current])!;
+                await task;
+                current = entry.TaskResultProperty.GetValue(task)!;
+                invokedInterceptorTypes.Add(interceptorType);
+            }
+        }
+
+        foreach (var interceptor in serviceInterceptors.Where(_ => !invokedInterceptorTypes.Contains(_.GetType())))
+        {
+            var task = (Task)serviceEntry.InterceptMethod.Invoke(interceptor, [current])!;
             await task;
-            current = entry.TaskResultProperty.GetValue(task)!;
+            current = serviceEntry.TaskResultProperty.GetValue(task)!;
         }
 
         return current;
     }
 
+    readonly record struct InterceptorCache(
+        IReadOnlyDictionary<Type, InterceptorEntry> ConcreteInterceptors,
+        IReadOnlyList<Type> OpenGenericInterceptorTypes);
+
     readonly record struct InterceptorEntry(IReadOnlyList<Type> InterceptorTypes, MethodInfo InterceptMethod, PropertyInfo TaskResultProperty);
+
+    readonly record struct ServiceInterceptorEntry(Type EnumerableServiceType, MethodInfo InterceptMethod, PropertyInfo TaskResultProperty);
 }

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Chronicle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+public class when_adding_read_models : Specification
+{
+    IServiceCollection _services;
+
+    void Establish()
+    {
+        var clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
+        clientArtifactsProvider.Projections.Returns([]);
+        clientArtifactsProvider.ModelBoundProjections.Returns([]);
+
+        _services = new ServiceCollection();
+        _services.AddReadModels(clientArtifactsProvider);
+    }
+
+    [Fact] void should_register_read_model_interceptor() =>
+        _services.ShouldContain(_ =>
+            _.ServiceType == typeof(IInterceptReadModel<>) &&
+            _.ImplementationType == typeof(ReadModelInterceptor<>));
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models_to_multiple_service_collections.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models_to_multiple_service_collections.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Chronicle;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+public class when_adding_read_models_to_multiple_service_collections : Specification
+{
+    IServiceCollection _firstServices;
+    IServiceCollection _secondServices;
+
+    void Establish()
+    {
+        var clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
+        clientArtifactsProvider.Projections.Returns([]);
+        clientArtifactsProvider.ModelBoundProjections.Returns([]);
+
+        _firstServices = new ServiceCollection();
+        _secondServices = new ServiceCollection();
+
+        _firstServices.AddReadModels(clientArtifactsProvider);
+        _secondServices.AddReadModels(clientArtifactsProvider);
+    }
+
+    [Fact] void should_register_read_model_interceptor_in_first_service_collection() =>
+        _firstServices.ShouldContain(ReadModelInterceptorRegistration);
+
+    [Fact] void should_register_read_model_interceptor_in_second_service_collection() =>
+        _secondServices.ShouldContain(ReadModelInterceptorRegistration);
+
+    static bool ReadModelInterceptorRegistration(ServiceDescriptor descriptor) =>
+        descriptor.ServiceType == typeof(IInterceptReadModel<>) &&
+        descriptor.ImplementationType == typeof(ReadModelInterceptor<>);
+}

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Arc.Chronicle.ReadModels;
 using Cratis.Arc.Commands;
+using Cratis.Arc.Queries;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Projections;
@@ -29,7 +30,6 @@ public static class ReadModelServiceCollectionExtensions
                    parameters.Length == 1 &&
                    parameters[0].ParameterType.IsGenericParameter;
         });
-    static bool _initialized;
 
     /// <summary>
     /// Adds read model auto-discovery and registration to the service collection.
@@ -39,11 +39,7 @@ public static class ReadModelServiceCollectionExtensions
     /// <returns>The service collection for continuation.</returns>
     public static IServiceCollection AddReadModels(this IServiceCollection services, IClientArtifactsProvider clientArtifactsProvider)
     {
-        if (_initialized)
-        {
-            return services;
-        }
-        _initialized = true;
+        services.TryAddEnumerable(ServiceDescriptor.Transient(typeof(IInterceptReadModel<>), typeof(ReadModelInterceptor<>)));
 
         var readModelTypesFromProjections = clientArtifactsProvider.Projections
             .Select(projectionType =>


### PR DESCRIPTION
## Changed

- Changed Chronicle read model setup to register the compliance interceptor in each service collection (#2152)

## Fixed

- Fixed open generic read model interceptors being skipped by Arc query interception (#2152)
- Fixed DI-registered read model interceptors not running for query read models (#2152)