### PR TITLE
Fix nullable type mapping in ProxyGenerator

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_DateTime.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_DateTime.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_nullable_types;
+
+public class and_type_is_nullable_DateTime : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(DateTime?).GetTargetType();
+
+    [Fact] void should_have_date_as_type() => _result.Type.ShouldEqual("Date");
+    [Fact] void should_have_date_as_constructor() => _result.Constructor.ShouldEqual("Date");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_DateTimeOffset.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_DateTimeOffset.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_nullable_types;
+
+public class and_type_is_nullable_DateTimeOffset : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(DateTimeOffset?).GetTargetType();
+
+    [Fact] void should_have_date_as_type() => _result.Type.ShouldEqual("Date");
+    [Fact] void should_have_date_as_constructor() => _result.Constructor.ShouldEqual("Date");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_Guid.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_Guid.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_nullable_types;
+
+public class and_type_is_nullable_Guid : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(Guid?).GetTargetType();
+
+    [Fact] void should_have_guid_as_type() => _result.Type.ShouldEqual("Guid");
+    [Fact] void should_have_guid_as_constructor() => _result.Constructor.ShouldEqual("Guid");
+    [Fact] void should_have_cratis_fundamentals_as_module() => _result.Module.ShouldEqual("@cratis/fundamentals");
+    [Fact] void should_be_from_package() => _result.FromPackage.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_bool.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_bool.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_nullable_types;
+
+public class and_type_is_nullable_bool : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(bool?).GetTargetType();
+
+    [Fact] void should_have_boolean_as_type() => _result.Type.ShouldEqual("boolean");
+    [Fact] void should_have_boolean_as_constructor() => _result.Constructor.ShouldEqual("Boolean");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_int.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_nullable_types/and_type_is_nullable_int.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_nullable_types;
+
+public class and_type_is_nullable_int : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(int?).GetTargetType();
+
+    [Fact] void should_have_number_as_type() => _result.Type.ShouldEqual("number");
+    [Fact] void should_have_number_as_constructor() => _result.Constructor.ShouldEqual("Number");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -458,6 +458,13 @@ public static class TypeExtensions
             type = type.GetConceptValueType();
         }
 
+        // Handle nullable types (Nullable<T>) by unwrapping and getting the target type of the underlying type
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type)!;
+            return underlyingType.GetTargetType();
+        }
+
         if (_primitiveTypeMap.TryGetValue(type.FullName!, out var value))
         {
             return value;


### PR DESCRIPTION
## Fixed
- ProxyGenerator now correctly maps nullable value types (`DateTimeOffset?`, `DateTime?`, `int?`, `Guid?`, `bool?`) to their underlying TypeScript types (`Date`, `number`, `boolean`, `Guid`) instead of the literal type name `Nullable`

## Summary

The ProxyGenerator's `GetTargetType` method did not handle `Nullable<T>` generic types, causing nullable primitives in C# controller parameters to be translated as `Nullable` in TypeScript proxies instead of their correct underlying types.

Added nullable type detection that unwraps `Nullable<T>` to the underlying type and recursively resolves the correct TypeScript mapping. This fix ensures type safety is preserved across the C#/TypeScript boundary for all nullable primitive query parameters.