### PR TITLE
Fix NullReferenceException on generic type parameters in ProxyGenerator

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_generic_type_parameters/and_type_is_dictionary_with_generic_key.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_generic_type_parameters/and_type_is_dictionary_with_generic_key.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_generic_type_parameters;
+
+public class and_type_is_dictionary_with_generic_key : Specification
+{
+    TargetType _result = null!;
+
+    void Because()
+    {
+        // Dictionary with a generic type parameter as key
+        var genericDictionaryType = typeof(Dictionary<,>);
+        _result = genericDictionaryType.GetTargetType();
+    }
+
+    [Fact] void should_not_throw_null_reference_exception() => _result.ShouldNotBeNull();
+    [Fact] void should_be_final() => _result.Final.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_generic_type_parameters/and_type_is_generic_type_parameter.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_generic_type_parameters/and_type_is_generic_type_parameter.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_getting_target_type_for_generic_type_parameters;
+
+public class and_type_is_generic_type_parameter : Specification
+{
+    TargetType _result = null!;
+
+    void Because()
+    {
+        // Get the generic type parameter T from a generic type definition
+        var genericType = typeof(List<>);
+        var typeParameter = genericType.GetGenericArguments()[0];
+        _result = typeParameter.GetTargetType();
+    }
+
+    [Fact] void should_not_throw_null_reference_exception() => _result.ShouldNotBeNull();
+    [Fact] void should_have_type_name() => _result.Type.ShouldEqual("T");
+    [Fact] void should_have_constructor_name() => _result.Constructor.ShouldEqual("T");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -262,8 +262,8 @@ public static class TypeExtensions
     /// <param name="type">Type to check.</param>
     /// <returns>True if it is observable, false if not.</returns>
     public static bool IsSubject(this Type type) =>
-        type.FullName!.StartsWith("System.Reactive.Subjects.ISubject`1") ||
-        type.FullName!.StartsWith("System.IObservable`1");
+        (type.FullName?.StartsWith("System.Reactive.Subjects.ISubject`1") ?? false) ||
+        (type.FullName?.StartsWith("System.IObservable`1") ?? false);
 
     /// <summary>
     /// Check if a type is a task or a task of T.
@@ -271,8 +271,8 @@ public static class TypeExtensions
     /// <param name="type">Type to check.</param>
     /// <returns>True if it is a task, false if not.</returns>
     public static bool IsTask(this Type type) =>
-        type.FullName!.StartsWith(_taskType.FullName!) ||
-        (type.IsGenericType && type.GetGenericTypeDefinition().FullName!.StartsWith(typeof(Task<>).FullName!));
+        (type.FullName?.StartsWith(_taskType.FullName!) ?? false) ||
+        (type.IsGenericType && (type.GetGenericTypeDefinition().FullName?.StartsWith(typeof(Task<>).FullName!) ?? false));
 
     /// <summary>
     /// Check if a type is a String or not.
@@ -313,7 +313,7 @@ public static class TypeExtensions
             type = type.GetConceptValueType();
         }
 
-        return _primitiveTypeMap.ContainsKey(type.FullName!);
+        return type.FullName is not null && _primitiveTypeMap.ContainsKey(type.FullName);
     }
 
     /// <summary>
@@ -439,7 +439,7 @@ public static class TypeExtensions
             var resolvedKeyType = keyType.IsConcept() ? keyType.GetConceptValueType() : keyType;
             var keyTargetType = resolvedKeyType.IsEnum
                 ? new TargetType(resolvedKeyType, resolvedKeyType.Name, "Number")
-                : _primitiveTypeMap.TryGetValue(resolvedKeyType.FullName!, out var primitiveKeyType)
+                : resolvedKeyType.FullName is not null && _primitiveTypeMap.TryGetValue(resolvedKeyType.FullName, out var primitiveKeyType)
                     ? primitiveKeyType
                     : new TargetType(resolvedKeyType, resolvedKeyType.Name, resolvedKeyType.Name);
 
@@ -465,7 +465,7 @@ public static class TypeExtensions
             return underlyingType.GetTargetType();
         }
 
-        if (_primitiveTypeMap.TryGetValue(type.FullName!, out var value))
+        if (type.FullName is not null && _primitiveTypeMap.TryGetValue(type.FullName, out var value))
         {
             return value;
         }
@@ -525,7 +525,7 @@ public static class TypeExtensions
 
                 var resolvedKeyTargetType = resolvedKeyType.IsEnum
                     ? new TargetType(resolvedKeyType, resolvedKeyType.Name, "Number")
-                    : _primitiveTypeMap.TryGetValue(resolvedKeyType.FullName!, out var keyPrimitiveType)
+                    : resolvedKeyType.FullName is not null && _primitiveTypeMap.TryGetValue(resolvedKeyType.FullName, out var keyPrimitiveType)
                         ? keyPrimitiveType
                         : new TargetType(resolvedKeyType, resolvedKeyType.Name, resolvedKeyType.Name);
                 if (resolvedKeyTargetType.Type != "string")
@@ -846,7 +846,7 @@ public static class TypeExtensions
     public static bool IsAPrimitiveType(this Type type)
     {
         return type.GetTypeInfo().IsPrimitive
-                || type.IsNullable() || _primitiveTypeMap.ContainsKey(type.FullName!);
+                || type.IsNullable() || (type.FullName is not null && _primitiveTypeMap.ContainsKey(type.FullName));
     }
 
     /// <summary>
@@ -1100,7 +1100,7 @@ public static class TypeExtensions
     /// <returns>The best type found, or the original tuple type if none match the criteria.</returns>
     public static Type GetBestTupleType(this Type type)
     {
-        if (!type.IsGenericType || !type.FullName!.StartsWith("System.ValueTuple"))
+        if (!type.IsGenericType || !(type.FullName?.StartsWith("System.ValueTuple") ?? false))
         {
             return type;
         }
@@ -1164,7 +1164,7 @@ public static class TypeExtensions
     /// <returns>The unwrapped type, or null if the type should be skipped.</returns>
     static Type? UnwrapType(Type type)
     {
-        if (type.IsGenericType && type.FullName!.StartsWith("System.ValueTuple"))
+        if (type.IsGenericType && (type.FullName?.StartsWith("System.ValueTuple") ?? false))
         {
             return type.GetBestTupleType();
         }


### PR DESCRIPTION
## Summary

Fixes a NullReferenceException regression where generic type parameters and certain constructed generic types have null `FullName` properties, causing crashes during proxy generation in downstream projects like Chronicle.

## Fixed

- Add integration specs for generic type parameter and dictionary with generic key scenarios that previously caused null reference exceptions
- Replace null-forgiving operators with proper null guards throughout TypeExtensions for all `type.FullName` usages