### PR TITLE
Fix IsKnownType to unwrap nullable types before checking primitive map

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_nullable_date_time_offset_is_known_type.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_nullable_date_time_offset_is_known_type.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+public class when_checking_if_nullable_date_time_offset_is_known_type : Specification
+{
+    bool _result;
+
+    void Because() => _result = typeof(DateTimeOffset?).IsKnownType();
+
+    [Fact] void should_be_known_type() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_nullable_guid_is_known_type.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_checking_if_nullable_guid_is_known_type.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+public class when_checking_if_nullable_guid_is_known_type : Specification
+{
+    bool _result;
+
+    void Because() => _result = typeof(Guid?).IsKnownType();
+
+    [Fact] void should_be_known_type() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -313,6 +313,13 @@ public static class TypeExtensions
             type = type.GetConceptValueType();
         }
 
+        // Unwrap nullable types before checking the primitive map - Nullable<T> primitives
+        // should be treated as known types since they map to TypeScript primitives
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == _nullableType)
+        {
+            type = type.GetGenericArguments()[0];
+        }
+
         return type.FullName is not null && _primitiveTypeMap.ContainsKey(type.FullName);
     }
 


### PR DESCRIPTION
## Fixed
- Incorrect TypeScript import generation for nullable primitive types (e.g. `import { Date } from '../Nullable\`1'`)