### PR TITLE
Fix Date serialization in URL query parameters

### DIFF
--- a/Source/JavaScript/Arc/UrlHelpers.ts
+++ b/Source/JavaScript/Arc/UrlHelpers.ts
@@ -1,6 +1,18 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+/**
+ * Format a single query / route parameter value into a string the .NET TypeConverter
+ * infrastructure can round-trip. Date values are emitted as ISO 8601 so DateTimeOffset
+ * binding succeeds; everything else falls back to the JS String coercion.
+ */
+function formatQueryValue(value: unknown): string {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    return String(value);
+}
+
 export class UrlHelpers {
     /**
      * Creates a URL from the given origin, API base path, and route.
@@ -40,8 +52,8 @@ export class UrlHelpers {
             }
 
             const pattern = new RegExp(`\\{${key}\\}`, 'gi');
-            const newRoute = result.replace(pattern, encodeURIComponent(String(value)));
-            
+            const newRoute = result.replace(pattern, encodeURIComponent(formatQueryValue(value)));
+
             if (newRoute !== result) {
                 delete unusedParameters[key as keyof T];
                 result = newRoute;
@@ -65,17 +77,17 @@ export class UrlHelpers {
             if (value !== undefined && value !== null) {
                 if (Array.isArray(value)) {
                     for (const item of value) {
-                        queryParams.append(key, String(item));
+                        queryParams.append(key, formatQueryValue(item));
                     }
                 } else {
-                    queryParams.set(key, String(value));
+                    queryParams.set(key, formatQueryValue(value));
                 }
             }
         }
 
         if (additionalParams) {
             for (const [key, value] of Object.entries(additionalParams)) {
-                queryParams.set(key, String(value));
+                queryParams.set(key, formatQueryValue(value));
             }
         }
 

--- a/Source/JavaScript/Arc/for_UrlHelpers/when_building_query_params/with_date_values.ts
+++ b/Source/JavaScript/Arc/for_UrlHelpers/when_building_query_params/with_date_values.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { describe, it, beforeEach } from 'vitest';
+import { UrlHelpers } from '../../UrlHelpers';
+
+describe('when building query params with date values', () => {
+    const startTime = new Date(Date.UTC(2026, 5, 3, 13, 57, 6));
+    const endTime = new Date(Date.UTC(2026, 5, 3, 14, 0, 32));
+    let result: URLSearchParams;
+
+    beforeEach(() => {
+        result = UrlHelpers.buildQueryParams({ startTime, endTime });
+    });
+
+    it('should serialize startTime as ISO 8601', () => result.get('startTime')!.should.equal('2026-06-03T13:57:06.000Z'));
+    it('should serialize endTime as ISO 8601', () => result.get('endTime')!.should.equal('2026-06-03T14:00:32.000Z'));
+});


### PR DESCRIPTION
## Fixed
- Date objects in URL query parameters and route replacements now serialize as ISO 8601 for .NET DateTimeOffset binding compatibility