### PR TITLE
Fix observable queries breaking under read model interception

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
@@ -14,6 +14,8 @@ public class an_observable_query_demultiplexer : Specification
     protected IQueryContextManager _queryContextManager;
     protected IHttpRequestContextAccessor _httpRequestContextAccessor;
     protected IHostApplicationLifetime _hostApplicationLifetime;
+    protected IReadModelInterceptors _readModelInterceptors;
+    protected IServiceProvider _serviceProvider;
     protected IOptions<ArcOptions> _arcOptions;
     protected ILogger<ObservableQueryDemultiplexer> _logger;
     protected ObservableQueryDemultiplexer _hub;
@@ -25,6 +27,14 @@ public class an_observable_query_demultiplexer : Specification
         _httpRequestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
         _hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
         _hostApplicationLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        // Pass-through interception by default — each emitted item flows out unchanged. Specs that
+        // exercise compliance/PII release override this to assert the streaming path is intercepted.
+        _readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        _readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+        _serviceProvider = Substitute.For<IServiceProvider>();
+
         _arcOptions = Options.Create(new ArcOptions());
         _logger = Substitute.For<ILogger<ObservableQueryDemultiplexer>>();
         _hub = new ObservableQueryDemultiplexer(
@@ -32,6 +42,8 @@ public class an_observable_query_demultiplexer : Specification
             _queryContextManager,
             _httpRequestContextAccessor,
             _hostApplicationLifetime,
+            _readModelInterceptors,
+            _serviceProvider,
             _arcOptions,
             _logger);
     }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
@@ -97,8 +97,7 @@ public class and_connection_is_known_and_read_models_are_intercepted_per_emissio
 
         foreach (var hubMessage in _messages
                      .Select(TryParseHubMessage)
-                     .Where(_ => _ is not null)
-                     .Select(_ => _))
+                     .Where(_ => _ is not null))
         {
             if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
             {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// Observed read models are stored encrypted; compliance/PII release happens through the read model interceptors.
+/// The multiplexed hub must therefore intercept every emission — keyed by the read model element type, even when
+/// the query streams a collection of read models — before sending each value to the client.
+/// </summary>
+public class and_connection_is_known_and_read_models_are_intercepted_per_emission : given.an_observable_query_demultiplexer
+{
+    const string ControllerQueryName = "Cratis.Chronicle.Api.EventStores.EventStoreQueries.AllEventStores";
+    const string QueryId = "query-1";
+
+    IHttpRequestContext _connectionContext;
+    IHttpRequestContext _subscribeContext;
+    CancellationTokenSource _connectionCancellation;
+    ConcurrentQueue<string> _messages;
+    BehaviorSubject<IEnumerable<string>> _subject;
+    string _connectionId;
+
+    void Establish()
+    {
+        _connectionCancellation = new CancellationTokenSource();
+        _messages = [];
+        _connectionId = string.Empty;
+
+        // Releasing interceptor — every item is transformed, standing in for PII decryption. If the streaming
+        // path failed to intercept, the emitted value would still be the raw "item-a".
+        _readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult<IEnumerable<object>>(
+                [.. callInfo.ArgAt<IEnumerable<object>>(1).Select(item => (object)$"{item}-released")]));
+
+        _subject = new BehaviorSubject<IEnumerable<string>>([]);
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                var queryResult = QueryResult.Success(CorrelationId.New());
+                queryResult.Data = _subject;
+                return Task.FromResult(queryResult);
+            });
+
+        _connectionContext = Substitute.For<IHttpRequestContext>();
+        _connectionContext.RequestAborted.Returns(_connectionCancellation.Token);
+        _connectionContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _connectionContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        _subscribeContext = Substitute.For<IHttpRequestContext>();
+        _subscribeContext.RequestAborted.Returns(CancellationToken.None);
+        _subscribeContext.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
+                _connectionId,
+                QueryId,
+                new ObservableQuerySubscriptionRequest(ControllerQueryName))));
+    }
+
+    async Task Because()
+    {
+        var connectionTask = _hub.HandleSSEConnection(_connectionContext);
+
+        await WaitFor(() => TryExtractConnectionId(out _connectionId));
+        await _hub.HandleSSESubscribe(_subscribeContext);
+
+        _subject.OnNext(["item-a"]);
+        await WaitFor(() => string.Concat(_messages).Contains("item-a-released", StringComparison.Ordinal));
+
+        await _connectionCancellation.CancelAsync();
+        await connectionTask;
+    }
+
+    [Fact] void should_intercept_each_emission_with_the_read_model_element_type() =>
+        _readModelInterceptors.Received().Intercept(typeof(string), Arg.Any<IEnumerable<object>>(), _serviceProvider);
+
+    [Fact] void should_send_the_released_value_to_the_client() =>
+        string.Concat(_messages).Contains("item-a-released", StringComparison.Ordinal).ShouldBeTrue();
+
+    bool TryExtractConnectionId(out string connectionId)
+    {
+        connectionId = string.Empty;
+
+        foreach (var hubMessage in _messages
+                     .Select(TryParseHubMessage)
+                     .Where(_ => _ is not null)
+                     .Select(_ => _))
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
+            {
+                continue;
+            }
+
+            connectionId = payload.GetString() ?? string.Empty;
+            return !string.IsNullOrEmpty(connectionId);
+        }
+
+        return false;
+    }
+
+    ObservableQueryHubMessage? TryParseHubMessage(string sseMessage)
+    {
+        if (!sseMessage.StartsWith("data: ", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var json = sseMessage["data: ".Length..].Trim();
+        return JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_async_enumerable_query_result.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_async_enumerable_query_result.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_QueryPipeline.when_performing;
+
+/// <summary>
+/// Like an observable subject, an async-enumerable result is a streaming wrapper that the streaming transport
+/// intercepts per item — the pipeline must leave it untouched rather than passing it to the per-item interceptor.
+/// </summary>
+public class with_async_enumerable_query_result : given.a_query_pipeline
+{
+    FullyQualifiedQueryName _queryName;
+    QueryArguments _parameters;
+    Paging _paging;
+    Sorting _sorting;
+    QueryResult _filterResult;
+    IAsyncEnumerable<object> _asyncEnumerable;
+    QueryRendererResult _rendererResult;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _queryName = "TestQuery";
+        _parameters = new();
+        _paging = Paging.NotPaged;
+        _sorting = Sorting.None;
+
+        _filterResult = QueryResult.Success(_correlationId);
+        _asyncEnumerable = CreateAsyncStream();
+        _rendererResult = new QueryRendererResult(0, _asyncEnumerable);
+
+        _queryPerformer.ReadModelType.Returns(typeof(object));
+        _queryPerformer.Dependencies.Returns(new List<Type>());
+        _queryPerformerProviders.TryGetPerformersFor(_queryName, out var _).Returns(callInfo =>
+        {
+            callInfo[1] = _queryPerformer;
+            return true;
+        });
+
+        query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_asyncEnumerable));
+        _queryRenderers.Render(_queryName, _asyncEnumerable, _serviceProvider).Returns(_rendererResult);
+    }
+
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
+
+    [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_capture_any_exception() => _result.ExceptionMessages.ShouldBeEmpty();
+    [Fact] void should_return_the_async_enumerable_untouched() => _result.Data.ShouldEqual(_asyncEnumerable);
+    [Fact] void should_not_invoke_the_read_model_interceptors() =>
+        _readModelInterceptors.DidNotReceive().Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>());
+
+    static async IAsyncEnumerable<object> CreateAsyncStream()
+    {
+        await Task.CompletedTask;
+        yield return new { value = "item-one" };
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_observable_query_result.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_observable_query_result.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.Queries.for_QueryPipeline.when_performing;
+
+/// <summary>
+/// An observable query result is a subject wrapper, not a read model instance. It must flow through the pipeline
+/// untouched so the streaming transport can intercept each emission; handing the wrapper to the per-item read
+/// model interceptor here would try to bind the subject to the read model type and throw at append time.
+/// </summary>
+public class with_observable_query_result : given.a_query_pipeline
+{
+    FullyQualifiedQueryName _queryName;
+    QueryArguments _parameters;
+    Paging _paging;
+    Sorting _sorting;
+    QueryResult _filterResult;
+    ISubject<IEnumerable<object>> _subject;
+    QueryRendererResult _rendererResult;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _queryName = "TestQuery";
+        _parameters = new();
+        _paging = Paging.NotPaged;
+        _sorting = Sorting.None;
+
+        _filterResult = QueryResult.Success(_correlationId);
+        _subject = new ReplaySubject<IEnumerable<object>>();
+        _rendererResult = new QueryRendererResult(0, _subject);
+
+        _queryPerformer.ReadModelType.Returns(typeof(object));
+        _queryPerformer.Dependencies.Returns(new List<Type>());
+        _queryPerformerProviders.TryGetPerformersFor(_queryName, out var _).Returns(callInfo =>
+        {
+            callInfo[1] = _queryPerformer;
+            return true;
+        });
+
+        query_filters.OnPerform(Arg.Any<QueryContext>()).Returns(_filterResult);
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(_subject));
+        _queryRenderers.Render(_queryName, _subject, _serviceProvider).Returns(_rendererResult);
+    }
+
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, _paging, _sorting, _serviceProvider);
+
+    [Fact] void should_return_successful_result() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_capture_any_exception() => _result.ExceptionMessages.ShouldBeEmpty();
+    [Fact] void should_return_the_subject_untouched() => _result.Data.ShouldEqual(_subject);
+    [Fact] void should_not_invoke_the_read_model_interceptors() =>
+        _readModelInterceptors.DidNotReceive().Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_a_streaming_subject_instead_of_a_read_model.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptors/when_intercepting/with_a_streaming_subject_instead_of_a_read_model.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptors.when_intercepting;
+
+/// <summary>
+/// Reproduces the production failure that motivated skipping streaming results in the query pipeline. When an
+/// observable query result — an <see cref="ISubject{T}"/> wrapper such as Arc's MongoDB LifetimeAwareSubject — is
+/// handed to the per-item interceptor as if it were a read model, the reflective
+/// <c>IInterceptReadModel&lt;TReadModel&gt;.Intercept(TReadModel)</c> call cannot bind the wrapper to the read
+/// model type and throws "...cannot be converted to type...". The pipeline must therefore never pass a streaming
+/// result to the interceptors.
+/// </summary>
+public class with_a_streaming_subject_instead_of_a_read_model : given.a_read_model_interceptors
+{
+    GenericReadModelInterceptor<TestReadModel> _interceptorInstance;
+    ISubject<IEnumerable<TestReadModel>> _subject;
+    Exception _exception;
+
+    void Establish()
+    {
+        _subject = new ReplaySubject<IEnumerable<TestReadModel>>();
+        _interceptorInstance = new GenericReadModelInterceptor<TestReadModel>();
+
+        var types = Substitute.For<ITypes>();
+        types.FindMultiple(typeof(IInterceptReadModel<>)).Returns([typeof(GenericReadModelInterceptor<>)]);
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _serviceProvider.GetService(typeof(GenericReadModelInterceptor<TestReadModel>)).Returns(_interceptorInstance);
+
+        _interceptors = new ReadModelInterceptors(types);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(
+        () => _interceptors.Intercept(typeof(TestReadModel), [_subject], _serviceProvider));
+
+    [Fact] void should_throw() => _exception.ShouldNotBeNull();
+    [Fact] void should_fail_to_convert_the_subject_to_the_read_model_type() =>
+        _exception.Message.ShouldContain("cannot be converted to type");
+    [Fact] void should_not_intercept_the_subject() => _interceptorInstance.InterceptedItems.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/given/interceptors.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/given/interceptors.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptorsExtensions.given;
+
+public class interceptors : Specification
+{
+    protected IReadModelInterceptors _interceptors;
+    protected IServiceProvider _serviceProvider;
+
+    public record TestReadModel(string Value);
+
+    void Establish()
+    {
+        _interceptors = Substitute.For<IReadModelInterceptors>();
+        _interceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+        _serviceProvider = Substitute.For<IServiceProvider>();
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_collection_of_read_models.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_collection_of_read_models.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptorsExtensions.when_intercepting_emission;
+
+/// <summary>
+/// A collection query emits an observable of an enumerable of read models. The interceptor must be keyed by the
+/// element read model type, not the enumerable type — otherwise no interceptor is found for the enumerable and
+/// compliance/PII release is silently skipped for every item.
+/// </summary>
+public class with_a_collection_of_read_models : given.interceptors
+{
+    TestReadModel _first;
+    TestReadModel _second;
+    IEnumerable<TestReadModel> _value;
+    object _result;
+
+    void Establish()
+    {
+        _first = new TestReadModel("one");
+        _second = new TestReadModel("two");
+        _value = [_first, _second];
+    }
+
+    async Task Because() => _result = await _interceptors.InterceptEmission(typeof(IEnumerable<TestReadModel>), _value, _serviceProvider);
+
+    [Fact] void should_intercept_using_the_element_read_model_type() =>
+        _interceptors.Received().Intercept(typeof(TestReadModel), Arg.Any<IEnumerable<object>>(), _serviceProvider);
+    [Fact] void should_not_intercept_using_the_enumerable_type() =>
+        _interceptors.DidNotReceive().Intercept(typeof(IEnumerable<TestReadModel>), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>());
+    [Fact] void should_intercept_every_item() =>
+        _interceptors.Received().Intercept(typeof(TestReadModel), Arg.Is<IEnumerable<object>>(_ => _.Contains(_first) && _.Contains(_second)), _serviceProvider);
+    [Fact] void should_return_the_intercepted_collection() => ((IEnumerable<object>)_result).ShouldContain(_first);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_null_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_null_value.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptorsExtensions.when_intercepting_emission;
+
+public class with_a_null_value : given.interceptors
+{
+    object _result;
+
+    async Task Because() => _result = await _interceptors.InterceptEmission(typeof(TestReadModel), null, _serviceProvider);
+
+    [Fact] void should_return_null() => _result.ShouldBeNull();
+    [Fact] void should_not_invoke_the_interceptors() =>
+        _interceptors.DidNotReceive().Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_single_read_model.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_single_read_model.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptorsExtensions.when_intercepting_emission;
+
+public class with_a_single_read_model : given.interceptors
+{
+    TestReadModel _value;
+    object _result;
+
+    void Establish() => _value = new TestReadModel("hello");
+
+    async Task Because() => _result = await _interceptors.InterceptEmission(typeof(TestReadModel), _value, _serviceProvider);
+
+    [Fact] void should_intercept_using_the_read_model_type() =>
+        _interceptors.Received().Intercept(typeof(TestReadModel), Arg.Any<IEnumerable<object>>(), _serviceProvider);
+    [Fact] void should_return_the_single_intercepted_value() => _result.ShouldEqual(_value);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_string_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ReadModelInterceptorsExtensions/when_intercepting_emission/with_a_string_value.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ReadModelInterceptorsExtensions.when_intercepting_emission;
+
+/// <summary>
+/// A string is an enumerable of characters, but a string-returning query is a single value, not a collection — it
+/// must be intercepted as one value rather than enumerated character by character.
+/// </summary>
+public class with_a_string_value : given.interceptors
+{
+    object _result;
+
+    async Task Because() => _result = await _interceptors.InterceptEmission(typeof(string), "abc", _serviceProvider);
+
+    [Fact] void should_intercept_the_string_as_a_single_value() =>
+        _interceptors.Received().Intercept(typeof(string), Arg.Is<IEnumerable<object>>(_ => _.Count() == 1), _serviceProvider);
+    [Fact] void should_return_the_string() => _result.ShouldEqual("abc");
+}

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
@@ -44,9 +44,7 @@ public class ClientEnumerableObservable<T>(
                         continue;
                     }
 
-                    var intercepted = await readModelInterceptors.Intercept(typeof(T), [item], serviceProvider);
-
-                    queryResult.Data = intercepted.First();
+                    queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, serviceProvider);
                     var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                     if (error is null)
                     {

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
@@ -48,9 +48,7 @@ public class ClientEnumerableObservableSSE<T>(
                     continue;
                 }
 
-                var intercepted = await readModelInterceptors.Intercept(typeof(T), [item], serviceProvider);
-
-                queryResult.Data = intercepted.First();
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, serviceProvider);
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";
 

--- a/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
@@ -80,10 +80,8 @@ public class ClientObservable<T>(
                     return;
                 }
 
-                var intercepted = await readModelInterceptors.Intercept(typeof(T), [data], serviceProvider);
-
                 queryResult.Paging = new(queryContext.Paging.Page, queryContext.Paging.Size, queryContext.TotalItems);
-                queryResult.Data = intercepted.First();
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
 
                 var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                 if (error is not null && !cts.IsCancellationRequested)

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
@@ -78,10 +78,8 @@ public class ClientObservableSSE<T>(
                     return;
                 }
 
-                var intercepted = await readModelInterceptors.Intercept(typeof(T), [data], serviceProvider);
-
                 queryResult.Paging = new(queryContext.Paging.Page, queryContext.Paging.Size, queryContext.TotalItems);
-                queryResult.Data = intercepted.First();
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
 
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.WebSockets;
+using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using Cratis.Arc.Http;
@@ -39,6 +40,8 @@ namespace Cratis.Arc.Queries;
 /// <param name="queryContextManager">The <see cref="IQueryContextManager"/> for managing query contexts.</param>
 /// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> used to propagate the caller's identity into the authorization pipeline.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/> used to cancel connections on shutdown.</param>
+/// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> used to intercept (e.g. decrypt compliance/PII properties on) each emitted read model before it is sent to the client.</param>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors. The root provider is used because subscriptions outlive the short-lived subscribe request scope.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/> used for JSON serialization.</param>
 /// <param name="logger">The logger.</param>
 [Singleton]
@@ -47,6 +50,8 @@ public class ObservableQueryDemultiplexer(
     IQueryContextManager queryContextManager,
     IHttpRequestContextAccessor httpRequestContextAccessor,
     IHostApplicationLifetime hostApplicationLifetime,
+    IReadModelInterceptors readModelInterceptors,
+    IServiceProvider serviceProvider,
     IOptions<ArcOptions> arcOptions,
     ILogger<ObservableQueryDemultiplexer> logger) : IObservableQueryDemultiplexer
 {
@@ -525,7 +530,7 @@ public class ObservableQueryDemultiplexer(
         return (IDisposable)method.Invoke(this, [subject, queryId, paging, transferMode, correlationId, onNext, onError, token])!;
     }
 
-    IDisposable SubscribeToSubjectOfType<T>(
+    CompositeDisposable SubscribeToSubjectOfType<T>(
         ISubject<T> subject,
         string queryId,
         PagingInfo paging,
@@ -539,19 +544,32 @@ public class ObservableQueryDemultiplexer(
         var isDeltaMode = string.Equals(transferMode, "delta", StringComparison.OrdinalIgnoreCase);
         var isFullMode = string.Equals(transferMode, "full", StringComparison.OrdinalIgnoreCase);
 
+        // Interception (compliance/PII release) is asynchronous. Emissions are serialized through this gate so
+        // the per-emission interception and the ChangeSet's previous/current item bookkeeping stay ordered even
+        // when the underlying subject delivers the next value before the previous one has finished interception.
+        var emissionGate = new SemaphoreSlim(1, 1);
+
         // Capture the per-subscription query context here, while the AsyncLocal still carries the
         // context set up by the query pipeline. Observer callbacks below are invoked from the MongoDB
         // change-stream thread, where AsyncLocal flow does not reach, so reading the manager from
         // inside the callback would return QueryContext.NotSet and overwrite the real paging info.
         var subscriptionQueryContext = queryContextManager.Current;
 
-        return subject.Subscribe(
-            data =>
+        var subscription = subject.Subscribe(OnEmission, OnSubscriptionError);
+
+        return new CompositeDisposable(subscription, emissionGate);
+
+        async void OnEmission(T data)
+        {
+            if (token.IsCancellationRequested)
             {
-                if (token.IsCancellationRequested)
-                {
-                    return;
-                }
+                return;
+            }
+
+            await emissionGate.WaitAsync(token);
+            try
+            {
+                var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
 
                 var isFirstEmission = previousItems is null;
 
@@ -559,7 +577,7 @@ public class ObservableQueryDemultiplexer(
                 // Delta mode: skip computation on first emission (full snapshot is sent instead).
                 // Full mode: skip computation entirely (client always receives the full snapshot).
                 ChangeSet? changeSet = null;
-                if (!(data is not IEnumerable enumerable || data is string))
+                if (interceptedData is IEnumerable enumerable and not string)
                 {
                     var currentItems = enumerable.Cast<object>().ToArray();
                     if (!isFullMode && (!isDeltaMode || !isFirstEmission))
@@ -576,7 +594,7 @@ public class ObservableQueryDemultiplexer(
 
                     // Delta mode subsequent emissions omit Data; client reconstructs from ChangeSet.
                     // First emission always includes the full snapshot regardless of mode.
-                    Data = isDeltaMode && !isFirstEmission ? null! : data!,
+                    Data = isDeltaMode && !isFirstEmission ? null! : interceptedData!,
                     IsAuthorized = true,
                     ValidationResults = [],
                     ExceptionMessages = [],
@@ -597,25 +615,45 @@ public class ObservableQueryDemultiplexer(
                         subscriptionQueryContext.TotalItems);
                 }
 
-                _ = onNext(result);
-            },
-            error =>
+                await onNext(result);
+            }
+            catch (OperationCanceledException)
             {
-                if (token.IsCancellationRequested)
+                // Connection cancelled — nothing to report.
+            }
+            catch (Exception error) when (error is not IOException)
+            {
+                // Transport errors (broken pipe, reset connection) indicate the client disconnected and are
+                // ignored; anything else is a genuine failure that must be surfaced to the subscriber.
+                if (!token.IsCancellationRequested)
                 {
-                    return;
+                    logger.SubscriptionError(queryId, error);
+                    _ = onError(queryId, error.Message);
                 }
+            }
+            finally
+            {
+                emissionGate.Release();
+            }
+        }
 
-                // Transport errors (broken pipe, reset connection) indicate the client
-                // disconnected — cancel the connection and do not forward to the client.
-                if (error is IOException)
-                {
-                    return;
-                }
+        void OnSubscriptionError(Exception error)
+        {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
 
-                logger.SubscriptionError(queryId, error);
-                _ = onError(queryId, error.Message);
-            });
+            // Transport errors (broken pipe, reset connection) indicate the client
+            // disconnected — cancel the connection and do not forward to the client.
+            if (error is IOException)
+            {
+                return;
+            }
+
+            logger.SubscriptionError(queryId, error);
+            _ = onError(queryId, error.Message);
+        }
     }
 
     async Task StreamAsyncEnumerable(

--- a/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Subjects;
 using Cratis.Arc.Queries.ModelBound;
 using Cratis.Arc.Validation;
 using Cratis.Execution;
+using Cratis.Reflection;
 using Cratis.Traces;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
@@ -105,6 +107,16 @@ public class QueryPipeline(
 
     async Task<object> ApplyInterceptors(Type readModelType, object data, IServiceProvider serviceProvider)
     {
+        // Streaming results are intercepted per emission by the streaming transport — ClientObservableSSE /
+        // ClientObservable for single observable queries, and ObservableQueryDemultiplexer for the multiplexed
+        // hub. The data here is the subject / async-enumerable wrapper, not a read model instance, so handing it
+        // to the per-item interceptor would try to bind the wrapper to the read model type and throw.
+        if (data.GetType().ImplementsOpenGeneric(typeof(ISubject<>)) ||
+            data.GetType().ImplementsOpenGeneric(typeof(IAsyncEnumerable<>)))
+        {
+            return data;
+        }
+
         if (data is IQueryable queryable)
         {
             var items = queryable.Cast<object>().ToList();

--- a/Source/DotNET/Arc.Core/Queries/ReadModelInterceptorsExtensions.cs
+++ b/Source/DotNET/Arc.Core/Queries/ReadModelInterceptorsExtensions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Extension methods for <see cref="IReadModelInterceptors"/> covering observable query emissions.
+/// </summary>
+public static class ReadModelInterceptorsExtensions
+{
+    /// <summary>
+    /// Intercepts a single value emitted by an observable query, applying the registered
+    /// <see cref="IInterceptReadModel{TReadModel}"/> interceptors per read model while preserving the emitted
+    /// shape. Collection emissions (an <see cref="IEnumerable{T}"/> of read models) are intercepted element by
+    /// element, keyed by the read model type rather than the enumerable type — without this, a collection query
+    /// would look for a non-existent interceptor for the enumerable and silently skip compliance/PII release.
+    /// </summary>
+    /// <param name="interceptors">The <see cref="IReadModelInterceptors"/> to apply.</param>
+    /// <param name="emittedType">The element type of the observable: the read model, or an enumerable of read models for collection queries.</param>
+    /// <param name="value">The emitted value to intercept.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors.</param>
+    /// <returns>The intercepted value, in the same shape (single value or enumerable) as the input.</returns>
+    public static async Task<object> InterceptEmission(
+        this IReadModelInterceptors interceptors,
+        Type emittedType,
+        object? value,
+        IServiceProvider serviceProvider)
+    {
+        if (value is null)
+        {
+            return value!;
+        }
+
+        var readModelType = GetReadModelType(emittedType);
+
+        if (value is IEnumerable enumerable and not string)
+        {
+            return await interceptors.Intercept(readModelType, enumerable.Cast<object>(), serviceProvider);
+        }
+
+        var intercepted = await interceptors.Intercept(readModelType, [value], serviceProvider);
+        return intercepted.First();
+    }
+
+    static Type GetReadModelType(Type emittedType)
+    {
+        if (emittedType == typeof(string))
+        {
+            return emittedType;
+        }
+
+        var enumerableInterface = emittedType.IsInterface && emittedType.IsGenericType && emittedType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            ? emittedType
+            : Array.Find(emittedType.GetInterfaces(), _ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        return enumerableInterface?.GetGenericArguments()[0] ?? emittedType;
+    }
+}


### PR DESCRIPTION
# Summary

The Chronicle read model interceptor (PII release) is registered for every read model, so `QueryPipeline.ApplyInterceptors` ran it against observable (`ISubject<T>`) and async-enumerable query results. It handed the streaming wrapper to `IInterceptReadModel<TReadModel>.Intercept(TReadModel)`, throwing `Object of type 'LifetimeAwareSubject<…>' cannot be converted to type '<ReadModel>'` and breaking every observable model-bound query served over the multiplexed SSE/WebSocket hub. Streaming interception now lives behind a single helper shared by all streaming transports, so compliance/PII release runs per emission — including for collection queries, which previously skipped it.

## Fixed

- Observable (`ISubject<T>`) and `IAsyncEnumerable<T>` model-bound query results no longer crash under read model interception. `QueryPipeline.ApplyInterceptors` now leaves streaming results untouched for the streaming transport to intercept per emission.
- Collection observable queries (`ISubject<IEnumerable<TReadModel>>`) now have compliance/PII release applied to each item. The streaming transports previously keyed interception on the enumerable type, found no matching interceptor, and silently served undecrypted values.

## Changed

- All streaming transports (`ObservableQueryDemultiplexer`, `ClientObservable`, `ClientObservableSSE`, `ClientEnumerableObservable`, `ClientEnumerableObservableSSE`) now share a single `IReadModelInterceptors.InterceptEmission` helper that intercepts each emission, unwrapping collection emissions to the read model element type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
