### PR TITLE
Improve and correct the Arc .NET onboarding & Chronicle-integration docs

### DIFF
--- a/Documentation/backend/chronicle/commands.md
+++ b/Documentation/backend/chronicle/commands.md
@@ -7,7 +7,7 @@ This content has moved. See [Commands](commands/index.md) for the full documenta
 When a model-bound command handler returns an event (or a collection of events), Chronicle appends those events to the event log automatically. This lets you keep command handlers focused on decisions and domain rules instead of event log plumbing.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -26,7 +26,7 @@ public record CustomerRegistered(EventSourceId CustomerId, string Email);
 You can also return multiple events as a collection:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -64,7 +64,7 @@ Chronicle resolves the event source id in this order:
 If none of these are present, Chronicle creates a new `EventSourceId` so the command still has a valid identity for event appends.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Keys;
 
@@ -90,7 +90,7 @@ Chronicle supports additional metadata that can be attached to commands and then
 Use `[EventStreamId]` to assign a specific event stream id to a command, or implement `ICanProvideEventStreamId` to supply it dynamically.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -113,7 +113,7 @@ If both a non-empty `[EventStreamId]` value and `ICanProvideEventStreamId` are u
 Use `[EventSourceType]` to tag events with a specific event source type when they are appended.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -133,7 +133,7 @@ Chronicle can build a concurrency scope based on command metadata so event appen
 This builds a [concurrency scope](xref:Chronicle.ConcurrencyScope) using the metadata values in the command context.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 

--- a/Documentation/backend/chronicle/commands/concurrency.md
+++ b/Documentation/backend/chronicle/commands/concurrency.md
@@ -16,7 +16,7 @@ Three attributes control concurrency scope declaration on a command. Each attrib
 Scopes concurrency to a specific event stream id within a stream type. Use this when independent streams within the same stream type should not interfere with each other.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -35,7 +35,7 @@ public record CustomerDisplayNameChanged(EventSourceId CustomerId, string Displa
 Scopes concurrency to a named stream type. Stream types group related streams — for example, separating `Onboarding` events from `Transactions` for the same customer.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -54,7 +54,7 @@ public record PaymentProcessed(EventSourceId AccountId, decimal Amount);
 Scopes concurrency to a named event source type. This is the overarching concept the event source belongs to — for example `Customer` or `BankAccount`.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -74,7 +74,7 @@ public record CustomerRegistered(EventSourceId CustomerId, string Email);
 You can combine multiple concurrency attributes to build a precise scope. Only the attributes with `concurrency: true` contribute to the scope; others still tag the events but do not affect concurrency.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -105,7 +105,7 @@ If no attribute has `concurrency: true`, Chronicle does not include a concurrenc
 When the event stream id is determined at runtime rather than as a constant, implement `ICanProvideEventStreamId` and return the id from `GetEventStreamId()`.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 

--- a/Documentation/backend/chronicle/commands/events.md
+++ b/Documentation/backend/chronicle/commands/events.md
@@ -6,7 +6,7 @@ uid: Arc.Chronicle.Commands.Events
 When a [model-bound](../../commands/model-bound/index.md) command handler returns an event (or a collection of events), Chronicle appends those events to the event log automatically. This lets you keep command handlers focused on decisions and domain rules instead of event log plumbing.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -25,7 +25,7 @@ public record CustomerRegistered(EventSourceId CustomerId, string Email);
 You can also return multiple events as a collection:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -63,7 +63,7 @@ Chronicle resolves the event source id in this order:
 If none of these are present, Chronicle creates a new `EventSourceId` so the command still has a valid identity for event appends.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Keys;
 
@@ -91,7 +91,7 @@ Chronicle supports additional metadata that can be attached to commands and used
 Use `[EventStreamId]` to assign a specific event stream id to a command, or implement `ICanProvideEventStreamId` to supply it dynamically.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -113,7 +113,7 @@ If both a non-empty `[EventStreamId]` value and `ICanProvideEventStreamId` are u
 Use `[EventStreamType]` to categorize events under a named stream type. This is useful for grouping related streams, such as separating onboarding events from transaction events for the same event source.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -127,7 +127,7 @@ public record RegisterCustomer(EventSourceId CustomerId, string Email);
 Use `[EventSourceType]` to tag events with a specific event source type when they are appended.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -147,7 +147,7 @@ Sometimes a single command needs to append events to multiple different event so
 Return a single `EventForEventSourceId` when only one cross-source event is needed:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -165,7 +165,7 @@ public record CustomerMigrated(EventSourceId OldCustomerId, EventSourceId NewCus
 Return an `IEnumerable<EventForEventSourceId>` to append events to several different event sources in one command:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 
@@ -191,7 +191,7 @@ Chronicle appends each event individually, in order. If any append fails (constr
 You can mix `EventForEventSourceId` values with regular events in a tuple return, letting some events use the command's own event source while others target specific event sources:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 

--- a/Documentation/backend/chronicle/commands/index.md
+++ b/Documentation/backend/chronicle/commands/index.md
@@ -11,6 +11,23 @@ A model-bound command handler in the Chronicle context can return events directl
 
 Chronicle also resolves the event source identity, event stream metadata, and concurrency scope from the command record itself — either by convention or via explicit attributes and interfaces. This means the same record that defines your command's shape also carries all the information Chronicle needs to append events correctly.
 
+## What `Handle()` returns decides what happens
+
+Chronicle inspects the value `Handle()` returns and appends accordingly. Anything it doesn't recognize as an event (or event metadata) becomes the command's **response** to the caller — so a tuple lets you append a fact *and* hand something back without ever calling the event log yourself.
+
+| `Handle()` returns | What Chronicle does |
+| --- | --- |
+| `void` / `Task` | Nothing is appended — the command just ran. |
+| An `[EventType]` event | Appended to the resolved event source's log. |
+| `IEnumerable<object>` of events | Each is appended, in order. |
+| `EventForEventSourceId` (or a collection of them) | Appended to the event source id carried *in the value*, overriding the resolved one — for writing to a different or several streams. |
+| Tuple `(event, result)` | The event is appended; the other element is returned to the caller as the response. |
+| Tuple `(EventSourceId, event)` | The `EventSourceId` sets the stream; the event is appended. See [Returning EventSourceId](./returning-event-source-id.md). |
+| Tuple `(event, Subject)` | The event is appended; the `Subject` is attached as [compliance metadata](./subject.md), not returned. |
+| `Result<TResult, TError>` (e.g. `Result<ValidationResult, T>`) | A failure short-circuits the command (nothing appended); a success is unwrapped and handled like the rows above. |
+
+The rule of thumb: **return the fact that happened.** The event source id (see [Resolving EventSourceId](./returning-event-source-id.md)) decides which stream it lands on.
+
 ## Topics
 
 | Topic | Description |

--- a/Documentation/backend/chronicle/commands/returning-event-source-id.md
+++ b/Documentation/backend/chronicle/commands/returning-event-source-id.md
@@ -10,7 +10,7 @@ Return `EventSourceId` from `Handle()` when the command decides which event sour
 When `Handle()` returns a tuple that contains both an event and an `EventSourceId`, Chronicle uses the returned id for the automatic append.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -30,7 +30,7 @@ public record CustomerRegistered(string Email, string DisplayName);
 The tuple order does not matter. Chronicle looks for the `EventSourceId` value anywhere in the tuple.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 [Command]
@@ -52,7 +52,7 @@ public record CustomerRegistered(string Email, string DisplayName);
 If your solution uses a type that derives from `EventSourceId`, you can return that type in the tuple as well.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.Events;
 
 public record CustomerId(Guid Value) : EventSourceId<Guid>(Value);

--- a/Documentation/backend/chronicle/commands/subject.md
+++ b/Documentation/backend/chronicle/commands/subject.md
@@ -14,7 +14,7 @@ When the subject is already part of the command, put it on the record itself.
 Implement `ICanProvideSubject` when you want the subject to be computed:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
@@ -35,7 +35,7 @@ public record OrderPlaced(EventSourceId OrderId, CustomerId CustomerId, decimal 
 Use a `Subject` property directly when the command already has the final compliance identity:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 
@@ -52,7 +52,7 @@ public record CustomerImported(EventSourceId CustomerId, string Email);
 Use `[Subject]` when the source value is not already a `Subject`:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 
@@ -73,7 +73,7 @@ Chronicle converts the `[Subject]` value to `Subject` by calling `ToString()`.
 Return `Subject` in the tuple from `Handle()` when the subject is decided inside the handler. A returned subject overrides any subject that was resolved from the command itself.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 

--- a/Documentation/backend/chronicle/compliance/subject.md
+++ b/Documentation/backend/chronicle/compliance/subject.md
@@ -23,7 +23,7 @@ If none of these are present, no subject is passed to Chronicle and it falls bac
 The simplest approach when the subject is computed inside the handler:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 
@@ -45,7 +45,7 @@ Arc detects the `Subject` in the tuple response and passes it to `Append` automa
 Use `ICanProvideSubject` when the subject is derived from command properties and you want an explicit, discoverable contract:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
@@ -65,7 +65,7 @@ public record PlaceOrder(EventSourceId OrderId, CustomerId CustomerId, decimal A
 When a command property directly represents the compliance identity, mark it with `[Subject]` from `Cratis.Chronicle`. Arc reads the property value and converts it to a `Subject`:
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 

--- a/Documentation/backend/chronicle/index.md
+++ b/Documentation/backend/chronicle/index.md
@@ -7,6 +7,26 @@ description: Add Chronicle's event-sourced write path to an Arc application whil
 
 Arc does not require Chronicle, and Chronicle does not require Arc. That independence is useful for adoption and bounded current-state slices. In a full Cratis information system, though, this integration is the natural pairing: Arc gives the CQRS boundary and Chronicle keeps the event-sourced facts underneath it.
 
+## How the two fit together
+
+The frameworks meet at one seam: an Arc **command** appends a Chronicle **event**, a Chronicle **projection** folds events into a **read model**, and an Arc **query** serves that read model back — with the generated TypeScript proxy carrying both ends to React.
+
+```mermaid
+flowchart LR
+    UI[React] -->|command| CMD["[Command] record · Handle()"]
+    CMD -->|returns an event| EV[(Chronicle event log)]
+    EV -->|projection| RM["[ReadModel] · materialized to the sink"]
+    RM -->|query| UI
+```
+
+Reading that loop in code:
+
+- **A command writes by *returning*.** A `[Command]` record carries the command's inputs as its **properties**, and the decision lives in a `Handle()` method on the record. Whatever `Handle()` **returns** is what Chronicle does with it — return an `[EventType]` event and it's appended; the [return signature](commands/events.md) (a single event, several, a tuple, a `Result<,>`, or nothing) decides the outcome. You never touch an event log directly.
+- **The event source id picks the stream.** Every event belongs to one **event source** — one entity's stream of history. Chronicle resolves that id from the command: a `[Key]` parameter, a property whose type converts to `EventSourceId` (typically a `ConceptAs<Guid>` with an `implicit operator EventSourceId`), or `ICanProvideEventSourceId`. See [Resolving EventSourceId](resolving-event-source-id.md).
+- **The read model is projected, then queried.** A `[ReadModel]` record declares the shape you want; `[FromEvent<T>]`, `[SetFrom<T>]`, and `[SetValue<T>]` map events onto its properties and Chronicle keeps it **materialized** in the configured sink (MongoDB by default). An Arc query — a static method on the read model, often returning an observable so the UI stays live — serves it through the generated proxy. See [Read Models](read-models.md).
+
+So the round-trip is: a fact happens (command → event), it's folded into state (projection → read model), and the UI reads it (query → proxy). Each piece is one of the topics below.
+
 ## What it provides
 
 Without this package, Arc and Chronicle are independent. With it:

--- a/Documentation/backend/chronicle/resolving-event-source-id.md
+++ b/Documentation/backend/chronicle/resolving-event-source-id.md
@@ -24,7 +24,7 @@ When Chronicle inspects a command, it resolves the event source id in this order
 If none of these are present, Chronicle creates a new `EventSourceId` so automatic event appends still have a valid identity.
 
 ```csharp
-using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
 using Cratis.Arc.Chronicle.Commands;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Keys;

--- a/Documentation/backend/proxy-generation/getting-started.md
+++ b/Documentation/backend/proxy-generation/getting-started.md
@@ -7,7 +7,7 @@ This guide covers the installation and basic setup of the Cratis Arc proxy gener
 To enable proxy generation, add a reference to the [Cratis.Arc.ProxyGenerator.Build](https://www.nuget.org/packages/Cratis.Arc.ProxyGenerator.Build) NuGet package to your project:
 
 ```xml
-<PackageReference Include="Cratis.Arc.ProxyGenerator.Build" Version="1.0.0" />
+<PackageReference Include="Cratis.Arc.ProxyGenerator.Build" Version="*" />
 ```
 
 > **Important**: All projects that contain controllers, commands, or queries should reference this package, as the proxy generation runs as part of the compilation process.

--- a/Documentation/tutorial/authorization.mdx
+++ b/Documentation/tutorial/authorization.mdx
@@ -35,7 +35,7 @@ The read side deserves the same protection — a public catalog might be fine, b
 
 ```csharp
 [ReadModel]
-public record Author([property: Key] AuthorId Id, AuthorName Name)
+public record Author(AuthorId Id, AuthorName Name)
 {
     [Roles(nameof(UserRole.Librarian))]
     public static ISubject<IEnumerable<Author>> AllAuthors(IMongoCollection<Author> collection) =>

--- a/Documentation/tutorial/books-and-relationships.mdx
+++ b/Documentation/tutorial/books-and-relationships.mdx
@@ -34,13 +34,13 @@ flowchart LR
    }
    ```
 
-2. **The command writes a book, tagged with its author.** `AddBook` is keyed by `AuthorId` — the author it belongs to — and writes a `Book` carrying that id:
+2. **The command writes a book, tagged with its author.** `AddBook` carries the `AuthorId` it belongs to — and writes a `Book` carrying that id:
 
    <Tabs syncKey="db">
    <TabItem label="MongoDB" icon="seti:db">
    ```csharp
    [Command]
-   public record AddBook([Key] AuthorId AuthorId, BookId BookId, BookTitle Title)
+   public record AddBook(AuthorId AuthorId, BookId BookId, BookTitle Title)
    {
        public Task Handle(IMongoCollection<Book> books) =>
            books.InsertOneAsync(new Book(BookId, AuthorId, Title));
@@ -50,7 +50,7 @@ flowchart LR
    <TabItem label="EF Core" icon="seti:db">
    ```csharp
    [Command]
-   public record AddBook([Key] AuthorId AuthorId, BookId BookId, BookTitle Title)
+   public record AddBook(AuthorId AuthorId, BookId BookId, BookTitle Title)
    {
        public async Task Handle(LibraryDbContext db)
        {
@@ -66,15 +66,15 @@ flowchart LR
 
 ## Read a catalog back, filtered
 
-The read model is just the book document — it carries the `AuthorId` it belongs to. The query takes the author's id (Arc binds it from the route via `[Key]`) and returns only that author's books, live:
+The read model is just the book document — it carries the `AuthorId` it belongs to. The query takes the author's id (Arc binds it by matching the parameter name) and returns only that author's books, live:
 
 <Tabs syncKey="db">
 <TabItem label="MongoDB" icon="seti:db">
 ```csharp
 [ReadModel]
-public record Book([property: Key] BookId Id, AuthorId AuthorId, BookTitle Title)
+public record Book(BookId Id, AuthorId AuthorId, BookTitle Title)
 {
-    public static ISubject<IEnumerable<Book>> BooksForAuthor([Key] AuthorId authorId, IMongoCollection<Book> books) =>
+    public static ISubject<IEnumerable<Book>> BooksForAuthor(AuthorId authorId, IMongoCollection<Book> books) =>
         books.Observe(b => b.AuthorId == authorId);
 }
 ```
@@ -82,9 +82,9 @@ public record Book([property: Key] BookId Id, AuthorId AuthorId, BookTitle Title
 <TabItem label="EF Core" icon="seti:db">
 ```csharp
 [ReadModel]
-public record Book([property: Key] BookId Id, AuthorId AuthorId, BookTitle Title)
+public record Book(BookId Id, AuthorId AuthorId, BookTitle Title)
 {
-    public static ISubject<IEnumerable<Book>> BooksForAuthor([Key] AuthorId authorId, LibraryDbContext db) =>
+    public static ISubject<IEnumerable<Book>> BooksForAuthor(AuthorId authorId, LibraryDbContext db) =>
         db.Books.Observe(b => b.AuthorId == authorId);
 
     // add the DbSet to LibraryDbContext: public DbSet<Book> Books => Set<Book>();

--- a/Documentation/tutorial/first-slice.mdx
+++ b/Documentation/tutorial/first-slice.mdx
@@ -72,7 +72,7 @@ flowchart LR
    <TabItem label="MongoDB" icon="seti:db">
    ```csharp
    [ReadModel]
-   public record Author([property: Key] AuthorId Id, AuthorName Name)
+   public record Author(AuthorId Id, AuthorName Name)
    {
        public static ISubject<IEnumerable<Author>> AllAuthors(IMongoCollection<Author> collection) =>
            collection.Observe();
@@ -82,7 +82,7 @@ flowchart LR
    <TabItem label="EF Core" icon="seti:db">
    ```csharp
    [ReadModel]
-   public record Author([property: Key] AuthorId Id, AuthorName Name)
+   public record Author(AuthorId Id, AuthorName Name)
    {
        public static ISubject<IEnumerable<Author>> AllAuthors(LibraryDbContext db) =>
            db.Authors.Observe();
@@ -101,21 +101,66 @@ flowchart LR
    That static `AllAuthors` method *is* your query — Arc serves it over HTTP automatically. No controller, no routing, no DTO. And it's **live**: `.Observe()` watches the database's change stream (MongoDB's, or an [observed `DbSet`](/arc/backend/entity-framework/observing/)), so the instant the command writes, every subscribed browser re-renders.
    </Aside>
 
-4. **Wire the database in once at startup, then build.**
+4. **Set up the project, then build.** Two pieces make the full-stack loop work: a build-time **proxy generator** and the **host wiring**. Add the packages and tell the generator where to write proxies — next to your source, so each `.ts` lands beside the `.tsx` that imports it:
 
    <Tabs syncKey="db">
    <TabItem label="MongoDB" icon="seti:db">
-   ```csharp
+   ```xml title="Library.csproj"
+   <ItemGroup>
+       <PackageReference Include="Cratis.Arc" Version="*" />
+       <PackageReference Include="Cratis.Arc.MongoDB" Version="*" />
+       <PackageReference Include="Cratis.Arc.ProxyGenerator.Build" Version="*" />
+   </ItemGroup>
+   <PropertyGroup>
+       <!-- Proxies are generated only when an output path is set -->
+       <CratisProxiesOutputPath>$(MSBuildThisFileDirectory)</CratisProxiesOutputPath>
+       <CratisProxiesUseSourceFileAsOutputFile>true</CratisProxiesUseSourceFileAsOutputFile>
+   </PropertyGroup>
+   ```
+
+   Then wire the host. `AddCratisArc` registers Arc, `UseCratisMongoDB` points it at MongoDB, and `UseCratisArc` maps the command, query, and observable-query endpoints:
+
+   ```csharp title="Program.cs"
    var builder = WebApplication.CreateBuilder(args);
    builder.AddCratisArc();
    builder.UseCratisMongoDB();
+   builder.Services.AddControllers();
+
+   var app = builder.Build();
+   app.UseRouting();
+   app.MapControllers();
+   app.UseCratisArc();          // maps the command, query, and observable-query endpoints
+
+   await app.RunAsync();
    ```
    </TabItem>
    <TabItem label="EF Core" icon="seti:db">
-   ```csharp
+   ```xml title="Library.csproj"
+   <ItemGroup>
+       <PackageReference Include="Cratis.Arc" Version="*" />
+       <PackageReference Include="Cratis.Arc.EntityFrameworkCore" Version="*" />
+       <PackageReference Include="Cratis.Arc.ProxyGenerator.Build" Version="*" />
+   </ItemGroup>
+   <PropertyGroup>
+       <!-- Proxies are generated only when an output path is set -->
+       <CratisProxiesOutputPath>$(MSBuildThisFileDirectory)</CratisProxiesOutputPath>
+       <CratisProxiesUseSourceFileAsOutputFile>true</CratisProxiesUseSourceFileAsOutputFile>
+   </PropertyGroup>
+   ```
+
+   Then wire the host. `WithEntityFrameworkCore` auto-discovers your `DbContext`, and `UseCratisArc` maps the endpoints:
+
+   ```csharp title="Program.cs"
    var builder = WebApplication.CreateBuilder(args);
    builder.AddCratisArc(configureBuilder: arc => arc.WithEntityFrameworkCore());
-   // your DbContext is auto-discovered and registered
+   builder.Services.AddControllers();
+
+   var app = builder.Build();
+   app.UseRouting();
+   app.MapControllers();
+   app.UseCratisArc();          // maps the command, query, and observable-query endpoints
+
+   await app.RunAsync();
    ```
    </TabItem>
    </Tabs>
@@ -124,7 +169,11 @@ flowchart LR
    dotnet build
    ```
 
-   Building compiles your C# and — the part that matters most for the next half — **generates TypeScript proxies** for `RegisterAuthor` and `AllAuthors`. Your frontend is about to call them as if they were local, typed code.
+   Building compiles your C# and — the part that matters most for the next half — **generates a TypeScript proxy** for `RegisterAuthor` and `AllAuthors` next to each slice. That's what `CratisProxiesOutputPath` turns on; with it unset, `dotnet build` still succeeds but emits nothing. Your frontend is about to call them as if they were local, typed code.
+
+   <Aside type="note" title="Route config lives in two places">
+   The proxy's URL is baked in at build time from the `CratisProxies*` properties; the server maps routes from `ArcOptions` at runtime. They agree by default — but if you customize one (a route prefix, say), mirror it in the other or the generated client calls a route the server never mapped. See [proxy-generation configuration](/arc/backend/proxy-generation/) and [ASP.NET Core host configuration](/arc/backend/asp-net-core/configuration/).
+   </Aside>
 
 </Steps>
 
@@ -166,6 +215,10 @@ The proxies now exist, generated *from your C#*. Normally this is exactly where 
 </Steps>
 
 Run the app, register an author, and the list updates the moment you confirm — you didn't write a line of refresh logic. `AllAuthors.use()` is subscribed to the read model, so when the command writes its document, the screen re-renders itself.
+
+<Aside type="note" title="One bit of dev wiring for live queries">
+Observable queries stream over a WebSocket, so in local dev your Vite server needs to proxy `/api` and `/.cratis` (with `ws: true`) through to the backend — otherwise the list loads but never updates live. The [Vite configuration](/arc/frontend/react/vite-configuration/) guide shows the exact `server.proxy` block.
+</Aside>
 
 ## Where the type safety lives
 


### PR DESCRIPTION
## Fixed
- Removed the invalid `[Key]`/`[property: Key]` from the Arc-over-a-database tutorial. `KeyAttribute` is `Cratis.Chronicle.Keys`-only and isn't on a no-Chronicle Arc project's classpath; Arc read models use a plain `Id` and bind query/command parameters by name. Corrected the prose that described `[Key]`-based route binding.
- Fixed the `[Command]` import across the Chronicle-integration command snippets — the attribute lives in `Cratis.Arc.Commands.ModelBound`, not `Cratis.Arc.Commands`, so the snippets now compile as pasted.
- Fixed the fabricated `Version="1.0.0"` pin on `Cratis.Arc.ProxyGenerator.Build`.

## Changed
- The first tutorial slice now shows the **complete** project setup that proxy generation and the HTTP round-trip require — the `.csproj` (packages + `CratisProxiesOutputPath`, which gates proxy generation) and the full `Program.cs` (`Build()` → `UseRouting()` → `MapControllers()` → `UseCratisArc()` → `RunAsync()`) for both MongoDB and EF Core — instead of stopping at `builder.AddCratisArc()`. Added asides on build-vs-runtime route config and the Vite dev-proxy/WebSocket needed for live observable queries.
- Added a cohesive **"How the two fit together"** overview to the Chronicle-integration front door — the command → event → read-model → query loop, naming `[Command]`/`Handle()`-return, `[Key]`/event-source-id resolution, and `[ReadModel]`/`[FromEvent]` projections — plus a **`Handle()` return-shape reference table** on the Commands index documenting what each return signature makes Chronicle do.
