### PR TITLE
Apply 2026-06-09 docs review feedback to Arc

### DIFF
--- a/Documentation/arc-without-event-sourcing.md
+++ b/Documentation/arc-without-event-sourcing.md
@@ -13,10 +13,10 @@ Arc is a layer that can sit *on top of* Chronicle; Chronicle never depends on Ar
 
 ```mermaid
 flowchart TB
-    Core["Arc.Core<br/>commands · queries · generated proxies"]
+    Core["Arc.Core — commands · queries · generated proxies"]
     Core --> Mongo[("MongoDB")]
     Core --> EF[("EF Core / SQL")]
-    Core --> Chr[("Chronicle<br/>event sourcing")]
+    Core --> Chr[("Chronicle — event sourcing")]
 ```
 
 Pick MongoDB or EF Core and you have a complete, fully-typed CQRS app without an event log. Pick Chronicle and the same Arc boundary records facts, builds projections, and keeps history.
@@ -25,7 +25,7 @@ Pick MongoDB or EF Core and you have a complete, fully-typed CQRS app without an
 
 Here's the whole thing — register an author, and list authors live — with the data stored straight in a MongoDB collection.
 
-**The read model is just a document.** Mark it `[ReadModel]` so Arc exposes its query methods; there's no `[FromEvent]` and no projection. A static method *is* the query, and returning an `ISubject<>` makes it live:
+**The read model is just a document.** Mark it `[ReadModel]` and Arc exposes its query methods. A static method *is* the query, and returning an `ISubject<>` makes it live:
 
 ```csharp
 [ReadModel]

--- a/Documentation/backend/getting-started/your-first-command.mdx
+++ b/Documentation/backend/getting-started/your-first-command.mdx
@@ -7,12 +7,12 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 Let's build the backend half of a real feature: registering an author in a library app. It's small, but it exercises the whole Arc loop — something *happens* (a command), it writes state, and that state is served back out (a query). We use a plain database in this lesson to keep the CQRS boundary visible; in a full Cratis information system, the same boundary usually writes events through Chronicle.
 
-In a layered app this would be files scattered across `Commands/`, `Handlers/`, and `ReadModels/`, and you'd hop between them to follow one behavior. Arc organizes by **feature** instead: everything below lives in one `Features/Authors/` folder you read top to bottom. Here's the shape we're building:
+In a layered app this would be files scattered across `Commands/`, `Handlers/`, and `ReadModels/`, and you'd hop between them to follow one behavior. Arc doesn't force a layout, but we strongly recommend organizing by **feature**: everything below lives in one `Authors/` folder you read top to bottom. Here's the shape we're building:
 
 ```mermaid
 flowchart LR
-    Cmd["RegisterAuthor<br/>command"] -->|Handle, writes| DB[("database")]
-    DB --> RM["Author<br/>read model"]
+    Cmd["RegisterAuthor command"] -->|Handle, writes| DB[("database")]
+    DB --> RM["Author read model"]
     RM -->|AllAuthors| Q["query over HTTP, live"]
 ```
 

--- a/Documentation/frontend/getting-started.mdx
+++ b/Documentation/frontend/getting-started.mdx
@@ -21,9 +21,9 @@ Proxies appear when you **build the backend** — until `dotnet build` succeeds,
 
 ```mermaid
 flowchart LR
-    Cmd["C# command + query<br/>RegisterAuthor · AllAuthors"] -->|dotnet build| Proxy["generated TS proxies"]
-    Proxy --> Q["AllAuthors.use()<br/>reads, live"]
-    Proxy --> X["CommandDialog<br/>executes"]
+    Cmd["C# command + query — RegisterAuthor · AllAuthors"] -->|dotnet build| Proxy["generated TS proxies"]
+    Proxy --> Q["AllAuthors.use() — reads, live"]
+    Proxy --> X["CommandDialog — executes"]
     Q --> UI["your React screen"]
     X --> UI
 ```

--- a/Documentation/frontend/index.mdx
+++ b/Documentation/frontend/index.mdx
@@ -31,7 +31,7 @@ You write the backend once. The proxy generator runs on build and emits a typed 
 code consumes it through each proxy's static `.use()` hook — and because the types flow across the
 boundary, there is no DTO to keep in sync and no untyped JSON to second-guess.
 
-## Run a command from React
+## Execute a command from React
 
 A command is an intent to change something — *open an account*, *check out a book*. You define it in
 C#; Arc generates a proxy whose static `.use()` hook gives you a reactive instance, change tracking,

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -8,7 +8,7 @@ import SimpleCard from '@components/SimpleCard.astro';
 import TopicHero from '@components/TopicHero.astro';
 
 <TopicHero icon="puzzle" eyebrow="Arc" title="Full-stack CQRS, typed to the browser">
-Turn **commands** and **queries** into a full-stack CQRS application with **generated TypeScript proxies** that keep React in lockstep with your C#: no hand-written API client, no DTO duplication. Arc pairs naturally with Chronicle's event sourcing, and can also run over MongoDB or EF Core when a slice is deliberately current-state only. [Build your first slice →](/arc/backend/getting-started/your-first-command/) · [Why Arc? →](/arc/why-arc/)
+Turn **commands** and **queries** into a full-stack CQRS application with **generated TypeScript proxies** that keep React in lockstep with your C#: no hand-written API client, no DTO duplication. Arc pairs naturally with Chronicle's event sourcing, and runs just as well over MongoDB or EF Core — no event log required. [Build your first slice →](/arc/backend/getting-started/your-first-command/) · [Why Arc? →](/arc/why-arc/)
 </TopicHero>
 
 ## Start here
@@ -32,7 +32,7 @@ Turn **commands** and **queries** into a full-stack CQRS application with **gene
     The plumbing Arc removes, and why CQRS plus proxy generation keeps a full-stack app honest.
   </SimpleCard>
   <SimpleCard title="Vertical slices" icon="seti:folder" link="/arc/vertical-slices/">
-    Why everything for one feature — backend and frontend — lives in a single folder.
+    How everything for one feature — backend and frontend — can live in a single folder.
   </SimpleCard>
   <SimpleCard title="CQRS without event sourcing" icon="right-arrow" link="/arc/arc-without-event-sourcing/">
     Use Arc on its own over MongoDB or EF Core when you want the CQRS boundary without an event log.

--- a/Documentation/scenarios/index.md
+++ b/Documentation/scenarios/index.md
@@ -10,7 +10,7 @@ These are recipes: "I need to do X — how?" Each one is short and assumes you'v
 | [Validate a command](./validate-a-command.md) | Reject malformed or duplicate input before it writes state |
 | [Return a result or an error](./return-a-result-or-error.md) | A command needs to hand back more than "it worked" — a value, or a typed failure |
 | [Query data across slices](./query-related-data.md) | A screen needs data that spans more than one feature |
-| [Run a command from React](./run-a-command-from-react.md) | Wire a form or button to a command through the generated proxy |
+| [Execute a command from React](./run-a-command-from-react.md) | Wire a form or button to a command through the generated proxy |
 | [Test a command](./test-a-command.md) | Prove a slice works through the real pipeline — no HTTP, no database |
 | [Authorize a command or query](/arc/backend/authorizing-commands-and-queries/) | Restrict who may run a command or read a query |
 

--- a/Documentation/scenarios/query-related-data.md
+++ b/Documentation/scenarios/query-related-data.md
@@ -15,14 +15,14 @@ In a database-backed Arc slice, model the relationship the same way you would in
 
 ```csharp
 [ReadModel]
-public record Book([property: Key] BookId Id, AuthorId AuthorId, BookTitle Title)
+public record Book(BookId Id, AuthorId AuthorId, BookTitle Title)
 {
-    public static ISubject<IEnumerable<Book>> BooksForAuthor([Key] AuthorId authorId, IMongoCollection<Book> books) =>
+    public static ISubject<IEnumerable<Book>> BooksForAuthor(AuthorId authorId, IMongoCollection<Book> books) =>
         books.Observe(book => book.AuthorId == authorId);
 }
 ```
 
-The generated proxy takes the same parameter:
+No attribute marks the identity — by convention the `Id` property is the read model's identity. Arc sorts the query method's parameters by type: `authorId` is data, so it becomes a query parameter; `IMongoCollection<Book>` is a service, so it's injected. The generated proxy takes the data parameter:
 
 ```tsx
 const [books] = BooksForAuthor.use(authorId);
@@ -36,4 +36,4 @@ For a list-with-details screen, let the author list call `AllAuthors.use()` and 
 
 - [Queries](/arc/backend/queries/) — observable and non-observable query methods, parameters, and filtering.
 - [Relate your slices](/arc/tutorial/books-and-relationships/) — this relationship built step by step.
-- [Run a command from React](./run-a-command-from-react.md) — consuming the query proxy.
+- [Execute a command from React](./run-a-command-from-react.md) — consuming the query proxy.

--- a/Documentation/scenarios/run-a-command-from-react.md
+++ b/Documentation/scenarios/run-a-command-from-react.md
@@ -1,5 +1,5 @@
 ---
-title: Run a command from React
+title: Execute a command from React
 description: Wire a React form or button to a command through the generated proxy — with CommandDialog handling instantiation, validation, and the buttons.
 ---
 

--- a/Documentation/scenarios/toc.yml
+++ b/Documentation/scenarios/toc.yml
@@ -6,7 +6,7 @@
   href: return-a-result-or-error.md
 - name: Query data across slices
   href: query-related-data.md
-- name: Run a command from React
+- name: Execute a command from React
   href: run-a-command-from-react.md
 - name: Test a command
   href: test-a-command.md

--- a/Documentation/scenarios/validate-a-command.md
+++ b/Documentation/scenarios/validate-a-command.md
@@ -42,7 +42,24 @@ Arc runs validators *before* it invokes `Handle()`. A command that fails validat
            : new AuthorRegistered(Name);
    ```
 
-Validators are discovered by convention — you never register them. The frontend surfaces the messages automatically; see [Run a command from React](./run-a-command-from-react.md).
+   The handler isn't the only place a state-dependent rule can live. A `CommandValidator<TCommand>` is resolved through dependency injection, so it can take a collaborator and check state with FluentValidation's `MustAsync` — the rule sits with the rest of the command's rules, and `Handle()` stays focused on producing the event:
+
+   ```csharp
+   public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+   {
+       public RegisterAuthorValidator(IAuthorsCatalog authors)
+       {
+           RuleFor(c => c.Name).NotEmpty().MaximumLength(200);
+           RuleFor(c => c)
+               .MustAsync(async (command, ct) => !await authors.IsRegistered(command.Name))
+               .WithMessage("An author with that name is already registered.");
+       }
+   }
+   ```
+
+   A `MustAsync` rule runs on the server only — unlike the declarative rules, it can't be extracted into the generated proxy. And like any pre-handler check, it reads eventually-consistent state: keep the in-`Handle()` guard for invariants that must hold under concurrency, and use the validator when separating rule checking from event production is what you're after.
+
+Validators are discovered by convention — you never register them. The frontend surfaces the messages automatically; see [Execute a command from React](./run-a-command-from-react.md).
 
 ## See also
 

--- a/Documentation/tutorial/books-and-relationships.mdx
+++ b/Documentation/tutorial/books-and-relationships.mdx
@@ -11,8 +11,8 @@ Here's the shape:
 
 ```mermaid
 flowchart LR
-    AB["AddBook<br/>(keyed by author)"] -->|writes| DB[("Books")]
-    DB --> Q["BooksForAuthor<br/>(filtered by AuthorId)"]
+    AB["AddBook (keyed by author)"] -->|writes| DB[("Books")]
+    DB --> Q["BooksForAuthor (filtered by AuthorId)"]
     Q -->|live| UI["React: author → books"]
 ```
 

--- a/Documentation/tutorial/first-slice.mdx
+++ b/Documentation/tutorial/first-slice.mdx
@@ -8,12 +8,12 @@ import FullStackTabs from '@components/FullStackTabs.astro';
 
 Every app starts with one feature. Ours is **registering an author** — the first thing a librarian does before they can catalog a single book. It's deliberately small, but building it touches the entire Arc loop: a command that expresses intent, the read model it updates, the query that serves it, and the React screen that calls both — all of it typed end to end.
 
-In a layered app these would be files scattered across `Commands/`, `Handlers/`, and `ReadModels/`, and you'd jump between folders to follow one behavior. Arc organizes by **feature**: everything below lives in one `Features/Authors/` folder you read top to bottom. Here's the slice we're about to build:
+In a layered app these would be files scattered across `Commands/`, `Handlers/`, and `ReadModels/`, and you'd jump between folders to follow one behavior. Arc doesn't force a layout on you — but we recommend the **vertical-slice** approach: a folder per feature, with a folder per slice inside it, mirroring the columns of your event model. That's how we'll build here: everything below lives in one `Authors/` folder you read top to bottom. Here's the slice we're about to build:
 
 ```mermaid
 flowchart LR
-    Cmd["RegisterAuthor<br/>command"] -->|Handle, writes| DB[("database")]
-    DB --> RM["Author<br/>read model"]
+    Cmd["RegisterAuthor command"] -->|Handle, writes| DB[("database")]
+    DB --> RM["Author read model"]
     RM -->|AllAuthors| Q["query, over HTTP"]
     Q -->|generated proxy, live| UI["React list"]
 ```
@@ -217,7 +217,7 @@ The proxies now exist, generated *from your C#*. Normally this is exactly where 
 Run the app, register an author, and the list updates the moment you confirm — you didn't write a line of refresh logic. `AllAuthors.use()` is subscribed to the read model, so when the command writes its document, the screen re-renders itself.
 
 <Aside type="note" title="One bit of dev wiring for live queries">
-Observable queries stream over a WebSocket, so in local dev your Vite server needs to proxy `/api` and `/.cratis` (with `ws: true`) through to the backend — otherwise the list loads but never updates live. The [Vite configuration](/arc/frontend/react/vite-configuration/) guide shows the exact `server.proxy` block.
+Observable queries stream over **Server-Sent Events** by default; you can switch to **WebSockets** with the `queryTransportMethod` prop on the [`<Arc/>` context component](/arc/frontend/react/arc/). Either way, in local dev your Vite server needs to proxy `/api` and `/.cratis` through to the backend (with `ws: true` if you use the WebSocket transport) — otherwise the list loads but never updates live. The [Vite configuration](/arc/frontend/react/vite-configuration/) guide shows the exact `server.proxy` block.
 </Aside>
 
 ## Where the type safety lives

--- a/Documentation/tutorial/index.md
+++ b/Documentation/tutorial/index.md
@@ -31,8 +31,8 @@ flowchart LR
         UI["Library screen"]
     end
     subgraph Backend["Arc (C#)"]
-        Cmd["commands<br/>RegisterAuthor · AddBook"]
-        RM["read models<br/>Author · BookOnShelf"]
+        Cmd["commands — RegisterAuthor · AddBook"]
+        RM["read models — Author · BookOnShelf"]
         Q["queries"]
     end
     DB[("MongoDB / EF Core")]

--- a/Documentation/understanding-identity-and-access.mdx
+++ b/Documentation/understanding-identity-and-access.mdx
@@ -32,10 +32,10 @@ public class LibraryIdentityProvider(IMongoCollection<Member> members)
 
 ```mermaid
 flowchart LR
-    T["Provider token<br/>id · name · claims"] --> P["IProvideIdentityDetails<br/>.Provide()"]
+    T["Provider token — id · name · claims"] --> P["IProvideIdentityDetails.Provide()"]
     P --> Q{IsUserAuthorized?}
     Q -- no --> F["HTTP 403"]
-    Q -- yes --> D["IdentityDetails<br/>your domain identity"]
+    Q -- yes --> D["IdentityDetails — your domain identity"]
     D --> C[".cratis-identity cookie"]
     C --> UI["Frontend — typed identity"]
 ```
@@ -86,7 +86,7 @@ The shape of it:
 3. **Tenant-aware data stores** (a database per tenant, or a partition) keep one customer's events and read models physically apart from another's — isolation by construction, not by remembering to add a `WHERE tenantId =` to every query.
 
 <Aside type="caution" title="Resolve the tenant after you authenticate">
-Tenant id is sensitive. Resolve it from authenticated claims, validate membership, and never trust a raw header or query parameter — otherwise tenant isolation is one spoofed value away from breaking.
+Tenant id is sensitive. Resolve it from authenticated claims, validate membership, and never trust a raw header or query parameter — otherwise tenant isolation is one spoofed value away from breaking. In production, [Cratis AuthProxy](/authproxy/) can take this on at the edge: it strips spoofable identity and tenant headers from every inbound request, resolves the tenant after the user signs in, and validates it before the request reaches your app.
 </Aside>
 
 Set it up with [tenant resolvers](/arc/backend/tenancy/resolvers/), reach it through [tenant context](/arc/backend/tenancy/tenant-context/), and isolate storage with [database resolvers](/arc/backend/tenancy/database-resolvers/) — the [tenancy overview](/arc/backend/tenancy/overview/) ties them together.
@@ -96,4 +96,4 @@ Set it up with [tenant resolvers](/arc/backend/tenancy/resolvers/), reach it thr
 - [Identity](/arc/backend/identity/) — the provider flow, contracts, and multi-service topologies in full.
 - [Authorization](/arc/backend/core/authorization/) — every attribute, the inheritance rules, and claims-based custom logic.
 - [Tenancy](/arc/backend/tenancy/overview/) — resolvers, context, and per-tenant data isolation.
-- [Microsoft Identity](/arc/backend/asp-net-core/microsoft-identity/) — wiring Entra ID / Azure AD as your provider.
+- [Microsoft Identity headers](/arc/backend/asp-net-core/microsoft-identity/) — accepting the `x-ms-client-principal` family of HTTP headers from your ingress. Azure services emit them out of the box, but any identity provider or proxy can supply them.

--- a/Documentation/understanding-the-proxy-boundary.mdx
+++ b/Documentation/understanding-the-proxy-boundary.mdx
@@ -16,8 +16,8 @@ The thing to internalize: **your C# command and query records are the contract.*
 
 ```mermaid
 flowchart LR
-    CS["C# record<br/>[Command] RegisterAuthor"] -->|dotnet build · Roslyn generator| TS["generated TS proxy<br/>RegisterAuthor"]
-    TS -->|import + call| RX["React<br/>CommandDialog · .use()"]
+    CS["C# record — [Command] RegisterAuthor"] -->|dotnet build · Roslyn generator| TS["generated TS proxy — RegisterAuthor"]
+    TS -->|import + call| RX["React — CommandDialog · .use()"]
     RX -.->|HTTP — typed both ends| CS
 ```
 
@@ -86,11 +86,24 @@ Rename a field on a `[ReadModel]`, rebuild, and every component reading it throu
 Each build, Arc emits typed proxies for:
 
 - **Commands** — a class you instantiate and execute (or hand to a `CommandDialog`), with every parameter — route, query string, body — flattened into typed properties.
-- **Queries** — a proxy exposing a React `.use()` hook that returns the typed result with its loading and error state; **observable** queries return a live subscription that re-renders on change, with no `perform` to call and no polling.
+- **Queries** — a proxy exposing a React `.use()` hook that returns the typed result with its loading and error state; **observable** queries return a live subscription that re-renders on change — no polling, no manual refresh.
 - **Types and enums** — every complex type and enum your commands and queries reference, so nested shapes are typed too.
 - **Identity details** — your custom identity type, so the signed-in user is typed on the frontend.
 
 Each has a detailed reference: [Commands](/arc/backend/proxy-generation/commands/), [Queries](/arc/backend/proxy-generation/queries/), and [Identity details](/arc/backend/proxy-generation/identity-details/). The [frontend proxy-generation guide](/arc/frontend/react/proxy-generation/) shows the generated TypeScript for each, with the `.use()` and `useSuspense()` hooks.
+
+## The transport disappears too
+
+Types are only half of what the proxy absorbs. The other half is **how the call travels**. Your component never writes a URL, picks an HTTP verb, or opens a socket — it executes `RegisterAuthor` or renders `AllAuthors.use()`, and the proxy owns the wire. That makes the transport an implementation detail behind the boundary: today the calls ride HTTP, and if Arc carried them over something else — gRPC-Web, say — the proxy is where that would change, not your components.
+
+The query system already cashes in on this freedom. A regular query executes as a plain HTTP request. An observable query streams — over WebSockets or Server-Sent Events, a choice you make once with the `queryTransportMethod` prop on the [`<Arc/>` context component](/arc/frontend/react/arc/), not in any component. And the same observable query can still be executed as a one-shot HTTP fetch by calling `perform()` on the proxy, when you want a snapshot instead of a subscription:
+
+```tsx
+const [authors] = AllAuthors.use();                  // live — streams over WebSockets or SSE
+const snapshot = await new AllAuthors().perform();   // one-shot — a plain HTTP fetch, same proxy
+```
+
+One definition in C#, one proxy in TypeScript — and whether the data arrives as a response or a stream is the proxy's concern, not yours. Tune the live transport in the [query configuration reference](/arc/frontend/react/queries/configuration/).
 
 ## It's a build step, not a checkout
 

--- a/Documentation/vertical-slices.md
+++ b/Documentation/vertical-slices.md
@@ -3,7 +3,7 @@ title: Vertical slices
 description: Why a Cratis feature keeps its backend and frontend together in one folder — and why that beats organizing code by technical layer.
 ---
 
-Cratis applications are organized by **feature**, not by technical layer. Everything for one behavior — the command that writes state, the read model and query that serve it, the React component that renders it, and the specs that prove it — lives together in a single folder. That folder is a **vertical slice**.
+We strongly recommend organizing a Cratis application by **feature**, not by technical layer. Nothing in the framework enforces this — Arc discovers your commands and read models wherever they live — but we recommend it emphatically, because high cohesion and low coupling fall out of the shape almost for free. Everything for one behavior — the command that writes state, the read model and query that serve it, the React component that renders it, and the specs that prove it — lives together in a single folder. That folder is a **vertical slice**, and the slice folders inside a feature map directly onto the timeline an [event model](/event-modeling/) lays out.
 
 This page explains *why*. If you want to see one built, the [capstone walkthrough](/build-a-full-app/) does exactly that.
 
@@ -26,7 +26,7 @@ A vertical slice puts the whole feature in one place:
 
 ```shell
 ✅ Organized by feature — one folder, read top to bottom
-Features/Authors/Registration/
+Authors/Registration/
 ├── Registration.cs        # command + Handle() + read model + query
 ├── AddAuthor.tsx          # the React screen
 └── when_registering/      # the specs
@@ -54,13 +54,15 @@ flowchart LR
     end
 ```
 
+None of this dictates your repository layout, though. The proxy generator writes the TypeScript wherever you point it — the `CratisProxiesOutputPath` MSBuild property in your backend project sets the output folder, which can just as well be a separate frontend folder or another checkout entirely. If your team keeps backend and frontend apart, Arc follows your structure and the type safety holds across the distance. We co-locate because the feedback loop in point 2 is at its tightest when the generated proxy sits next to the command it mirrors — a strong preference, not a requirement.
+
 ## What lives in a slice
 
-A single backend `.cs` file can hold the backend artifacts for the behavior — the `[Command]` with its `Handle()`, validators, and the `[ReadModel]` with its query methods. Alongside it sit the React component(s) that consume the generated proxies, and the specs. Conventions and proxy generation rely on this co-location, so it's the easy path *and* the right one.
+A single backend `.cs` file can hold the backend artifacts for the behavior — the `[Command]` with its `Handle()`, validators, and the `[ReadModel]` with its query methods. Alongside it sit the React component(s) that consume the generated proxies, and the specs. Arc's convention-based discovery means none of it needs registration or wiring — the slice folder is self-contained and reads top to bottom.
 
 ## Slice types
 
-Not every slice does the same job. There are four kinds:
+Not every slice does the same job. There are four kinds — the same building blocks an event model lays out on its timeline:
 
 | Type | Purpose |
 |---|---|

--- a/Documentation/why-arc.md
+++ b/Documentation/why-arc.md
@@ -34,7 +34,7 @@ That diagram is the direct-database setup, useful for bounded current-state slic
 
 ## Vertical slices, not layers
 
-Arc applications are organized by **feature**, not by technical role. Everything for one behavior — the command, the read model and query it serves, the React component that renders it, and the specs that prove it — lives in one folder. You read a feature top to bottom instead of hunting across `Commands/`, `Handlers/`, `DTOs`, and `Clients/`.
+Arc doesn't impose a folder structure, but it's built to make one shine: organize the application by **feature**, with a folder per slice inside it — the shape [event modeling](/event-modeling/) gives you. Everything for one behavior — the command, the read model and query it serves, the React component that renders it, and the specs that prove it — then lives in one folder, and you read a feature top to bottom instead of hunting across `Commands/`, `Handlers/`, `DTOs`, and `Clients/`.
 
 ## Where to start
 


### PR DESCRIPTION
Applies the Arc portions of the 2026-06-09 documentation review feedback: vertical slice wording, validator-based rule checks, React command execution, proxy-boundary transport transparency, and AuthProxy identity corrections.

Verification from the completed local pass: the aggregated docs gate reported 0 lint errors and 0 broken links.

Companion branch: docs/review-20260609 in Documentation, Chronicle, cli, and .github.