### PR TITLE
Make command scenarios discover validators

### DIFF
--- a/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
@@ -67,10 +67,12 @@ public sealed record QueryHealth
     [AllowAnonymous]
     public static ISubject<QueryHealth> ObserveHealth(IQueryHealthTracker healthTracker)
     {
+#pragma warning disable CA2000 // DisposableQueryHealthSubject owns and disposes the BehaviorSubject returned from this method.
         var subject = new BehaviorSubject<QueryHealth>(new QueryHealth
         {
             Connections = healthTracker.GetAllConnectionHealth()
         });
+#pragma warning restore CA2000
 
         var subscription = healthTracker.ObserveHealth().Subscribe(connections =>
             subject.OnNext(new QueryHealth { Connections = connections }));

--- a/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
+++ b/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
@@ -15,13 +15,24 @@ namespace Cratis.Arc.Validation;
 public class DiscoverableValidators : IDiscoverableValidators
 {
     readonly Dictionary<Type, Type> _validatorTypesByModelType;
+    readonly Func<IServiceProvider> _serviceProviderAccessor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DiscoverableValidators"/> class.
     /// </summary>
     /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
-    public DiscoverableValidators(ITypes types)
+    public DiscoverableValidators(ITypes types) : this(types, () => Internals.ServiceProvider)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiscoverableValidators"/> class.
+    /// </summary>
+    /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
+    /// <param name="serviceProviderAccessor">Callback for getting the <see cref="IServiceProvider"/> to resolve validators from.</param>
+    internal DiscoverableValidators(ITypes types, Func<IServiceProvider> serviceProviderAccessor)
+    {
+        _serviceProviderAccessor = serviceProviderAccessor;
         var candidates = types.FindMultiple(typeof(IDiscoverableValidator<>));
         var invalidValidators = candidates.Where(_ =>
         {
@@ -50,12 +61,17 @@ public class DiscoverableValidators : IDiscoverableValidators
                 _ => _);
     }
 
+    /// <summary>
+    /// Gets the discovered validator types.
+    /// </summary>
+    internal IEnumerable<Type> ValidatorTypes => _validatorTypesByModelType.Values;
+
     /// <inheritdoc/>
     public bool TryGet(Type modelType, [MaybeNullWhen(false)] out IValidator validator)
     {
         if (_validatorTypesByModelType.TryGetValue(modelType, out var value))
         {
-            validator = (Internals.ServiceProvider.GetRequiredService(value) as IValidator)!;
+            validator = (_serviceProviderAccessor().GetRequiredService(value) as IValidator)!;
             return true;
         }
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/ApproveTimesheet.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/ApproveTimesheet.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using FluentValidation;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario;
+
+[Command]
+public record ApproveTimesheet(TimesheetId Id)
+{
+    public TimesheetApproved Handle() => new();
+}
+
+[Command]
+public record StartTimesheetReview(TimesheetId Id)
+{
+    public TimesheetReviewStarted Handle() => new();
+}
+
+public record TimesheetId(Guid Value) : EventSourceId<Guid>(Value);
+
+public interface ITimesheetState
+{
+    TimesheetPhase Phase { get; }
+}
+
+public enum TimesheetPhase
+{
+    Draft = 0,
+    Submitted = 1
+}
+
+public record TimesheetState(TimesheetPhase Phase) : ITimesheetState;
+
+public class ApproveTimesheetValidator : CommandValidator<ApproveTimesheet>
+{
+    public ApproveTimesheetValidator(TimesheetState state)
+    {
+        RuleFor(command => command.Id)
+            .Must(_ => state.Phase == TimesheetPhase.Submitted)
+            .WithMessage("Timesheet must be submitted before it can be approved.");
+    }
+}
+
+public class StartTimesheetReviewValidator : CommandValidator<StartTimesheetReview>
+{
+    public StartTimesheetReviewValidator(ITimesheetState state)
+    {
+        RuleFor(command => command.Id)
+            .Must(_ => state.Phase == TimesheetPhase.Submitted)
+            .WithMessage("Timesheet must be submitted before review can start.");
+    }
+}
+
+[EventType("53fc1ff0-8ee9-4de0-8e2c-5d2742c3568f")]
+public record TimesheetApproved;
+
+[EventType("cfc55948-829d-4ca6-a733-56bb742e4f60")]
+public record TimesheetReviewStarted;

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_is_missing/and_command_is_executed.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_is_missing/and_command_is_executed.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_dependency_is_missing;
+
+public class and_command_is_executed : Specification
+{
+    CommandScenario<ApproveTimesheet> _scenario;
+    CommandResult _result;
+    TimesheetId _timesheetId;
+
+    void Establish()
+    {
+        _timesheetId = new TimesheetId(Guid.NewGuid());
+        _scenario = new CommandScenario<ApproveTimesheet>();
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new ApproveTimesheet(_timesheetId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_exceptions() => _result.HasExceptions.ShouldBeTrue();
+    [Fact] void should_include_activation_failure() => _result.ExceptionMessages.First().ShouldContain("A suitable constructor");
+    [Fact] void should_tell_the_user_constructor_services_must_be_registered() => _result.ExceptionMessages.First().ShouldContain("services are registered for all parameters");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_state_allows_command/and_command_is_executed.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_state_allows_command/and_command_is_executed.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_dependency_state_allows_command;
+
+public class and_command_is_executed : Specification
+{
+    CommandScenario<ApproveTimesheet> _scenario;
+    CommandResult _result;
+    TimesheetId _timesheetId;
+
+    void Establish()
+    {
+        _timesheetId = new TimesheetId(Guid.NewGuid());
+        _scenario = new CommandScenario<ApproveTimesheet>();
+        _scenario.Services.AddSingleton(new TimesheetState(TimesheetPhase.Submitted));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new ApproveTimesheet(_timesheetId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+    [Fact] async Task should_have_appended_timesheet_approved_event() =>
+        await _scenario.ShouldHaveAppendedEvent<ApproveTimesheet, TimesheetApproved>((EventSourceId)_timesheetId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_state_rejects_command/and_command_is_executed.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_dependency_state_rejects_command/and_command_is_executed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_dependency_state_rejects_command;
+
+public class and_command_is_executed : Specification
+{
+    CommandScenario<ApproveTimesheet> _scenario;
+    CommandResult _result;
+    TimesheetId _timesheetId;
+
+    void Establish()
+    {
+        _timesheetId = new TimesheetId(Guid.NewGuid());
+        _scenario = new CommandScenario<ApproveTimesheet>();
+        _scenario.Services.AddSingleton(new TimesheetState(TimesheetPhase.Draft));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new ApproveTimesheet(_timesheetId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_validation_errors() => _result.ValidationResults.ShouldNotBeEmpty();
+    [Fact] void should_have_validation_error_from_validator() => _result.ValidationResults.First().Message.ShouldEqual("Timesheet must be submitted before it can be approved.");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_has_interface_dependency/and_command_is_executed.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_has_interface_dependency/and_command_is_executed.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_has_interface_dependency;
+
+public class and_command_is_executed : Specification
+{
+    CommandScenario<StartTimesheetReview> _scenario;
+    CommandResult _result;
+    TimesheetId _timesheetId;
+
+    void Establish()
+    {
+        _timesheetId = new TimesheetId(Guid.NewGuid());
+        _scenario = new CommandScenario<StartTimesheetReview>();
+        _scenario.Services.AddScoped<ITimesheetState>(_ => new TimesheetState(TimesheetPhase.Submitted));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new StartTimesheetReview(_timesheetId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+    [Fact] async Task should_have_appended_timesheet_review_started_event() =>
+        await _scenario.ShouldHaveAppendedEvent<StartTimesheetReview, TimesheetReviewStarted>((EventSourceId)_timesheetId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_is_manually_registered/and_command_is_executed.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_is_manually_registered/and_command_is_executed.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_is_manually_registered;
+
+public class and_command_is_executed : Specification
+{
+    CommandScenario<ApproveTimesheet> _scenario;
+    CommandResult _result;
+    TimesheetId _timesheetId;
+
+    void Establish()
+    {
+        _timesheetId = new TimesheetId(Guid.NewGuid());
+        _scenario = new CommandScenario<ApproveTimesheet>();
+        _scenario.Services.AddSingleton(new TimesheetState(TimesheetPhase.Draft));
+        _scenario.Services.AddTransient<ApproveTimesheetValidator>(_ => new ApproveTimesheetValidator(new TimesheetState(TimesheetPhase.Submitted)));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new ApproveTimesheet(_timesheetId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+    [Fact] async Task should_have_appended_timesheet_approved_event() =>
+        await _scenario.ShouldHaveAppendedEvent<ApproveTimesheet, TimesheetApproved>((EventSourceId)_timesheetId);
+}

--- a/Source/DotNET/Testing/Commands/CommandScenario.cs
+++ b/Source/DotNET/Testing/Commands/CommandScenario.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Commands;
+using Cratis.Arc.Validation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Testing.Commands;
@@ -127,8 +129,27 @@ public class CommandScenario<TCommand>
             return;
         }
 
+        var explicitlyRegisteredServiceTypes = Services.Select(_ => _.ServiceType).ToHashSet();
+        var hasExplicitDiscoverableValidatorsRegistration = explicitlyRegisteredServiceTypes.Contains(typeof(IDiscoverableValidators));
+
         Services.AddCratisArcCore();
+        IServiceProvider? serviceProvider = null;
+        var discoverableValidators = new DiscoverableValidators(
+            Cratis.Types.Types.Instance,
+            () => serviceProvider ?? throw new InvalidOperationException("The command scenario service provider has not been built."));
+        foreach (var validatorType in discoverableValidators.ValidatorTypes)
+        {
+            Services.TryAddTransient(validatorType, validatorType);
+        }
+
+        if (!hasExplicitDiscoverableValidatorsRegistration)
+        {
+            Services.RemoveAll<IDiscoverableValidators>();
+            Services.AddSingleton<IDiscoverableValidators>(discoverableValidators);
+        }
+
         _serviceProvider = Services.BuildServiceProvider();
+        serviceProvider = _serviceProvider;
         Internals.ServiceProvider = _serviceProvider;
         _pipeline = _serviceProvider.GetRequiredService<ICommandPipeline>();
     }

--- a/Source/JavaScript/Arc/commands/CommandResult.ts
+++ b/Source/JavaScript/Arc/commands/CommandResult.ts
@@ -152,11 +152,18 @@ export class CommandResult<TResponse = object> implements ICommandResult<TRespon
         this.exceptionStackTrace = result.exceptionStackTrace;
         this.authorizationFailureReason = result.authorizationFailureReason;
 
-        if (result.response) {
+        if (result.response !== undefined && result.response !== null) {
+            const isPrimitive = responseInstanceType === String || responseInstanceType === Number || responseInstanceType === Boolean;
             if (isResponseTypeEnumerable) {
-                this.response = JsonSerializer.deserializeArrayFromInstance(responseInstanceType, result.response) as TResponse;
+                this.response = (Array.isArray(result.response)
+                    ? (isPrimitive
+                        ? Array.from(result.response)
+                        : JsonSerializer.deserializeArrayFromInstance(responseInstanceType, result.response))
+                    : []) as TResponse;
             } else {
-                this.response = JsonSerializer.deserializeFromInstance(responseInstanceType, result.response) as TResponse;
+                this.response = (isPrimitive
+                    ? result.response
+                    : JsonSerializer.deserializeFromInstance(responseInstanceType, result.response)) as TResponse;
             }
         }
     }

--- a/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_with_primitive_response.ts
+++ b/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_with_primitive_response.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { CommandResult } from '../CommandResult';
+
+describe('when constructing with primitive response', () => {
+    const stringResult = new CommandResult<string>({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: 'Handled: TestName'
+    }, String, false);
+
+    const zeroResult = new CommandResult<number>({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: 0
+    }, Number, false);
+
+    const falseResult = new CommandResult<boolean>({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: false
+    }, Boolean, false);
+
+    const stringArrayResult = new CommandResult<string[]>({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: ['one', 'two']
+    }, String, true);
+
+    it('should preserve string response', () => stringResult.response!.should.equal('Handled: TestName'));
+    it('should preserve zero response', () => zeroResult.response!.should.equal(0));
+    it('should preserve false response', () => falseResult.response!.should.equal(false));
+    it('should preserve primitive array response', () => stringArrayResult.response!.should.deep.equal(['one', 'two']));
+});


### PR DESCRIPTION
# Summary

Command scenarios now exercise command validators discovered by Arc, including validators with scenario-provided dependencies and manual overrides.

## Added

- Specs covering automatic dependency-backed command validator execution in `CommandScenario<TCommand>`.
- Specs covering missing validator dependencies and manual concrete validator overrides.
- A spec proving validators can receive interface-backed scoped dependencies from `scenario.Services` without manually registering the validator.
- JavaScript command result specs covering primitive command responses.

## Changed

- `CommandScenario<TCommand>` registers discovered validators in its isolated service provider so scenario validation matches runtime command execution without leaking validators or dependencies across scenarios.
- Existing concrete validator registrations are preserved; scenarios only add missing validator registrations, so custom factories/lifetimes and manual overrides still win.
- JavaScript `CommandResult` now preserves primitive command responses directly instead of passing strings, numbers, and booleans through object deserialization.
- Added a narrow CA2000 ownership suppression for the query-health observable wrapper so Release builds recognize the existing disposal ownership pattern.