### PR TITLE
Replace reflect-metadata with the @cratis/fundamentals Reflect polyfill

### DIFF
--- a/.ai/skills/cratis-react-page/references/mvvm.md
+++ b/.ai/skills/cratis-react-page/references/mvvm.md
@@ -15,7 +15,7 @@ For simple pages, MVVM is optional — use regular hooks directly in the compone
 Install packages if not already present:
 
 ```
-npm install @cratis/arc.react.mvvm tsyringe reflect-metadata
+npm install @cratis/arc.react.mvvm tsyringe
 ```
 
 Ensure `tsconfig.json` enables decorators:
@@ -29,11 +29,8 @@ Ensure `tsconfig.json` enables decorators:
 }
 ```
 
-Import `reflect-metadata` once, at the entry point of your app:
-
-```tsx
-import 'reflect-metadata';
-```
+The `Reflect` metadata API that Tsyringe relies on is polyfilled automatically by `@cratis/arc` (via `@cratis/fundamentals`),
+so there is nothing extra to install or set up.
 
 ## View model class
 

--- a/Documentation/frontend/react.mvvm/tsyringe.md
+++ b/Documentation/frontend/react.mvvm/tsyringe.md
@@ -16,11 +16,11 @@ In your `tsconfig.json` make sure to enable the following compiler options:
 }
 ```
 
-In addition to this, you will also need the `reflect-metadata` package installed and included in your project at the top of the `index.tsx` file for
-your application.
+In addition to this, Tsyringe needs the `Reflect` metadata API to be available at runtime. Cratis Arc ships a lightweight
+polyfill for this (provided by `@cratis/fundamentals`) and loads it automatically when you import `@cratis/arc`, so there is
+nothing extra to install or set up.
 
 ```tsx
-import 'reflect-metadata';
 import { App } from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -30,7 +30,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 );
 ```
 
-This will enable the necessary reflection metadata for Tsyringe to work properly.
+This enables the necessary reflection metadata for Tsyringe to work properly.
 
 ## Vite
 

--- a/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Subjects;
 using Cratis.Arc.Authorization;
 using Cratis.Arc.Queries.ModelBound;
@@ -65,6 +66,7 @@ public sealed record QueryHealth
     /// <param name="healthTracker">The query health tracker service.</param>
     /// <returns>Observable subject emitting query health snapshots.</returns>
     [AllowAnonymous]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership of the subject and subscription is transferred to the returned DisposableQueryHealthSubject, which disposes both.")]
     public static ISubject<QueryHealth> ObserveHealth(IQueryHealthTracker healthTracker)
     {
         var subject = new BehaviorSubject<QueryHealth>(new QueryHealth

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
@@ -36,10 +36,6 @@
                                    Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/typescript/lib/typescript.js')">
             <TargetPath>node_modules/typescript/lib/typescript.js</TargetPath>
         </ProxyJavaScriptDependency>
-        <ProxyJavaScriptDependency Include="$(MSBuildThisFileDirectory)../../../../node_modules/reflect-metadata/Reflect.js"
-                                   Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/reflect-metadata/Reflect.js')">
-            <TargetPath>node_modules/reflect-metadata/Reflect.js</TargetPath>
-        </ProxyJavaScriptDependency>
         <ProxyJavaScriptDependency Include="$(MSBuildThisFileDirectory)../../../../node_modules/@cratis/fundamentals/dist/cjs/**/*"
                                    Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/@cratis/fundamentals/dist/cjs')">
             <TargetPath>node_modules/@cratis/fundamentals/dist/cjs/%(RecursiveDir)%(Filename)%(Extension)</TargetPath>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
@@ -115,15 +115,16 @@ public sealed class JavaScriptRuntime : IDisposable
                        "            if (!globalThis.exports) { globalThis.exports = globalThis.module.exports; }\n" +
                        "        ");
 
-        // Load reflect-metadata polyfill directly
+        // Load the Reflect metadata polyfill directly so the API is available globally
+        // before any script that relies on it runs.
         try
         {
-            var reflectMetadata = ReadJavaScriptFile("node_modules/reflect-metadata/Reflect.js");
-            Engine.Execute(reflectMetadata);
+            var reflectionPolyfill = ReadJavaScriptFile("node_modules/@cratis/fundamentals/dist/cjs/reflection.js");
+            Engine.Execute(reflectionPolyfill);
         }
         catch
         {
-            // Ignore errors loading reflect-metadata
+            // Ignore errors loading the reflection polyfill
         }
     }
 

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/arc-bootstrap.js
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/arc-bootstrap.js
@@ -234,7 +234,7 @@
     // Map of module specifiers to built JavaScript file paths (dist/cjs)
     const modulePathMap = {
         '@cratis/fundamentals': 'node_modules/@cratis/fundamentals/dist/cjs/index.js',
-        'reflect-metadata': 'node_modules/reflect-metadata/Reflect.js',
+        '@cratis/fundamentals/reflection': 'node_modules/@cratis/fundamentals/dist/cjs/reflection.js',
         'rxjs': 'node_modules/rxjs/dist/cjs/index.js',
         '@cratis/arc/commands': 'Arc/dist/cjs/commands/index.js',
         '@cratis/arc/identity': 'Arc/dist/cjs/identity/index.js',
@@ -356,13 +356,6 @@
 
         if (globalThis.__write_to_file && modulePath.includes('fundamentals')) {
             globalThis.__write_to_file('[ModuleCache] MISS for: ' + modulePath);
-        }
-
-        // Special handling for reflect-metadata to avoid reloading it if it's already global
-        // This prevents resetting the metadata store if the library is loaded multiple times
-        if (modulePath.includes('reflect-metadata/Reflect.js') && globalThis.Reflect && globalThis.Reflect.metadata) {
-            moduleCache[modulePath] = { exports: {} };
-            return moduleCache[modulePath].exports;
         }
 
         // Check if we're already loading this module (circular dependency)

--- a/Source/JavaScript/Arc.React.MVVM/for_params/when_decorating_constructor_parameter/with_typed_class.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_params/when_decorating_constructor_parameter/with_typed_class.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import 'reflect-metadata';
 import { injectable } from 'tsyringe';
 import { params, routeParamsTypeKey } from '../../params';
 

--- a/Source/JavaScript/Arc.React.MVVM/for_props/when_decorating_constructor_parameter/with_typed_class.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_props/when_decorating_constructor_parameter/with_typed_class.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import 'reflect-metadata';
 import { injectable } from 'tsyringe';
 import { props as propsDecorator, propsTypeKey } from '../../props';
 

--- a/Source/JavaScript/Arc.React.MVVM/for_queryParams/when_decorating_constructor_parameter/with_typed_class.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_queryParams/when_decorating_constructor_parameter/with_typed_class.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import 'reflect-metadata';
 import { injectable } from 'tsyringe';
 import { queryParams, queryParamsTypeKey } from '../../queryParams';
 

--- a/Source/JavaScript/Arc.React.MVVM/index.ts
+++ b/Source/JavaScript/Arc.React.MVVM/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import 'reflect-metadata';
 import * as browser from './browser';
 import * as messaging from './messaging';
 import * as dialogs from './dialogs';

--- a/Source/JavaScript/Arc.React.MVVM/package.json
+++ b/Source/JavaScript/Arc.React.MVVM/package.json
@@ -57,7 +57,6 @@
         "@cratis/arc.react": "1.0.0",
         "mobx": "^6.15.3",
         "mobx-react": "^9.2.1",
-        "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "tsyringe": "^4.10.0"
     },

--- a/Source/JavaScript/Arc/index.ts
+++ b/Source/JavaScript/Arc/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import '@cratis/fundamentals/reflection';
 import * as commands from './commands';
 import * as identity from './identity';
 import * as messaging from './messaging';

--- a/Source/JavaScript/Arc/package.json
+++ b/Source/JavaScript/Arc/package.json
@@ -69,7 +69,7 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "^7.15.1",
+        "@cratis/fundamentals": "^7.16.0",
         "rxjs": "^7.8.2"
     }
 }

--- a/mocha-setup.js
+++ b/mocha-setup.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 (async () => {
-    await import('reflect-metadata');
+    await import('@cratis/fundamentals/reflection');
     const chai = await import('chai');
     global.expect = chai.expect;
     const should = chai.should();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "up": "node ./run-task-on-workspaces.js up"
     },
     "devDependencies": {
-        "@cratis/fundamentals": "^7.10.3",
+        "@cratis/fundamentals": "^7.16.0",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "10.0.1",
         "@testing-library/dom": "^10.4.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -64,6 +64,7 @@ export function rollup(cjsPath, esmPath, tsconfigPath, pkg) {
             ...Object.keys(pkg.dependencies || {}),
             ...Object.keys(pkg.peerDependencies || {}),
             /^@cratis\/arc/,
+            /^@cratis\/fundamentals/,
             'react',
             'react-dom',
         ],
@@ -78,7 +79,7 @@ export function rollup(cjsPath, esmPath, tsconfigPath, pkg) {
             }),
             typescript2({
                 include: ['**/*.ts', '**/*.tsx'],
-                exclude: "for_**/**/*",
+                exclude: ["for_**/**/*", "**/node_modules/**"],
                 tsconfig: tsconfigPath,
                 clean: true
             }),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import 'reflect-metadata';
+import '@cratis/fundamentals/reflection';
 import * as chai from 'chai';
 chai.should();
 import * as chaiAsPromised from 'chai-as-promised';


### PR DESCRIPTION
## Changed

- `@cratis/arc` now sets up the `Reflect` metadata API automatically via the polyfill in `@cratis/fundamentals` — no separate `reflect-metadata` install or import is needed (#2286)

## Fixed

- Proxy metadata reflection no longer breaks in the React Native Hermes engine, where the `reflect-metadata` UMD wrapper failed partway through initialization and left `Reflect.getOwnMetadataKeys` undefined (#2286)

## Removed

- The `reflect-metadata` dependency is gone from `@cratis/arc.react.mvvm` (#2286)