### PR TITLE
Rename RouteAttribute to PathAttribute for unambiguous model-bound path override

### DIFF
--- a/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -35,16 +35,16 @@ public class ModelBoundQueryPerformer : IQueryPerformer
         FullyQualifiedName = $"{readModelTypeName}.{performMethod.Name}";
         Location = readModelType.Namespace?.Split('.') ?? [];
 
-        // Check for Route attribute on method or type
-        var routeAttribute = performMethod.GetCustomAttributes(true)
-            .FirstOrDefault(a => a.GetType().Name == "RouteAttribute") ??
+        // Check for Path attribute on method or type
+        var pathAttribute = performMethod.GetCustomAttributes(true)
+            .FirstOrDefault(a => a.GetType().Name == "PathAttribute") ??
             readModelType.GetCustomAttributes(true)
-            .FirstOrDefault(a => a.GetType().Name == "RouteAttribute");
+            .FirstOrDefault(a => a.GetType().Name == "PathAttribute");
 
-        if (routeAttribute != null)
+        if (pathAttribute != null)
         {
-            var routeProperty = routeAttribute.GetType().GetProperty("Route");
-            CustomRoute = routeProperty?.GetValue(routeAttribute) as string;
+            var pathProperty = pathAttribute.GetType().GetProperty("Path");
+            CustomRoute = pathProperty?.GetValue(pathAttribute) as string;
         }
 
         _dependencies = performMethod.GetParameters().Where(p => serviceProviderIsService.IsService(p.ParameterType));

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/PathAttribute.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/PathAttribute.cs
@@ -4,14 +4,14 @@
 namespace Cratis.Arc.Queries.ModelBound;
 
 /// <summary>
-/// Attribute to specify a custom route for a read model or query method.
+/// Attribute to specify a custom path for a read model or query method.
 /// </summary>
-/// <param name="route">The custom route path.</param>
+/// <param name="path">The custom path.</param>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-public sealed class RouteAttribute(string route) : Attribute
+public sealed class PathAttribute(string path) : Attribute
 {
     /// <summary>
-    /// Gets the custom route.
+    /// Gets the custom path.
     /// </summary>
-    public string Route { get; } = route;
+    public string Path { get; } = path;
 }

--- a/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryHealth.cs
@@ -12,7 +12,7 @@ namespace Cratis.Arc.Queries;
 /// Read model for query health monitoring.
 /// </summary>
 [ReadModel]
-[Route("/.cratis/queries/health")]
+[Path("/.cratis/queries/health")]
 [AllowAnonymous]
 public sealed record QueryHealth
 {

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/QueryExtensions.cs
@@ -95,9 +95,9 @@ public static class QueryExtensions
         var hasConflict = totalMethodsInNamespace > 1;
         var includeQueryName = !skipQueryNameInRoute || hasConflict;
 
-        // Check for Route attribute on method or type
-        var methodRouteAttr = method.GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.Name == "RouteAttribute");
-        var typeRouteAttr = readModelType.GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.Name == "RouteAttribute");
+        // Check for Path attribute on method or type
+        var methodRouteAttr = method.GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.Name == "PathAttribute");
+        var typeRouteAttr = readModelType.GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.Name == "PathAttribute");
         var routeAttributeData = methodRouteAttr ?? typeRouteAttr;
 
         var customRouteValue = routeAttributeData is { ConstructorArguments.Count: > 0 }


### PR DESCRIPTION
## Changed
- `RouteAttribute` in `Cratis.Arc.Queries.ModelBound` is renamed to `PathAttribute`, with the `Route` property renamed to `Path`. The old name was ambiguous when both ASP.NET Core and the model-bound namespace were in scope.