### PR TITLE
Switch Arc React Storybook docs page to full-page embed mode

### DIFF
--- a/Documentation/frontend/react/storybook.mdx
+++ b/Documentation/frontend/react/storybook.mdx
@@ -1,12 +1,8 @@
 ---
 title: Storybook
 description: Browse Arc's React building blocks — CommandForm fields, query and observable-query helpers, and the story components — live in an interactive Storybook.
+tableOfContents: false
 ---
 import StorybookEmbed from '@components/StorybookEmbed.astro';
 
-Arc's React layer ships with **stories** — live, interactive examples of the building blocks you
-compose screens from: the `CommandForm` field types, the query and observable-query helpers, and
-the reusable story components. Toggle props and states to see exactly how each piece behaves before
-you wire it into a page.
-
-<StorybookEmbed storybook="/storybook-arc" title="Cratis Arc React Storybook" />
+<StorybookEmbed storybook="/storybook-arc" title="Cratis Arc React Storybook" fullPage={true} />


### PR DESCRIPTION
## Changed
- Arc React Storybook page now fills the entire content area with Storybook's navigation and panels visible, matching the Components Storybook page layout.