### PR TITLE
Add command Provide method for supplying Handle arguments

### DIFF
--- a/Documentation/backend/code-analysis/ARC0005.md
+++ b/Documentation/backend/code-analysis/ARC0005.md
@@ -1,0 +1,47 @@
+# ARC0005: Value produced by Provide is not consumed by Handle
+
+## Rule
+
+When a command declares a `Provide()` method, every value it produces must be consumed by a parameter of the command's `Handle()` method. A produced value that no `Handle` parameter can receive is almost always a mistake.
+
+Control values that short-circuit execution rather than feed `Handle` — `ValidationResult`, `AuthorizationResult`, and `CommandResult` — are exempt.
+
+## Severity
+
+Warning
+
+## Example
+
+### Violation
+
+```csharp
+using Cratis.Arc.Commands.ModelBound;
+
+[Command]
+public record ApproveLoan(ApplicantId Applicant)
+{
+    public CreditScore Provide(ICreditBureau bureau) => bureau.GetScore(Applicant);
+
+    public void Handle()
+    {
+    }
+}
+```
+
+`Provide` returns a `CreditScore`, but `Handle` has no parameter that can receive it.
+
+### Fix
+
+```csharp
+using Cratis.Arc.Commands.ModelBound;
+
+[Command]
+public record ApproveLoan(ApplicantId Applicant)
+{
+    public CreditScore Provide(ICreditBureau bureau) => bureau.GetScore(Applicant);
+
+    public LoanApproved Handle(CreditScore creditScore) => new(Applicant, creditScore);
+}
+```
+
+See [Provide data to a command handler](../../scenarios/provide-data-to-a-command.md) for the full pattern.

--- a/Documentation/backend/code-analysis/index.md
+++ b/Documentation/backend/code-analysis/index.md
@@ -14,6 +14,7 @@ All rules follow the identifier format `ARC####` where the numbers are sequentia
 | [ARC0002](ARC0002.md) | Missing [Command] attribute on command-like type | Warning | Command-like types must be marked with `[Command]` to be recognized as commands. |
 | [ARC0003](ARC0003.md) | Handle() must be on [Command] type | Error | Public command `Handle()` methods must be declared on the command type itself. |
 | [ARC0004](ARC0004.md) | [Command] type must have public Handle() method | Error | Types marked with `[Command]` must declare a public instance `Handle()` method. |
+| [ARC0005](ARC0005.md) | Value produced by Provide is not consumed by Handle | Warning | Every value a command's `Provide()` method produces must be consumed by a `Handle()` parameter. |
 
 ## Quick Fixes
 

--- a/Documentation/backend/code-analysis/toc.yml
+++ b/Documentation/backend/code-analysis/toc.yml
@@ -4,3 +4,9 @@
   href: ARC0001.md
 - name: ARC0002 - Missing [Command] attribute on command-like type
   href: ARC0002.md
+- name: ARC0003 - Handle() must be on [Command] type
+  href: ARC0003.md
+- name: ARC0004 - [Command] type must have public Handle() method
+  href: ARC0004.md
+- name: ARC0005 - Value produced by Provide is not consumed by Handle
+  href: ARC0005.md

--- a/Documentation/backend/commands/index.md
+++ b/Documentation/backend/commands/index.md
@@ -39,6 +39,11 @@ command as an HTTP `POST`, binds the incoming JSON to the record, runs any valid
 service, or anything else your slice owns. With the [Chronicle integration](../chronicle/) installed, a
 command can return events instead and let Arc append them for you.
 
+> [!TIP]
+> When a decision needs data you have to *fetch* — a lookup, an external score, current state — move that
+> fetch into a `Provide()` method next to `Handle()`, so `Handle` stays a pure, easily tested function of
+> its arguments. See [Provide data to a command handler](../../scenarios/provide-data-to-a-command.md).
+
 `Handle()` can return what suits the operation:
 
 - **nothing** (`void` / `Task`) — fire-and-forget changes

--- a/Documentation/scenarios/index.md
+++ b/Documentation/scenarios/index.md
@@ -9,6 +9,7 @@ These are recipes: "I need to do X — how?" Each one is short and assumes you'v
 |---|---|
 | [Validate a command](./validate-a-command.md) | Reject malformed or duplicate input before it writes state |
 | [Return a result or an error](./return-a-result-or-error.md) | A command needs to hand back more than "it worked" — a value, or a typed failure |
+| [Provide data to a command handler](./provide-data-to-a-command.md) | A decision needs data you must fetch — keep the fetch out of `Handle` so it stays testable |
 | [Query data across slices](./query-related-data.md) | A screen needs data that spans more than one feature |
 | [Execute a command from React](./run-a-command-from-react.md) | Wire a form or button to a command through the generated proxy |
 | [Test a command](./test-a-command.md) | Prove a slice works through the real pipeline — no HTTP, no database |

--- a/Documentation/scenarios/provide-data-to-a-command.md
+++ b/Documentation/scenarios/provide-data-to-a-command.md
@@ -1,0 +1,87 @@
+---
+title: Provide data to a command handler
+description: Fetch the data a command's decision needs in a Provide method so Handle stays a pure, easily tested function of its arguments.
+---
+
+**Goal:** your command's `Handle()` needs data it doesn't carry — a lookup, an external score, some current state — and you don't want that IO tangled into the decision logic, where it's hard to test.
+
+## Lift the IO out of `Handle`
+
+Add a `Provide()` method next to `Handle()` on the command. `Provide` fetches or computes what the decision needs, and its return value is passed into `Handle()` as an argument. `Handle` is left as a pure function of its arguments — given its inputs it returns events or results, with no IO to set up.
+
+`Provide` runs before `Handle`, after validation and authorization pass. Its parameters are resolved from dependency injection just like `Handle`'s, and `this` is the command, so it can read the command's own data.
+
+```csharp
+[Command]
+public record ApproveLoan(LoanId LoanId, ApplicantId Applicant)
+{
+    public CreditScore Provide(ICreditBureau bureau) => bureau.GetScore(Applicant);
+
+    public LoanApproved Handle(CreditScore creditScore) => new(LoanId, creditScore);
+}
+```
+
+## Why this matters: testability
+
+Because the IO lives in `Provide`, testing the decision needs no mocking — construct the command and call `Handle` directly with the values it would have received:
+
+```csharp
+[Fact] void should_produce_the_event() =>
+    new ApproveLoan(LoanId.New(), ApplicantId.New())
+        .Handle(new CreditScore(800))
+        .ShouldBeOfExactType<LoanApproved>();
+```
+
+`Provide` has a single job — acquire data — so it is easy to test in isolation too, with a stubbed `ICreditBureau`.
+
+## Return more than one value
+
+Return a tuple to feed several `Handle` parameters; each value is matched to a parameter by type:
+
+```csharp
+public (CreditScore, RiskBand) Provide(ICreditBureau bureau, IRiskModel risk) =>
+    (bureau.GetScore(Applicant), risk.Band(Applicant));
+
+public LoanApproved Handle(CreditScore score, RiskBand band) => new(LoanId, score, band);
+```
+
+`Provide` may be synchronous or `async` (`Task<T>` / `ValueTask<T>`).
+
+## Short-circuit before `Handle` runs
+
+`Provide` can stop the command before `Handle` is ever called:
+
+| Return / do | Result |
+|---|---|
+| `ValidationResult.Error("…")` | command fails validation (HTTP 400) |
+| an `AuthorizationResult` that is not authorized | command is unauthorized (HTTP 403) |
+| throw | command fails with the exception (HTTP 500) |
+| a value | flows into `Handle` as an argument |
+
+Use `Result<,>` to reject or proceed in one method — return the error to stop, or the value to continue:
+
+```csharp
+public Result<ValidationResult, CreditScore> Provide(ICreditBureau bureau)
+{
+    var score = bureau.GetScore(Applicant);
+    return score is null
+        ? ValidationResult.Error("No credit history", [nameof(Applicant)])
+        : score;
+}
+```
+
+A `Provide` value that no `Handle` parameter consumes is almost always a mistake, so the analyzer flags it (ARC0005).
+
+## Cross-cutting values
+
+`Provide` is per-command. For a value that many handlers need — the current tenant's settings, say — register it as a scoped service and take it as a `Handle` parameter. Arc resolves any `Handle` or `Provide` parameter it can't otherwise supply from the container.
+
+## When not to use it
+
+If `Handle` already has everything it needs from the command and its injected services, you don't need `Provide`. Reach for it specifically when a decision depends on data you must fetch — that's where moving the fetch out buys you the testability.
+
+## See also
+
+- [Return a result or an error](./return-a-result-or-error.md) — the shapes `Handle()` itself can return.
+- [Test a command](./test-a-command.md) — testing a slice through the real pipeline.
+- [Validate a command](./validate-a-command.md) — where `ValidationResult.Error` comes from.

--- a/Documentation/scenarios/toc.yml
+++ b/Documentation/scenarios/toc.yml
@@ -4,6 +4,8 @@
   href: validate-a-command.md
 - name: Return a result or an error
   href: return-a-result-or-error.md
+- name: Provide data to a command handler
+  href: provide-data-to-a-command.md
 - name: Query data across slices
   href: query-related-data.md
 - name: Execute a command from React

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_a_tuple_element_is_unused.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_a_tuple_element_is_unused.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandProvideAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandProvideAnalyzer.for_ARC0005;
+
+public class when_a_tuple_element_is_unused
+{
+    [Fact] async Task should_report_diagnostic_for_the_unused_element() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public class UsedData { }
+    public class UnusedData { }
+
+    [Command]
+    public record CreateOrder
+    {
+        public (UsedData Used, UnusedData Unused) {|#0:Provide|}() => (new UsedData(), new UnusedData());
+        public void Handle(UsedData used) { }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0005")
+            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("UnusedData", "CreateOrder"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_async_provided_value_is_unused.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_async_provided_value_is_unused.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandProvideAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandProvideAnalyzer.for_ARC0005;
+
+public class when_async_provided_value_is_unused
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public class ExtraData { }
+
+    [Command]
+    public record CreateOrder
+    {
+        public Task<ExtraData> {|#0:Provide|}() => Task.FromResult(new ExtraData());
+        public void Handle() { }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0005")
+            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("ExtraData", "CreateOrder"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_a_validation_result.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_a_validation_result.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandProvideAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandProvideAnalyzer.for_ARC0005;
+
+public class when_provided_value_is_a_validation_result
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.Validation;
+
+namespace TestNamespace
+{
+    [Command]
+    public record CreateOrder
+    {
+        public ValidationResult Provide() => ValidationResult.Error(""Not allowed"");
+        public void Handle() { }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_consumed.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_consumed.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandProvideAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandProvideAnalyzer.for_ARC0005;
+
+public class when_provided_value_is_consumed
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public class ExtraData { }
+
+    [Command]
+    public record CreateOrder
+    {
+        public ExtraData Provide() => new ExtraData();
+        public void Handle(ExtraData data) { }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_unused.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandProvideAnalyzer/for_ARC0005/when_provided_value_is_unused.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandProvideAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandProvideAnalyzer.for_ARC0005;
+
+public class when_provided_value_is_unused
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public class ExtraData { }
+
+    [Command]
+    public record CreateOrder
+    {
+        public ExtraData {|#0:Provide|}() => new ExtraData();
+        public void Handle() { }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0005")
+            .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("ExtraData", "CreateOrder"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@ ARC0001|Arc|Error|Incorrect Query method signature on ReadModel
 ARC0002|Arc|Warning|Missing [Command] attribute on command-like type
 ARC0003|Arc|Error|Handle() must be on [Command] type
 ARC0004|Arc|Error|[Command] type must have public Handle() method
+ARC0005|Arc|Warning|Value produced by Provide is not consumed by Handle

--- a/Source/DotNET/Arc.Core.CodeAnalysis/CommandProvideAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/CommandProvideAnalyzer.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer for the optional Provide method on a Command type.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandProvideAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
+            DiagnosticDescriptors.ARC0005_ProvidedValueNotConsumed
+        ];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+        if (!HasAttribute(namedTypeSymbol, "Cratis.Arc.Commands.ModelBound.CommandAttribute"))
+        {
+            return;
+        }
+
+        var handleMethod = FindMethod(namedTypeSymbol, "Handle");
+        var provideMethod = FindMethod(namedTypeSymbol, "Provide");
+        if (handleMethod is null || provideMethod is null)
+        {
+            return;
+        }
+
+        var handleParameterTypes = handleMethod.Parameters.Select(parameter => parameter.Type).ToArray();
+
+        foreach (var providedType in GetProducedTypes(provideMethod.ReturnType))
+        {
+            if (IsControlType(providedType))
+            {
+                continue;
+            }
+
+            if (handleParameterTypes.Any(parameterType => IsAssignableTo(context.Compilation, providedType, parameterType)))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARC0005_ProvidedValueNotConsumed,
+                provideMethod.Locations[0],
+                providedType.Name,
+                namedTypeSymbol.Name));
+        }
+    }
+
+    static IEnumerable<ITypeSymbol> GetProducedTypes(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol named)
+        {
+            return [type];
+        }
+
+        var ns = Namespace(named);
+        if (ns == "System.Threading.Tasks" && (named.Name == "Task" || named.Name == "ValueTask"))
+        {
+            return named.TypeArguments.Length == 1 ? GetProducedTypes(named.TypeArguments[0]) : [];
+        }
+
+        if (named.IsTupleType)
+        {
+            return named.TupleElements.SelectMany(element => GetProducedTypes(element.Type));
+        }
+
+        if (IsOneOf(named))
+        {
+            return named.TypeArguments.SelectMany(GetProducedTypes);
+        }
+
+        return [type];
+    }
+
+    static bool IsControlType(ITypeSymbol type)
+    {
+        if (IsNamed(type, "Cratis.Arc.Validation", "ValidationResult") ||
+            IsNamed(type, "Cratis.Arc.Authorization", "AuthorizationResult") ||
+            IsNamed(type, "Cratis.Arc.Commands", "CommandResult"))
+        {
+            return true;
+        }
+
+        var interfaces = type is INamedTypeSymbol named ? named.AllInterfaces.Add(named) : type.AllInterfaces;
+        return interfaces.Any(@interface =>
+            @interface.Name == "IEnumerable" &&
+            @interface.TypeArguments.Length == 1 &&
+            IsNamed(@interface.TypeArguments[0], "Cratis.Arc.Validation", "ValidationResult"));
+    }
+
+    static bool IsAssignableTo(Compilation compilation, ITypeSymbol source, ITypeSymbol destination)
+    {
+        var conversion = compilation.ClassifyCommonConversion(source, destination);
+        return conversion.IsIdentity || conversion.IsImplicit;
+    }
+
+    static bool IsOneOf(INamedTypeSymbol type) =>
+        type.TypeArguments.Length > 0 &&
+        type.AllInterfaces.Any(@interface => @interface.Name == "IOneOf" && Namespace(@interface) == "OneOf");
+
+    static bool IsNamed(ITypeSymbol type, string @namespace, string name) =>
+        type.Name == name && Namespace(type) == @namespace;
+
+    static string Namespace(ITypeSymbol type) => type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+
+    static IMethodSymbol? FindMethod(INamedTypeSymbol typeSymbol, string name) =>
+        typeSymbol.GetMembers(name)
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(method => method.MethodKind == MethodKind.Ordinary && !method.IsStatic);
+
+    static bool HasAttribute(INamedTypeSymbol typeSymbol, string attributeFullName) =>
+        typeSymbol.GetAttributes().Any(attribute => attribute.AttributeClass?.ToDisplayString() == attributeFullName);
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -58,5 +58,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Fix by adding a public instance Handle() method to the [Command] type. Non-public Handle methods do not satisfy the model-bound command contract.");
 
+    /// <summary>
+    /// ARC0005: Value produced by Provide is not consumed by Handle.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0005_ProvidedValueNotConsumed = new(
+        id: "ARC0005",
+        title: "Value produced by Provide is not consumed by Handle",
+        messageFormat: "Value of type '{0}' produced by the Provide method on command '{1}' is not consumed by any Handle parameter. Add a matching Handle parameter or remove the value from Provide.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Fix by adding a Handle parameter that consumes the value the Provide method returns, or by removing the unused value from Provide. Control values (ValidationResult, AuthorizationResult, CommandResult) are exempt because they short-circuit execution rather than feed Handle.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/given/a_command_handler_argument_resolver.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/given/a_command_handler_argument_resolver.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.given;
+
+public class a_command_handler_argument_resolver : Specification
+{
+    protected ICommandProvideInvoker _provideInvoker;
+    protected CommandHandlerArgumentResolver _resolver;
+    protected IServiceProvider _serviceProvider;
+    protected CommandContext _context;
+    protected ICommandHandler _handler;
+    protected CorrelationId _correlationId;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _provideInvoker = Substitute.For<ICommandProvideInvoker>();
+        ProvideReturns();
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _handler = Substitute.For<ICommandHandler>();
+        _handler.Parameters.Returns([]);
+        _context = new(_correlationId, typeof(object), new object(), [], new());
+        _resolver = new(_provideInvoker);
+    }
+
+    protected void ProvideReturns(params object[] values) =>
+        _provideInvoker.Invoke(Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>())
+            .Returns(_ => new ValueTask<IReadOnlyList<object>>(values));
+
+    protected void HandleHasParameters<THandlerSample>() =>
+        _handler.Parameters.Returns(ParametersFor<THandlerSample>());
+
+    protected static ParameterInfo[] ParametersFor<THandlerSample>() =>
+        typeof(THandlerSample).GetMethod("Handle")!.GetParameters();
+
+    protected ValueTask<CommandHandlerArgumentResolution> Resolve() =>
+        _resolver.Resolve(_handler, _context, _serviceProvider, allowedSeverity: null);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_a_parameter_is_not_provided.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_a_parameter_is_not_provided.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_a_parameter_is_not_provided : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns();
+        _serviceProvider.GetService(typeof(string)).Returns("from di");
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_fall_back_to_the_service_provider() => _result.Arguments[0].ShouldEqual("from di");
+    [Fact] void should_resolve_the_parameter_from_di() => _serviceProvider.Received().GetService(typeof(string));
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_multiple_values_are_provided.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_multiple_values_are_provided.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_multiple_values_are_provided : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string first, int second) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns("hello", 42);
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_not_short_circuit() => _result.IsShortCircuited.ShouldBeFalse();
+    [Fact] void should_match_the_first_parameter_by_type() => _result.Arguments[0].ShouldEqual("hello");
+    [Fact] void should_match_the_second_parameter_by_type() => _result.Arguments[1].ShouldEqual(42);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_command_result.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_command_result.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_returns_a_command_result : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns(CommandResult.Error(_correlationId, "boom"));
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_short_circuit() => _result.IsShortCircuited.ShouldBeTrue();
+    [Fact] void should_carry_the_exception() => _result.ControlResult.HasExceptions.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_non_blocking_warning.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_non_blocking_warning.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_returns_a_non_blocking_warning : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns(ValidationResult.Warning("Heads up"), "the value");
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_not_short_circuit() => _result.IsShortCircuited.ShouldBeFalse();
+    [Fact] void should_still_build_arguments() => _result.Arguments[0].ShouldEqual("the value");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_single_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_single_value.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_returns_a_single_value : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns("the value");
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_not_short_circuit() => _result.IsShortCircuited.ShouldBeFalse();
+    [Fact] void should_have_a_single_argument() => _result.Arguments.Count.ShouldEqual(1);
+    [Fact] void should_pass_the_provided_value() => _result.Arguments[0].ShouldEqual("the value");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_validation_error.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_a_validation_error.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_returns_a_validation_error : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns(ValidationResult.Error("Not allowed"));
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_short_circuit() => _result.IsShortCircuited.ShouldBeTrue();
+    [Fact] void should_not_build_any_arguments() => _result.Arguments.ShouldBeEmpty();
+    [Fact] void should_carry_the_validation_result() => _result.ControlResult.ValidationResults.ShouldNotBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_an_unauthorized_result.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_returns_an_unauthorized_result.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_returns_an_unauthorized_result : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns(new AuthorizationResult(false, "Denied"));
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_short_circuit() => _result.IsShortCircuited.ShouldBeTrue();
+    [Fact] void should_not_be_authorized() => _result.ControlResult.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_not_build_any_arguments() => _result.Arguments.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_value_overrides_a_di_type.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_provide_value_overrides_a_di_type.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_provide_value_overrides_a_di_type : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(string value) { }
+    }
+
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns("from provide");
+        _serviceProvider.GetService(typeof(string)).Returns("from di");
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    [Fact] void should_use_the_provided_value() => _result.Arguments[0].ShouldEqual("from provide");
+    [Fact] void should_not_resolve_from_di() => _serviceProvider.DidNotReceive().GetService(typeof(string));
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/given/a_command_pipeline.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Validation;
 using Cratis.Execution;
 using Cratis.Traces;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ public class a_command_pipeline : Specification
     protected ICommandResponseValueHandlers _commandResponseValueHandlers;
     protected ICommandContextModifier _commandContextModifier;
     protected ICommandContextValuesBuilder _commandContextValuesBuilder;
+    protected ICommandHandlerArgumentResolver _commandHandlerArgumentResolver;
     protected IServiceProvider _serviceProvider;
     protected IServiceScopeFactory _serviceScopeFactory;
     protected IServiceScope _serviceScope;
@@ -34,6 +36,10 @@ public class a_command_pipeline : Specification
         _commandContextModifier = Substitute.For<ICommandContextModifier>();
         _commandContextValuesBuilder = Substitute.For<ICommandContextValuesBuilder>();
         _commandContextValuesBuilder.Build(Arg.Any<object>()).Returns(new CommandContextValues());
+        _commandHandlerArgumentResolver = Substitute.For<ICommandHandlerArgumentResolver>();
+        _commandHandlerArgumentResolver
+            .Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>())
+            .Returns(_ => new ValueTask<CommandHandlerArgumentResolution>(new CommandHandlerArgumentResolution([], CommandResult.Success(_correlationId))));
         _serviceProvider = Substitute.For<IServiceProvider>();
         _serviceScope = Substitute.For<IServiceScope>();
         _serviceScope.ServiceProvider.Returns(_serviceProvider);
@@ -47,6 +53,7 @@ public class a_command_pipeline : Specification
             _commandResponseValueHandlers,
             _commandContextModifier,
             _commandContextValuesBuilder,
+            _commandHandlerArgumentResolver,
             _serviceScopeFactory,
             CreateActivitySource<CommandPipeline>());
     }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_filters_are_reporting_not_successful.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Validation;
 using Cratis.Execution;
 
 namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
@@ -18,5 +19,6 @@ public class and_command_filters_are_reporting_not_successful : given.a_command_
 
     [Fact] void should_return_not_successful() => _result.IsSuccess.ShouldBeFalse();
     [Fact] void should_not_call_command_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());
+    [Fact] void should_not_resolve_arguments() => _commandHandlerArgumentResolver.DidNotReceive().Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>());
     [Fact] void should_set_current_command_context() => _commandContextModifier.Received(1).SetCurrent(Arg.Any<CommandContext>());
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_provide_short_circuits.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_provide_short_circuits.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+public class and_provide_short_circuits : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var shortCircuit = new CommandResult
+        {
+            CorrelationId = _correlationId,
+            ValidationResults = [ValidationResult.Error("Not allowed")]
+        };
+        _commandHandlerArgumentResolver
+            .Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>())
+            .Returns(_ => new ValueTask<CommandHandlerArgumentResolution>(new CommandHandlerArgumentResolution([], shortCircuit)));
+    }
+
+    async Task Because() => _result = await _commandPipeline.Execute(_command, _serviceProvider);
+
+    [Fact] void should_return_not_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_carry_the_validation_result() => _result.ValidationResults.ShouldNotBeEmpty();
+    [Fact] void should_not_call_command_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_there_is_a_handler_that_has_dependencies.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Validation;
+
 namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
 
 public class and_there_is_a_handler_that_has_dependencies : given.a_command_pipeline_and_a_handler_for_command
@@ -14,9 +16,9 @@ public class and_there_is_a_handler_that_has_dependencies : given.a_command_pipe
     void Establish()
     {
         _expectedDependencies = ["Forty two", 42];
-        _commandHandler.Dependencies.Returns([typeof(string), typeof(int)]);
-        _serviceProvider.GetService(typeof(string)).Returns(_expectedDependencies[0]);
-        _serviceProvider.GetService(typeof(int)).Returns(_expectedDependencies[1]);
+        _commandHandlerArgumentResolver
+            .Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>())
+            .Returns(_ => new ValueTask<CommandHandlerArgumentResolution>(new CommandHandlerArgumentResolution(_expectedDependencies, CommandResult.Success(_correlationId))));
 
         _expectedValues = new CommandContextValues
         {

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_has_a_provide_method.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_has_a_provide_method.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_validating;
+
+public class and_command_has_a_provide_method : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await _commandPipeline.Validate(_command, _serviceProvider);
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_resolve_arguments() => _commandHandlerArgumentResolver.DidNotReceive().Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>());
+    [Fact] void should_not_call_command_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/given/a_command_provide_invoker.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/given/a_command_provide_invoker.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.given;
+
+public class a_command_provide_invoker : Specification
+{
+    protected CommandProvideInvoker _invoker;
+    protected IServiceProvider _serviceProvider;
+
+    void Establish()
+    {
+        _invoker = new();
+        _serviceProvider = Substitute.For<IServiceProvider>();
+    }
+
+    protected ValueTask<IReadOnlyList<object>> Invoke(object command) =>
+        _invoker.Invoke(new CommandContext(CorrelationId.New(), command.GetType(), command, [], new()), _serviceProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_command_has_no_provide_method.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_command_has_no_provide_method.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_command_has_no_provide_method : given.a_command_provide_invoker
+{
+    class Command;
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_no_values() => _result.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_one_of.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_one_of.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using OneOf;
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_returns_a_one_of : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public OneOf<string, int> Provide() => OneOf<string, int>.FromT0("the value");
+    }
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_a_single_value() => _result.Count.ShouldEqual(1);
+    [Fact] void should_unwrap_to_the_active_value() => _result[0].ShouldEqual("the value");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_single_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_single_value.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_returns_a_single_value : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public string Provide() => "the value";
+    }
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_a_single_value() => _result.Count.ShouldEqual(1);
+    [Fact] void should_return_the_value() => _result[0].ShouldEqual("the value");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_task.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_task.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_returns_a_task : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public Task<string> Provide() => Task.FromResult("the value");
+    }
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_a_single_value() => _result.Count.ShouldEqual(1);
+    [Fact] void should_await_and_return_the_value() => _result[0].ShouldEqual("the value");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_tuple.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_tuple.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_returns_a_tuple : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public (string First, int Second) Provide() => ("hello", 42);
+    }
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_each_element() => _result.Count.ShouldEqual(2);
+    [Fact] void should_contain_the_first_element() => _result.ShouldContain("hello");
+    [Fact] void should_contain_the_second_element() => _result.ShouldContain(42);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_value_task.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_returns_a_value_task.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_returns_a_value_task : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public ValueTask<int> Provide() => new(42);
+    }
+
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_return_a_single_value() => _result.Count.ShouldEqual(1);
+    [Fact] void should_await_and_return_the_value() => _result[0].ShouldEqual(42);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_takes_dependencies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_takes_dependencies.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_takes_dependencies : given.a_command_provide_invoker
+{
+    public interface IDependency
+    {
+        string Value { get; }
+    }
+
+    class Command
+    {
+        public string Provide(IDependency dependency) => dependency.Value;
+    }
+
+    IReadOnlyList<object> _result;
+
+    void Establish()
+    {
+        var dependency = Substitute.For<IDependency>();
+        dependency.Value.Returns("from dependency");
+        _serviceProvider.GetService(typeof(IDependency)).Returns(dependency);
+    }
+
+    async Task Because() => _result = await Invoke(new Command());
+
+    [Fact] void should_resolve_the_dependency_from_di() => _serviceProvider.Received().GetService(typeof(IDependency));
+    [Fact] void should_use_the_dependency() => _result[0].ShouldEqual("from dependency");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_throws.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_throws : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public string Provide() => throw new Exception("provide failed");
+    }
+
+    Exception _exception;
+
+    async Task Because() => _exception = await Catch.Exception(async () => await Invoke(new Command()));
+
+    [Fact] void should_surface_the_inner_exception() => _exception.ShouldNotBeNull();
+    [Fact] void should_preserve_the_message() => _exception.Message.ShouldEqual("provide failed");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/given/a_loan_approval_command.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/given/a_loan_approval_command.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+
+namespace Cratis.Arc.Commands.for_a_command_with_a_provide_method.given;
+
+public class a_loan_approval_command : Specification
+{
+    public interface ICreditBureau
+    {
+        int GetScore(string applicant);
+    }
+
+    public record CreditScore(int Value);
+
+    public record LoanApproved(string Applicant);
+
+    [Command]
+    public record ApproveLoan(string Applicant)
+    {
+        public CreditScore Provide(ICreditBureau bureau) => new(bureau.GetScore(Applicant));
+
+        public LoanApproved? Handle(CreditScore creditScore) =>
+            creditScore.Value >= 700 ? new LoanApproved(Applicant) : null;
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_handling_directly.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_handling_directly.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_a_command_with_a_provide_method;
+
+public class when_handling_directly : given.a_loan_approval_command
+{
+    LoanApproved? _approved;
+    LoanApproved? _rejected;
+
+    void Because()
+    {
+        _approved = new ApproveLoan("acme").Handle(new CreditScore(800));
+        _rejected = new ApproveLoan("acme").Handle(new CreditScore(500));
+    }
+
+    [Fact] void should_approve_when_the_score_is_high_enough() => _approved.ShouldNotBeNull();
+    [Fact] void should_reject_when_the_score_is_too_low() => _rejected.ShouldBeNull();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_resolving_and_handling.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_resolving_and_handling.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.for_a_command_with_a_provide_method;
+
+public class when_resolving_and_handling : given.a_loan_approval_command
+{
+    ICreditBureau _bureau;
+    IServiceProvider _serviceProvider;
+    ICommandHandler _handler;
+    CommandHandlerArgumentResolver _resolver;
+    object _result;
+
+    void Establish()
+    {
+        _bureau = Substitute.For<ICreditBureau>();
+        _bureau.GetScore("acme").Returns(800);
+        _serviceProvider = new ServiceCollection().AddSingleton(_bureau).BuildServiceProvider();
+        _resolver = new CommandHandlerArgumentResolver(new CommandProvideInvoker());
+        _handler = new ModelBoundCommandHandler(typeof(ApproveLoan), typeof(ApproveLoan).GetMethod(nameof(ApproveLoan.Handle))!);
+    }
+
+    async Task Because()
+    {
+        var context = new CommandContext(CorrelationId.New(), typeof(ApproveLoan), new ApproveLoan("acme"), [], new());
+        var resolution = await _resolver.Resolve(_handler, context, _serviceProvider, allowedSeverity: null);
+        context = context with { Dependencies = resolution.Arguments };
+        _result = await _handler.Handle(context);
+    }
+
+    [Fact] void should_fetch_the_score_through_provide() => _bureau.Received().GetScore("acme");
+    [Fact] void should_produce_the_event_from_handle() => _result.ShouldBeOfExactType<LoanApproved>();
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolution.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolution.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Represents the outcome of resolving the arguments for a command handler.
+/// </summary>
+/// <param name="Arguments">The resolved arguments to pass to the handler, in declaration order.</param>
+/// <param name="ControlResult">
+/// The <see cref="CommandResult"/> produced by any short-circuiting control values returned from the
+/// command's <c>Provide</c> method. Successful when nothing short-circuited.
+/// </param>
+public record CommandHandlerArgumentResolution(IReadOnlyList<object> Arguments, CommandResult ControlResult)
+{
+    /// <summary>
+    /// Gets a value indicating whether argument resolution short-circuited command execution.
+    /// </summary>
+    public bool IsShortCircuited => !ControlResult.IsSuccess;
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolver.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolver.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Validation;
+using Cratis.DependencyInjection;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Represents an implementation of <see cref="ICommandHandlerArgumentResolver"/>.
+/// </summary>
+/// <param name="provideInvoker">The <see cref="ICommandProvideInvoker"/> used to invoke the command's <c>Provide</c> method.</param>
+[Singleton]
+public class CommandHandlerArgumentResolver(ICommandProvideInvoker provideInvoker) : ICommandHandlerArgumentResolver
+{
+    /// <inheritdoc/>
+    public async ValueTask<CommandHandlerArgumentResolution> Resolve(
+        ICommandHandler handler,
+        CommandContext context,
+        IServiceProvider serviceProvider,
+        ValidationResultSeverity? allowedSeverity)
+    {
+        var provided = await provideInvoker.Invoke(context, serviceProvider);
+        var controlResult = CommandResult.Success(context.CorrelationId);
+        var candidates = new List<object>();
+
+        foreach (var value in provided)
+        {
+            if (IsControlSignal(value))
+            {
+                controlResult.MergeWith(ToCommandResult(value, context.CorrelationId));
+            }
+            else
+            {
+                candidates.Add(value);
+            }
+        }
+
+        if (CommandValidationResults.IsBlocking(controlResult, allowedSeverity))
+        {
+            return new CommandHandlerArgumentResolution([], controlResult);
+        }
+
+        // Non-blocking control values (for example warnings) are dropped here, just as the pipeline drops
+        // them when filtering by severity, so the resolution reports a clean success.
+        var arguments = BuildArguments(handler, candidates, serviceProvider);
+        return new CommandHandlerArgumentResolution(arguments, CommandResult.Success(context.CorrelationId));
+    }
+
+    static object[] BuildArguments(ICommandHandler handler, List<object> candidates, IServiceProvider serviceProvider)
+    {
+        var parameters = handler.Parameters.ToArray();
+        var arguments = new object[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameterType = parameters[i].ParameterType;
+            var match = candidates.Find(parameterType.IsInstanceOfType);
+            if (match is not null)
+            {
+                arguments[i] = match;
+                candidates.Remove(match);
+            }
+            else
+            {
+                arguments[i] = serviceProvider.GetRequiredService(parameterType);
+            }
+        }
+
+        return arguments;
+    }
+
+    static bool IsControlSignal(object value) =>
+        value is CommandResult or ValidationResult or IEnumerable<ValidationResult> or AuthorizationResult;
+
+    static CommandResult ToCommandResult(object value, CorrelationId correlationId) => value switch
+    {
+        CommandResult commandResult => commandResult,
+        ValidationResult validationResult => new() { CorrelationId = correlationId, ValidationResults = [validationResult] },
+        IEnumerable<ValidationResult> validationResults => new() { CorrelationId = correlationId, ValidationResults = [.. validationResults] },
+        AuthorizationResult { IsAuthorized: false } authorizationResult => CommandResult.Unauthorized(correlationId, authorizationResult.FailureReason),
+        _ => CommandResult.Success(correlationId)
+    };
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -20,6 +20,7 @@ namespace Cratis.Arc.Commands;
 /// <param name="valueHandlers">The <see cref="ICommandResponseValueHandlers"/> to use for handling response values.</param>
 /// <param name="contextModifier">The <see cref="ICommandContextModifier"/> to use for setting the current command context.</param>
 /// <param name="contextValuesBuilder">The <see cref="ICommandContextValuesBuilder"/> to use for building command context values.</param>
+/// <param name="argumentResolver">The <see cref="ICommandHandlerArgumentResolver"/> to use for resolving handler arguments.</param>
 /// <param name="scopeFactory">The <see cref="IServiceScopeFactory"/> used to create a dedicated service scope when no <see cref="IServiceProvider"/> is provided.</param>
 /// <param name="activitySource">The <see cref="IActivitySource{T}"/> for tracing.</param>
 [Singleton]
@@ -30,6 +31,7 @@ public class CommandPipeline(
     ICommandResponseValueHandlers valueHandlers,
     ICommandContextModifier contextModifier,
     ICommandContextValuesBuilder contextValuesBuilder,
+    ICommandHandlerArgumentResolver argumentResolver,
     IServiceScopeFactory scopeFactory,
     IActivitySource<CommandPipeline> activitySource) : ICommandPipeline
 {
@@ -68,12 +70,11 @@ public class CommandPipeline(
                 return CommandResult.MissingHandler(correlationId, command.GetType());
             }
 
-            var dependencies = commandHandler.Dependencies.Select(serviceProvider.GetRequiredService);
             var commandContext = new CommandContext(
                 correlationId,
                 command.GetType(),
                 command,
-                dependencies,
+                [],
                 contextValuesBuilder.Build(command),
                 allowedSeverity);
             contextModifier.SetCurrent(commandContext);
@@ -83,6 +84,16 @@ public class CommandPipeline(
             {
                 return result;
             }
+
+            var resolution = await argumentResolver.Resolve(commandHandler, commandContext, serviceProvider, allowedSeverity);
+            result.MergeWith(resolution.ControlResult);
+            result = FilterValidationResults(result, allowedSeverity);
+            if (!result.IsSuccess)
+            {
+                return result;
+            }
+
+            commandContext = commandContext with { Dependencies = resolution.Arguments };
 
             var response = await commandHandler.Handle(commandContext);
             if (response is not null)
@@ -139,17 +150,16 @@ public class CommandPipeline(
                 return CommandResult.MissingHandler(correlationId, command.GetType());
             }
 
-            var dependencies = commandHandler.Dependencies.Select(serviceProvider.GetRequiredService);
             var commandContext = new CommandContext(
                 correlationId,
                 command.GetType(),
                 command,
-                dependencies,
+                [],
                 contextValuesBuilder.Build(command),
                 allowedSeverity);
             contextModifier.SetCurrent(commandContext);
 
-            // Run only filters (authorization and validation), skip handler execution
+            // Run only filters (authorization and validation), skip handler execution and argument resolution
             result = await commandFilters.OnExecution(commandContext);
             result = FilterValidationResults(result, allowedSeverity);
         }
@@ -372,17 +382,7 @@ public class CommandPipeline(
     /// </remarks>
     CommandResult FilterValidationResults(CommandResult result, ValidationResultSeverity? allowedSeverity)
     {
-        if (allowedSeverity is null)
-        {
-            // Default behavior: only errors block execution (warnings and information are filtered out)
-            result.ValidationResults = result.ValidationResults.Where(v => v.Severity == ValidationResultSeverity.Error).ToArray();
-        }
-        else
-        {
-            // Filter out validation results with severity <= allowedSeverity
-            result.ValidationResults = result.ValidationResults.Where(v => v.Severity > allowedSeverity).ToArray();
-        }
-
+        result.ValidationResults = [.. CommandValidationResults.Blocking(result.ValidationResults, allowedSeverity)];
         return result;
     }
 

--- a/Source/DotNET/Arc.Core/Commands/CommandProvideInvoker.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandProvideInvoker.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.DependencyInjection;
+using Cratis.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using OneOf;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Represents an implementation of <see cref="ICommandProvideInvoker"/>.
+/// </summary>
+[Singleton]
+public class CommandProvideInvoker : ICommandProvideInvoker
+{
+    readonly ConcurrentDictionary<Type, MethodInfo?> _provideMethodsByCommandType = new();
+
+    /// <inheritdoc/>
+    public async ValueTask<IReadOnlyList<object>> Invoke(CommandContext context, IServiceProvider serviceProvider)
+    {
+        var provideMethod = _provideMethodsByCommandType.GetOrAdd(context.Type, type => type.GetProvideMethod());
+        if (provideMethod is null)
+        {
+            return [];
+        }
+
+        var arguments = ResolveArguments(provideMethod, serviceProvider);
+        var invocationResult = Invoke(provideMethod, context.Command, arguments);
+        var (_, value) = await AwaitableHelpers.AwaitIfNeeded(invocationResult);
+        return Flatten(value);
+    }
+
+    static object[]? ResolveArguments(MethodInfo provideMethod, IServiceProvider serviceProvider)
+    {
+        var parameters = provideMethod.GetParameters();
+        return parameters.Length == 0
+            ? null
+            : [.. parameters.Select(parameter => serviceProvider.GetRequiredService(parameter.ParameterType))];
+    }
+
+    static object? Invoke(MethodInfo provideMethod, object command, object[]? arguments)
+    {
+        try
+        {
+            return provideMethod.Invoke(command, arguments);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    static List<object> Flatten(object? value)
+    {
+        value = Unwrap(value);
+        if (value is null)
+        {
+            return [];
+        }
+
+        if (value is ITuple tuple)
+        {
+            var values = new List<object>(tuple.Length);
+            for (var i = 0; i < tuple.Length; i++)
+            {
+                if (Unwrap(tuple[i]) is { } element)
+                {
+                    values.Add(element);
+                }
+            }
+
+            return values;
+        }
+
+        return [value];
+    }
+
+    static object? Unwrap(object? value) => value switch
+    {
+        IOneOf oneOf => Unwrap(oneOf.Value),
+        _ => value
+    };
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandServiceCollectionExtensions.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ public static class CommandServiceCollectionExtensions
         services.AddSingleton<ICommandFilters, CommandFilters>();
         services.AddSingleton<ICommandHandlerProviders, CommandHandlerProviders>();
         services.AddSingleton<ICommandResponseValueHandlers, CommandResponseValueHandlers>();
+        services.AddSingleton<ICommandProvideInvoker, CommandProvideInvoker>();
+        services.AddSingleton<ICommandHandlerArgumentResolver, CommandHandlerArgumentResolver>();
         services.AddTransient(sp => sp.GetRequiredService<ICommandContextAccessor>().Current);
 
         return services;

--- a/Source/DotNET/Arc.Core/Commands/CommandValidationResults.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandValidationResults.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Helpers for deciding which validation results on a <see cref="CommandResult"/> block command execution
+/// relative to an allowed severity level.
+/// </summary>
+static class CommandValidationResults
+{
+    /// <summary>
+    /// Gets the validation results that block execution for the given allowed severity.
+    /// </summary>
+    /// <param name="results">The validation results to filter.</param>
+    /// <param name="allowedSeverity">The maximum allowed severity; results with higher severity block.</param>
+    /// <returns>The blocking validation results.</returns>
+    /// <remarks>
+    /// When <paramref name="allowedSeverity"/> is <see langword="null"/>, only errors block execution.
+    /// Otherwise, results with a severity higher than <paramref name="allowedSeverity"/> block execution.
+    /// </remarks>
+    public static IEnumerable<ValidationResult> Blocking(IEnumerable<ValidationResult> results, ValidationResultSeverity? allowedSeverity) =>
+        allowedSeverity is null
+            ? results.Where(_ => _.Severity == ValidationResultSeverity.Error)
+            : results.Where(_ => _.Severity > allowedSeverity);
+
+    /// <summary>
+    /// Determines whether the given <see cref="CommandResult"/> blocks execution for the allowed severity.
+    /// </summary>
+    /// <param name="result">The <see cref="CommandResult"/> to evaluate.</param>
+    /// <param name="allowedSeverity">The maximum allowed validation severity.</param>
+    /// <returns>True if the result should stop command execution; otherwise, false.</returns>
+    public static bool IsBlocking(CommandResult result, ValidationResultSeverity? allowedSeverity) =>
+        !result.IsAuthorized ||
+        result.HasExceptions ||
+        Blocking(result.ValidationResults, allowedSeverity).Any();
+}

--- a/Source/DotNET/Arc.Core/Commands/ICommandHandler.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandHandler.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
+
 namespace Cratis.Arc.Commands;
 
 /// <summary>
@@ -25,6 +27,11 @@ public interface ICommandHandler
     /// Gets the dependencies required by the handler.
     /// </summary>
     IEnumerable<Type> Dependencies { get; }
+
+    /// <summary>
+    /// Gets the parameters of the handler's handle method.
+    /// </summary>
+    IEnumerable<ParameterInfo> Parameters { get; }
 
     /// <summary>
     /// Gets a value indicating whether anonymous access is allowed for this command.

--- a/Source/DotNET/Arc.Core/Commands/ICommandHandlerArgumentResolver.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandHandlerArgumentResolver.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Defines a system that resolves the arguments for a command handler, including any values produced by the
+/// command's <c>Provide</c> method, and surfaces any short-circuiting result it produces.
+/// </summary>
+public interface ICommandHandlerArgumentResolver
+{
+    /// <summary>
+    /// Resolves the arguments for the given command handler.
+    /// </summary>
+    /// <param name="handler">The <see cref="ICommandHandler"/> to resolve arguments for.</param>
+    /// <param name="context">The <see cref="CommandContext"/> for the command being handled.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve arguments not produced by <c>Provide</c>.</param>
+    /// <param name="allowedSeverity">The maximum validation result severity to allow before short-circuiting.</param>
+    /// <returns>
+    /// A <see cref="CommandHandlerArgumentResolution"/> carrying the resolved arguments, or a short-circuiting
+    /// <see cref="CommandResult"/> when the command's <c>Provide</c> method produced a blocking control value.
+    /// </returns>
+    ValueTask<CommandHandlerArgumentResolution> Resolve(
+        ICommandHandler handler,
+        CommandContext context,
+        IServiceProvider serviceProvider,
+        ValidationResultSeverity? allowedSeverity);
+}

--- a/Source/DotNET/Arc.Core/Commands/ICommandProvideInvoker.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandProvideInvoker.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Defines a system that invokes the optional <c>Provide</c> method on a command and returns the values it produces.
+/// </summary>
+public interface ICommandProvideInvoker
+{
+    /// <summary>
+    /// Invokes the <c>Provide</c> method on the command in the given <see cref="CommandContext"/>, if it has one.
+    /// </summary>
+    /// <param name="context">The <see cref="CommandContext"/> for the command being handled.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve the <c>Provide</c> method's parameters.</param>
+    /// <returns>
+    /// The non-null values produced by the <c>Provide</c> method (a single value, or each element of a returned
+    /// tuple), or an empty collection when the command has no <c>Provide</c> method.
+    /// </returns>
+    ValueTask<IReadOnlyList<object>> Invoke(CommandContext context, IServiceProvider serviceProvider);
+}

--- a/Source/DotNET/Arc.Core/Commands/ModelBound/CommandProvideMethodExtensions.cs
+++ b/Source/DotNET/Arc.Core/Commands/ModelBound/CommandProvideMethodExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.Commands.ModelBound;
+
+/// <summary>
+/// Extension methods for working with the optional <c>Provide</c> method on a command.
+/// </summary>
+/// <remarks>
+/// The <c>Provide</c> method is an optional instance method on a command that runs before <c>Handle</c>.
+/// It fetches or computes the values that <c>Handle</c> needs and returns them so they can be passed in
+/// as arguments, keeping <c>Handle</c> a pure function of its arguments.
+/// </remarks>
+public static class CommandProvideMethodExtensions
+{
+    /// <summary>
+    /// The name of the optional provide method on a command.
+    /// </summary>
+    public const string ProvideMethodName = "Provide";
+
+    /// <summary>
+    /// Check if a type has a <c>Provide</c> method.
+    /// </summary>
+    /// <param name="type">Type to check.</param>
+    /// <returns>True if the type has a <c>Provide</c> method; otherwise, false.</returns>
+    public static bool HasProvideMethod(this Type type) =>
+        type.GetProvideMethod() is not null;
+
+    /// <summary>
+    /// Gets the <c>Provide</c> method from a type, if any.
+    /// </summary>
+    /// <param name="type">Type to get the <c>Provide</c> method from.</param>
+    /// <returns>The <c>Provide</c> method, or <see langword="null"/> if the type does not declare one.</returns>
+    public static MethodInfo? GetProvideMethod(this Type type) =>
+        type.GetMethod(ProvideMethodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+}

--- a/Source/DotNET/Arc.Core/Commands/ModelBound/ModelBoundCommandHandler.cs
+++ b/Source/DotNET/Arc.Core/Commands/ModelBound/ModelBoundCommandHandler.cs
@@ -25,15 +25,17 @@ public class ModelBoundCommandHandler(Type commandType, MethodInfo handleMethod)
     public IEnumerable<Type> Dependencies { get; } = handleMethod.GetParameters().Select(p => p.ParameterType);
 
     /// <inheritdoc/>
+    public IEnumerable<ParameterInfo> Parameters { get; } = handleMethod.GetParameters();
+
+    /// <inheritdoc/>
     public bool AllowsAnonymousAccess { get; } = commandType.IsAnonymousAllowed();
 
     /// <inheritdoc/>
     public async ValueTask<object?> Handle(CommandContext commandContext)
     {
-        var parameters = handleMethod.GetParameters();
-        var args = parameters.Length == 0
+        var args = handleMethod.GetParameters().Length == 0
             ? null
-            : commandContext.Dependencies.Take(parameters.Length).ToArray();
+            : commandContext.Dependencies.ToArray();
         try
         {
             var invocationResult = handleMethod.Invoke(commandContext.Command, args);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/given/a_command_pipeline_with_event_handlers.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandPipeline_with_events/given/a_command_pipeline_with_event_handlers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Commands;
+using Cratis.Arc.Validation;
 using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences;
@@ -20,6 +21,7 @@ public class a_command_pipeline_with_event_handlers : Specification
     protected ICommandResponseValueHandlers _commandResponseValueHandlers;
     protected ICommandContextModifier _commandContextModifier;
     protected ICommandContextValuesBuilder _commandContextValuesBuilder;
+    protected ICommandHandlerArgumentResolver _commandHandlerArgumentResolver;
     protected IServiceProvider _serviceProvider;
     protected IServiceScopeFactory _serviceScopeFactory;
     protected IEventLog _eventLog;
@@ -43,6 +45,10 @@ public class a_command_pipeline_with_event_handlers : Specification
         _commandHandlerProviders = Substitute.For<ICommandHandlerProviders>();
         _commandContextModifier = Substitute.For<ICommandContextModifier>();
         _commandContextValuesBuilder = Substitute.For<ICommandContextValuesBuilder>();
+        _commandHandlerArgumentResolver = Substitute.For<ICommandHandlerArgumentResolver>();
+        _commandHandlerArgumentResolver
+            .Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>())
+            .Returns(_ => new ValueTask<CommandHandlerArgumentResolution>(new CommandHandlerArgumentResolution([], CommandResult.Success(_correlationId))));
         _serviceProvider = Substitute.For<IServiceProvider>();
 
         var serviceScope = Substitute.For<IServiceScope>();
@@ -144,6 +150,7 @@ public class a_command_pipeline_with_event_handlers : Specification
             _commandResponseValueHandlers,
             _commandContextModifier,
             _commandContextValuesBuilder,
+            _commandHandlerArgumentResolver,
             _serviceScopeFactory,
             CreateActivitySource<CommandPipeline>());
     }


### PR DESCRIPTION
# Summary

Commands can now declare a `Provide()` method that runs before `Handle()`.  It fetches or computes the data the decision needs and passes it into `Handle()` as arguments, so `Handle()` stays a pure, easily tested function of its inputs. It can also short-circuit the command before `Handle()` runs.

## Added

- Commands can define a `Provide()` method that supplies `Handle()`'s arguments — fetched or computed, with its own parameters resolved from dependency injection — without registering those values in the container. Single, tuple, `Result<,>`, and async (`Task`/`ValueTask`) return shapes are all supported.
- New analyzer rule **ARC0005** warns when a value produced by `Provide()` is not consumed by any `Handle()` parameter.