### PR TITLE
Support read models as dependencies in command validators

### DIFF
--- a/Documentation/backend/chronicle/read-models.md
+++ b/Documentation/backend/chronicle/read-models.md
@@ -7,7 +7,7 @@ Read Models in Arc provide automatic dependency injection and seamless integrati
 
 ## Overview
 
-Arc automatically registers all read model types and provides them as transient services in the dependency injection container. When a read model is requested, it uses the resolved identity from the current command context to load the appropriate projection instance.
+Arc automatically registers all read model types and provides them as scoped services in the dependency injection container, tied to the scope the command runs in. When a read model is requested, it uses the resolved identity from the current command context to load the appropriate projection instance. Because the handler and the `CommandValidator<>` resolve from the same command scope, both receive the same read model instance for the command.
 
 ## Automatic Registration
 
@@ -193,6 +193,9 @@ Key points when using read models in validators:
 - **Rich Rules**: Access to full read model state enables complex business rule validation
 - **Async Validation**: Use `MustAsync` for asynchronous validation rules that need to check external systems
 
+> [!NOTE]
+> Read-model injection into validators works when commands run through the Arc command pipeline — minimal-API command endpoints (the default) and `ICommandPipeline` directly. It does **not** work when commands are exposed through MVC controllers, because MVC model validation runs during model binding, before the command context (and therefore the event source id) exists. In that case Arc raises an explicit `ReadModelValidatorRequiresCommandPipeline` error. Expose the command through a minimal-API endpoint, or move the read-model based check into the command's `Handle()` method.
+
 For more details on command validation, see the [Validation](../commands/validation.md) documentation.
 
 ## Error Handling
@@ -213,11 +216,11 @@ public record InvalidCommand(string SomeProperty);
 
 ## Lifecycle Management
 
-### Transient Scope
+### Command Scope
 
-Read models are registered as transient services, meaning:
+Read models are registered as scoped services, meaning:
 
-- The current projected state is fetched for each request
+- The current projected state is fetched once per command and shared across the command's validator and handler
 - The instance is tied to the specific identity/key resolved from the command context
 - Read models are read-only snapshots of the current projection state
 - The read model is automatically disposed after the command completes

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_filter_resolving_validators_from_a_real_container.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_filter_resolving_validators_from_a_real_container.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Arc.Validation.for_DiscoverableValidators;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.given;
+
+/// <summary>
+/// Reproduces the runtime/HTTP condition: a container with scope validation enabled (as ASP.NET Core enables in
+/// development) where a validator depends on a scoped collaborator — the stand-in for a read model resolved for the
+/// command's event source id. The command runs in a child scope, exactly as the HTTP endpoint runs it through
+/// <c>RequestServices</c>.
+/// </summary>
+public class a_filter_resolving_validators_from_a_real_container : Specification
+{
+    protected FluentValidationFilter _filter;
+    protected ServiceProvider _root;
+    protected CorrelationId _correlationId;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance));
+        _root = new ServiceCollection()
+            .AddScoped(_ => new CommandDependency { IsAllowed = false })
+            .AddTransient<CommandWithDependencyValidator>()
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    void Destroy() => _root.Dispose();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_a_scoped_validator_dependency_in_the_command_scope.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_a_scoped_validator_dependency_in_the_command_scope.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation.for_DiscoverableValidators;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+/// <summary>
+/// The regression spec for read-model injection into validators. Without resolving the validator from the command
+/// scope, the scoped dependency would throw under scope validation (the old behavior, where validators resolved from
+/// the root provider). With the fix it resolves cleanly and the validator runs against it.
+/// </summary>
+public class with_a_scoped_validator_dependency_in_the_command_scope : given.a_filter_resolving_validators_from_a_real_container
+{
+    CommandResult _result;
+    Exception _exception;
+
+    async Task Because()
+    {
+        await using var commandScope = _root.CreateAsyncScope();
+        var context = new CommandContext(
+            _correlationId,
+            typeof(CommandWithDependency),
+            new CommandWithDependency(Guid.NewGuid()),
+            [],
+            new(),
+            ServiceProvider: commandScope.ServiceProvider);
+
+        _exception = await Catch.Exception(async () => _result = await _filter.OnExecution(context));
+    }
+
+    [Fact] void should_resolve_the_scoped_dependency_without_throwing() => _exception.ShouldBeNull();
+    [Fact] void should_run_the_validator_against_the_scoped_dependency() => _result.ValidationResults.First().Message.ShouldEqual("The dependency does not allow this command.");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_a_scoped_validator_dependency_resolved_from_the_root_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_a_scoped_validator_dependency_resolved_from_the_root_provider.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation.for_DiscoverableValidators;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+/// <summary>
+/// Documents the old, broken behavior: resolving the validator from the root provider (as happened before the fix,
+/// via <c>Internals.ServiceProvider</c>) cannot resolve a scoped dependency under scope validation, so a read model
+/// could never be injected into a validator. The fix is to resolve from the command scope instead.
+/// </summary>
+public class with_a_scoped_validator_dependency_resolved_from_the_root_provider : given.a_filter_resolving_validators_from_a_real_container
+{
+    Exception _exception;
+
+    async Task Because()
+    {
+        var context = new CommandContext(
+            _correlationId,
+            typeof(CommandWithDependency),
+            new CommandWithDependency(Guid.NewGuid()),
+            [],
+            new(),
+            ServiceProvider: _root);
+
+        _exception = await Catch.Exception(async () => await _filter.OnExecution(context));
+    }
+
+    [Fact] void should_fail_because_a_scoped_dependency_cannot_be_resolved_from_the_root_provider() => _exception.ShouldNotBeNull();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_scoped_service_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_scoped_service_provider.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using FluentValidationResult = FluentValidation.Results.ValidationResult;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_command_scoped_service_provider : given.a_fluent_validation_filter
+{
+    IServiceProvider _commandScopedProvider;
+    IValidator _validator;
+    TestCommand _command;
+
+    void Establish()
+    {
+        _command = new TestCommand("Name");
+        _commandScopedProvider = new ServiceCollection().BuildServiceProvider();
+        _context = new CommandContext(_correlationId, typeof(TestCommand), _command, [], new(), ServiceProvider: _commandScopedProvider);
+
+        _validator = Substitute.For<IValidator>();
+        _validator.ValidateAsync(Arg.Any<IValidationContext>(), Arg.Any<CancellationToken>()).Returns(new FluentValidationResult());
+
+        _discoverableValidators.TryGet(typeof(TestCommand), _commandScopedProvider, out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[2] = _validator;
+                return true;
+            });
+    }
+
+    async Task Because() => await _filter.OnExecution(_context);
+
+    [Fact] void should_resolve_the_validator_from_the_command_scoped_provider() =>
+        _discoverableValidators.Received(1).TryGet(typeof(TestCommand), _commandScopedProvider, out Arg.Any<IValidator>());
+    [Fact] void should_not_fall_back_to_the_ambient_service_provider() =>
+        _discoverableValidators.DidNotReceive().TryGet(typeof(TestCommand), out Arg.Any<IValidator>());
+
+    record TestCommand(string Name);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_an_explicit_service_provider_is_supplied.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_an_explicit_service_provider_is_supplied.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+/// <summary>
+/// The HTTP endpoint and any direct caller of <see cref="ICommandPipeline"/> invoke
+/// <c>Execute(command, serviceProvider)</c> with a request/command-scoped provider. This proves that provider
+/// is carried on the <see cref="CommandContext"/> so validators resolve from the same scope as the handler.
+/// </summary>
+public class and_an_explicit_service_provider_is_supplied : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandContext _capturedContext = null!;
+    IServiceProvider _explicitServiceProvider = null!;
+
+    void Establish()
+    {
+        _explicitServiceProvider = Substitute.For<IServiceProvider>();
+        _commandFilters.OnExecution(Arg.Do<CommandContext>(context => _capturedContext = context))
+            .Returns(CommandResult.Success(_correlationId));
+    }
+
+    async Task Because() => await _commandPipeline.Execute(_command, _explicitServiceProvider);
+
+    [Fact] void should_carry_the_explicit_service_provider_on_the_context() => _capturedContext.ServiceProvider.ShouldEqual(_explicitServiceProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_context_carries_the_created_scope.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_command_context_carries_the_created_scope.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+public class and_command_context_carries_the_created_scope : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandContext _capturedContext = null!;
+
+    void Establish() =>
+        _commandFilters.OnExecution(Arg.Do<CommandContext>(context => _capturedContext = context))
+            .Returns(CommandResult.Success(_correlationId));
+
+    async Task Because() => await _commandPipeline.Execute(_command);
+
+    [Fact] void should_carry_the_service_provider_from_the_created_scope() => _capturedContext.ServiceProvider.ShouldEqual(_serviceProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_context_carries_the_service_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_validating/and_command_context_carries_the_service_provider.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_validating;
+
+/// <summary>
+/// The dry-run validation endpoint (the <c>/validate</c> path) runs the same filters as execution, so it must also
+/// carry the command-scoped service provider — otherwise a read-model-injecting validator would fail during a
+/// validation-only request while succeeding during execution.
+/// </summary>
+public class and_command_context_carries_the_service_provider : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandContext _capturedContext = null!;
+
+    void Establish() =>
+        _commandFilters.OnExecution(Arg.Do<CommandContext>(context => _capturedContext = context))
+            .Returns(CommandResult.Success(_correlationId));
+
+    async Task Because() => await _commandPipeline.Validate(_command, _serviceProvider);
+
+    [Fact] void should_carry_the_service_provider_on_the_context() => _capturedContext.ServiceProvider.ShouldEqual(_serviceProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/CommandWithDependency.cs
+++ b/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/CommandWithDependency.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using FluentValidation;
+
+namespace Cratis.Arc.Validation.for_DiscoverableValidators;
+
+#pragma warning disable SA1649, SA1402
+
+/// <summary>
+/// A command whose validator depends on an injected, provider-resolved collaborator. This stands in for a
+/// Chronicle read model that is resolved for the command's event source id — the value differs per service
+/// provider/scope, which is exactly what the validator resolution must honor.
+/// </summary>
+/// <param name="Id">The identifier of the command.</param>
+public record CommandWithDependency(Guid Id);
+
+/// <summary>
+/// A collaborator for <see cref="CommandWithDependencyValidator"/> whose value is determined by the service
+/// provider it is resolved from — mimicking a command-scoped read model.
+/// </summary>
+public class CommandDependency
+{
+    /// <summary>
+    /// Gets a value indicating whether the dependency allows the command to validate.
+    /// </summary>
+    public bool IsAllowed { get; init; }
+}
+
+/// <summary>
+/// Validator for <see cref="CommandWithDependency"/> that only passes when its injected
+/// <see cref="CommandDependency"/> allows it.
+/// </summary>
+public class CommandWithDependencyValidator : CommandValidator<CommandWithDependency>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandWithDependencyValidator"/> class.
+    /// </summary>
+    /// <param name="dependency">The provider-resolved <see cref="CommandDependency"/>.</param>
+    public CommandWithDependencyValidator(CommandDependency dependency) =>
+        RuleFor(command => command.Id)
+            .Must(_ => dependency.IsAllowed)
+            .WithMessage("The dependency does not allow this command.");
+}
+
+#pragma warning restore SA1649, SA1402

--- a/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/from_the_supplied_service_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/from_the_supplied_service_provider.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using FluentValidationResult = FluentValidation.Results.ValidationResult;
+
+namespace Cratis.Arc.Validation.for_DiscoverableValidators.when_resolving_a_validator;
+
+public class from_the_supplied_service_provider : Specification
+{
+    DiscoverableValidators _validators;
+    IValidator _validatorFromAllowingProvider = null!;
+    IValidator _validatorFromRejectingProvider = null!;
+    FluentValidationResult _allowingResult = null!;
+    FluentValidationResult _rejectingResult = null!;
+
+    void Establish()
+    {
+        _validators = new DiscoverableValidators(Cratis.Types.Types.Instance);
+
+        var allowingProvider = new ServiceCollection()
+            .AddSingleton(new CommandDependency { IsAllowed = true })
+            .AddTransient<CommandWithDependencyValidator>()
+            .BuildServiceProvider();
+
+        var rejectingProvider = new ServiceCollection()
+            .AddSingleton(new CommandDependency { IsAllowed = false })
+            .AddTransient<CommandWithDependencyValidator>()
+            .BuildServiceProvider();
+
+        _validators.TryGet(typeof(CommandWithDependency), allowingProvider, out _validatorFromAllowingProvider!);
+        _validators.TryGet(typeof(CommandWithDependency), rejectingProvider, out _validatorFromRejectingProvider!);
+    }
+
+    void Because()
+    {
+        var command = new CommandWithDependency(Guid.NewGuid());
+        _allowingResult = _validatorFromAllowingProvider.Validate(new ValidationContext<CommandWithDependency>(command));
+        _rejectingResult = _validatorFromRejectingProvider.Validate(new ValidationContext<CommandWithDependency>(command));
+    }
+
+    [Fact] void should_resolve_a_validator_whose_dependency_came_from_the_allowing_provider() => _allowingResult.IsValid.ShouldBeTrue();
+    [Fact] void should_resolve_a_validator_whose_dependency_came_from_the_rejecting_provider() => _rejectingResult.IsValid.ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/with_a_scoped_dependency.cs
+++ b/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/with_a_scoped_dependency.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Validation.for_DiscoverableValidators.when_resolving_a_validator;
+
+/// <summary>
+/// Proves the reason read models (registered as scoped, keyed off the command's event source id) could not be
+/// injected into a validator when the validator was resolved from the root provider: a scoped dependency cannot be
+/// resolved from the root provider, but it resolves cleanly from the command scope.
+/// </summary>
+public class with_a_scoped_dependency : Specification
+{
+    DiscoverableValidators _validators;
+    ServiceProvider _root = null!;
+    bool _resolvedFromCommandScope;
+    Exception _exceptionResolvingFromRoot = null!;
+
+    void Establish()
+    {
+        _validators = new DiscoverableValidators(Cratis.Types.Types.Instance);
+        _root = new ServiceCollection()
+            .AddScoped(_ => new CommandDependency { IsAllowed = true })
+            .AddTransient<CommandWithDependencyValidator>()
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    void Because()
+    {
+        using var commandScope = _root.CreateScope();
+        _resolvedFromCommandScope = _validators.TryGet(typeof(CommandWithDependency), commandScope.ServiceProvider, out _);
+        _exceptionResolvingFromRoot = Catch.Exception(() => _validators.TryGet(typeof(CommandWithDependency), _root, out _));
+    }
+
+    void Destroy() => _root.Dispose();
+
+    [Fact] void should_resolve_the_validator_from_the_command_scope() => _resolvedFromCommandScope.ShouldBeTrue();
+    [Fact] void should_fail_to_resolve_the_scoped_dependency_from_the_root_provider() => _exceptionResolvingFromRoot.ShouldNotBeNull();
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandContext.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandContext.cs
@@ -16,6 +16,7 @@ namespace Cratis.Arc.Commands;
 /// <param name="Values">A set of values associated with the command context.</param>
 /// <param name="AllowedSeverity">The maximum validation result severity level to allow. Validation results with severity higher than this will cause the command to fail.</param>
 /// <param name="Response">The optional response from handling the command, if any.</param>
+/// <param name="ServiceProvider">The <see cref="IServiceProvider"/> scoped to the command, used to resolve scoped collaborators such as validators and read models during the command's lifetime.</param>
 public record CommandContext(
     CorrelationId CorrelationId,
     Type Type,
@@ -23,4 +24,5 @@ public record CommandContext(
     IEnumerable<object> Dependencies,
     CommandContextValues Values,
     ValidationResultSeverity? AllowedSeverity = default,
-    object? Response = default);
+    object? Response = default,
+    IServiceProvider? ServiceProvider = default);

--- a/Source/DotNET/Arc.Core/Commands/CommandContextManager.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandContextManager.cs
@@ -11,7 +11,7 @@ public class CommandContextManager : ICommandContextModifier, ICommandContextAcc
     static readonly AsyncLocal<CommandContext?> _current = new();
 
     /// <inheritdoc/>
-    public CommandContext Current => _current.Value ?? throw new InvalidOperationException("No command context is available in the current scope.");
+    public CommandContext Current => _current.Value ?? throw new NoCommandContextAvailable();
 
     /// <inheritdoc/>
     public void SetCurrent(CommandContext context) => _current.Value = context;

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -75,7 +75,8 @@ public class CommandPipeline(
                 command,
                 dependencies,
                 contextValuesBuilder.Build(command),
-                allowedSeverity);
+                allowedSeverity,
+                ServiceProvider: serviceProvider);
             contextModifier.SetCurrent(commandContext);
             result = await commandFilters.OnExecution(commandContext);
             result = FilterValidationResults(result, allowedSeverity);
@@ -146,7 +147,8 @@ public class CommandPipeline(
                 command,
                 dependencies,
                 contextValuesBuilder.Build(command),
-                allowedSeverity);
+                allowedSeverity,
+                ServiceProvider: serviceProvider);
             contextModifier.SetCurrent(commandContext);
 
             // Run only filters (authorization and validation), skip handler execution

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Cratis.Arc.Validation;
 using FluentValidation;
@@ -26,7 +27,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
         var commandResult = CommandResult.Success(context.CorrelationId);
 
         var instanceType = instance.GetType();
-        if (discoverableValidators.TryGet(instanceType, out var validator))
+        if (TryGetValidator(context, instanceType, out var validator))
         {
             var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
             var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
@@ -80,4 +81,18 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
 
         return commandResult;
     }
+
+    /// <summary>
+    /// Resolves a validator for the given model type, preferring the command-scoped <see cref="IServiceProvider"/>
+    /// from the <see cref="CommandContext"/> so the validator and its dependencies resolve from the same scope as
+    /// the command's <c>Handle()</c> method.
+    /// </summary>
+    /// <param name="context">The <see cref="CommandContext"/> the validation runs within.</param>
+    /// <param name="modelType">The type to resolve a validator for.</param>
+    /// <param name="validator">The resolved <see cref="IValidator"/> when found.</param>
+    /// <returns>True if a validator was found; otherwise false.</returns>
+    bool TryGetValidator(CommandContext context, Type modelType, [MaybeNullWhen(false)] out IValidator validator) =>
+        context.ServiceProvider is { } serviceProvider
+            ? discoverableValidators.TryGet(modelType, serviceProvider, out validator)
+            : discoverableValidators.TryGet(modelType, out validator);
 }

--- a/Source/DotNET/Arc.Core/Commands/NoCommandContextAvailable.cs
+++ b/Source/DotNET/Arc.Core/Commands/NoCommandContextAvailable.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// The exception that is thrown when the current <see cref="CommandContext"/> is requested but none is available in the current scope.
+/// </summary>
+public class NoCommandContextAvailable()
+    : Exception("No command context is available in the current scope. This typically happens when a command-scoped service, such as a read model, is resolved outside of an executing command.");

--- a/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
+++ b/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
@@ -67,11 +67,15 @@ public class DiscoverableValidators : IDiscoverableValidators
     internal IEnumerable<Type> ValidatorTypes => _validatorTypesByModelType.Values;
 
     /// <inheritdoc/>
-    public bool TryGet(Type modelType, [MaybeNullWhen(false)] out IValidator validator)
+    public bool TryGet(Type modelType, [MaybeNullWhen(false)] out IValidator validator) =>
+        TryGet(modelType, _serviceProviderAccessor(), out validator);
+
+    /// <inheritdoc/>
+    public bool TryGet(Type modelType, IServiceProvider serviceProvider, [MaybeNullWhen(false)] out IValidator validator)
     {
         if (_validatorTypesByModelType.TryGetValue(modelType, out var value))
         {
-            validator = (_serviceProviderAccessor().GetRequiredService(value) as IValidator)!;
+            validator = (serviceProvider.GetRequiredService(value) as IValidator)!;
             return true;
         }
 

--- a/Source/DotNET/Arc.Core/Validation/IDiscoverableValidators.cs
+++ b/Source/DotNET/Arc.Core/Validation/IDiscoverableValidators.cs
@@ -18,4 +18,17 @@ public interface IDiscoverableValidators
     /// <param name="validator">The <see cref="IValidator"/> if found.</param>
     /// <returns>True if a validator was found, false otherwise.</returns>
     bool TryGet(Type modelType, [MaybeNullWhen(false)] out IValidator validator);
+
+    /// <summary>
+    /// Try to get a validator for the given model type, resolving it from the supplied <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="modelType">Type of model to get a validator for.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to resolve the validator and its dependencies from.</param>
+    /// <param name="validator">The <see cref="IValidator"/> if found.</param>
+    /// <returns>True if a validator was found, false otherwise.</returns>
+    /// <remarks>
+    /// Resolving from a command-scoped provider lets a validator take scoped dependencies — such as read models
+    /// resolved for the command's event source id — exactly like a command's <c>Handle()</c> method.
+    /// </remarks>
+    bool TryGet(Type modelType, IServiceProvider serviceProvider, [MaybeNullWhen(false)] out IValidator validator);
 }

--- a/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/given/a_discoverable_model_validator_provider.cs
+++ b/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/given/a_discoverable_model_validator_provider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+
+namespace Cratis.Arc.Validation.for_DiscoverableModelValidatorProvider.given;
+
+public class a_discoverable_model_validator_provider : Specification
+{
+    protected IDiscoverableValidators _discoverableValidators;
+    protected DiscoverableModelValidatorProvider _provider;
+    protected ModelValidatorProviderContext _context;
+
+    void Establish()
+    {
+        _discoverableValidators = Substitute.For<IDiscoverableValidators>();
+        _provider = new DiscoverableModelValidatorProvider(_discoverableValidators);
+
+        var modelMetadataProvider = new EmptyModelMetadataProvider();
+        var modelMetadata = modelMetadataProvider.GetMetadataForType(typeof(TestCommand));
+        _context = new ModelValidatorProviderContext(modelMetadata, []);
+    }
+
+    public class TestCommand
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_a_validator_is_found.cs
+++ b/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_a_validator_is_found.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Validation.for_DiscoverableModelValidatorProvider.when_creating_validators;
+
+public class and_a_validator_is_found : given.a_discoverable_model_validator_provider
+{
+    IValidator _validator;
+
+    void Establish()
+    {
+        _validator = Substitute.For<IValidator>();
+        _discoverableValidators
+            .TryGet(typeof(TestCommand), out Arg.Any<IValidator>())
+            .Returns(call =>
+            {
+                call[1] = _validator;
+                return true;
+            });
+    }
+
+    void Because() => _provider.CreateValidators(_context);
+
+    [Fact] void should_add_a_validator_item() => _context.Results.Count.ShouldEqual(1);
+    [Fact] void should_wrap_the_discovered_validator() => _context.Results[0].Validator.ShouldBeOfExactType<DiscoverableModelValidator>();
+}

--- a/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_validator_requires_a_command_context.cs
+++ b/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_validator_requires_a_command_context.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using FluentValidation;
+
+namespace Cratis.Arc.Validation.for_DiscoverableModelValidatorProvider.when_creating_validators;
+
+/// <summary>
+/// A validator that depends on a command-scoped read model cannot be constructed during MVC model validation, because
+/// model binding runs before the command context exists. The provider must surface an actionable error rather than
+/// the opaque dependency-resolution failure.
+/// </summary>
+public class and_validator_requires_a_command_context : given.a_discoverable_model_validator_provider
+{
+    Exception _exception;
+
+    void Establish() =>
+        _discoverableValidators
+            .TryGet(typeof(TestCommand), out Arg.Any<IValidator>())
+            .Returns(_ => throw new NoCommandContextAvailable());
+
+    void Because() => _exception = Catch.Exception(() => _provider.CreateValidators(_context));
+
+    [Fact] void should_throw_read_model_validator_requires_command_pipeline() => _exception.ShouldBeOfExactType<ReadModelValidatorRequiresCommandPipeline>();
+    [Fact] void should_preserve_the_underlying_cause() => _exception.InnerException.ShouldBeOfExactType<NoCommandContextAvailable>();
+}

--- a/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_validator_resolution_fails_for_an_unrelated_reason.cs
+++ b/Source/DotNET/Arc.Specs/Validation/for_DiscoverableModelValidatorProvider/when_creating_validators/and_validator_resolution_fails_for_an_unrelated_reason.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Validation.for_DiscoverableModelValidatorProvider.when_creating_validators;
+
+/// <summary>
+/// Only the missing-command-context failure is translated into the actionable error. Any other failure must surface
+/// unchanged so genuine misconfigurations are not masked as a read-model problem.
+/// </summary>
+public class and_validator_resolution_fails_for_an_unrelated_reason : given.a_discoverable_model_validator_provider
+{
+    Exception _exception;
+    UnrelatedFailure _thrown;
+
+    void Establish()
+    {
+        _thrown = new UnrelatedFailure();
+        _discoverableValidators
+            .TryGet(typeof(TestCommand), out Arg.Any<IValidator>())
+            .Returns(_ => throw _thrown);
+    }
+
+    void Because() => _exception = Catch.Exception(() => _provider.CreateValidators(_context));
+
+    [Fact] void should_propagate_the_original_exception() => _exception.ShouldEqual(_thrown);
+
+    public class UnrelatedFailure() : Exception("Something unrelated went wrong.");
+}

--- a/Source/DotNET/Arc/Validation/DiscoverableModelValidatorProvider.cs
+++ b/Source/DotNET/Arc/Validation/DiscoverableModelValidatorProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Commands;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 namespace Cratis.Arc.Validation;
@@ -14,14 +15,24 @@ public class DiscoverableModelValidatorProvider(IDiscoverableValidators discover
     /// <inheritdoc/>
     public void CreateValidators(ModelValidatorProviderContext context)
     {
-        if (discoverableValidators.TryGet(context.ModelMetadata.ModelType, out var validator))
+        try
         {
-            var modelValidator = new DiscoverableModelValidator(validator);
-            context.Results.Add(new ValidatorItem
+            if (discoverableValidators.TryGet(context.ModelMetadata.ModelType, out var validator))
             {
-                IsReusable = false,
-                Validator = modelValidator
-            });
+                var modelValidator = new DiscoverableModelValidator(validator);
+                context.Results.Add(new ValidatorItem
+                {
+                    IsReusable = false,
+                    Validator = modelValidator
+                });
+            }
+        }
+        catch (NoCommandContextAvailable exception)
+        {
+            // MVC model validation runs during model binding, before the command context is established, so a
+            // validator that depends on a command-scoped read model cannot be constructed here. Surface an
+            // actionable error instead of the opaque dependency-resolution failure.
+            throw new ReadModelValidatorRequiresCommandPipeline(context.ModelMetadata.ModelType, exception);
         }
     }
 }

--- a/Source/DotNET/Arc/Validation/ReadModelValidatorRequiresCommandPipeline.cs
+++ b/Source/DotNET/Arc/Validation/ReadModelValidatorRequiresCommandPipeline.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Validation;
+
+/// <summary>
+/// The exception that is thrown when a validator that depends on a command-scoped read model is used through the MVC
+/// controller model-validation path, which runs before a command context is established.
+/// </summary>
+/// <param name="modelType">The command/model type whose validator could not be constructed.</param>
+/// <param name="innerException">The underlying exception that occurred while constructing the validator.</param>
+public class ReadModelValidatorRequiresCommandPipeline(Type modelType, Exception innerException)
+    : Exception(
+        $"The validator for '{modelType.FullName}' could not be constructed during MVC model validation. " +
+        "Validators that take a read model as a dependency require the Arc command pipeline (minimal-API command endpoints or ICommandPipeline directly), " +
+        "because the read model is resolved for the command's event source id from the command scope, which does not exist during MVC model binding. " +
+        "Expose the command through a minimal-API endpoint, or move the read-model based check into the command's Handle() method.",
+        innerException);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/WithdrawFunds.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/WithdrawFunds.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using FluentValidation;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario;
+
+[Command]
+public record WithdrawFunds(EventSourceId EventSourceId)
+{
+    public FundsWithdrawn Handle() => new();
+}
+
+public class WithdrawFundsValidator : CommandValidator<WithdrawFunds>
+{
+    public WithdrawFundsValidator(AccountBalanceReadModel account) =>
+        RuleFor(command => command.EventSourceId)
+            .Must(_ => account.Balance > 0)
+            .WithMessage("Account has insufficient funds.");
+}
+
+[EventType("b2e6f3a1-4c7d-4e2a-9f10-2a3b4c5d6e7f")]
+public record FundsWithdrawn;

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_takes_read_model_dependency/and_balance_is_insufficient.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_takes_read_model_dependency/and_balance_is_insufficient.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_takes_read_model_dependency;
+
+public class and_balance_is_insufficient : Specification
+{
+    CommandScenario<WithdrawFunds> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFunds>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(AccountBalanceReadModel), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new AccountBalanceReadModel(0m)));
+
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.Replace(
+            _scenario.Services,
+            new Microsoft.Extensions.DependencyInjection.ServiceDescriptor(typeof(IReadModels), readModels));
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.Replace(
+            _scenario.Services,
+            new Microsoft.Extensions.DependencyInjection.ServiceDescriptor(typeof(AccountBalanceReadModel), _ => new AccountBalanceReadModel(0m), Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFunds(_eventSourceId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_validation_errors() => _result.ValidationResults.ShouldNotBeEmpty();
+    [Fact] void should_have_validation_error_from_validator() => _result.ValidationResults.First().Message.ShouldEqual("Account has insufficient funds.");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_takes_read_model_dependency/and_balance_is_sufficient.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_validator_takes_read_model_dependency/and_balance_is_sufficient.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_validator_takes_read_model_dependency;
+
+public class and_balance_is_sufficient : Specification
+{
+    CommandScenario<WithdrawFunds> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFunds>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(AccountBalanceReadModel), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new AccountBalanceReadModel(100m)));
+
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.Replace(
+            _scenario.Services,
+            new Microsoft.Extensions.DependencyInjection.ServiceDescriptor(typeof(IReadModels), readModels));
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.Replace(
+            _scenario.Services,
+            new Microsoft.Extensions.DependencyInjection.ServiceDescriptor(typeof(AccountBalanceReadModel), _ => new AccountBalanceReadModel(100m), Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFunds(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+}


### PR DESCRIPTION
## Fixed

- A `CommandValidator<>` can now take a read model as a constructor dependency, resolved for the command's event source id — the same way a command's `Handle()` method receives it. Validators are now resolved from the command scope, so this no longer fails as it did when they were resolved from the root provider (throwing under scope validation or returning a stale instance).
- Using a read-model validator on the MVC controller path now raises a clear `ReadModelValidatorRequiresCommandPipeline` error pointing to the command pipeline, instead of an opaque dependency-resolution failure.