### PR TITLE
Resolve command validators from the command scope without requiring registration

### DIFF
--- a/Documentation/backend/chronicle/commands/index.md
+++ b/Documentation/backend/chronicle/commands/index.md
@@ -24,7 +24,7 @@ Chronicle inspects the value `Handle()` returns and appends accordingly. Anythin
 | Tuple `(event, result)` | The event is appended; the other element is returned to the caller as the response. |
 | Tuple `(EventSourceId, event)` | The `EventSourceId` sets the stream; the event is appended. See [Returning EventSourceId](./returning-event-source-id.md). |
 | Tuple `(event, Subject)` | The event is appended; the `Subject` is attached as [compliance metadata](./subject.md), not returned. |
-| `Result<TResult, TError>` (e.g. `Result<ValidationResult, T>`) | A failure short-circuits the command (nothing appended); a success is unwrapped and handled like the rows above. |
+| `Result<TResult, TError>` (e.g. `Result<TEvent, ValidationResult>`) | A failure short-circuits the command (nothing appended); a success is unwrapped and handled like the rows above. |
 
 The rule of thumb: **return the fact that happened.** The event source id (see [Resolving EventSourceId](./returning-event-source-id.md)) decides which stream it lands on.
 

--- a/Documentation/backend/chronicle/read-models.md
+++ b/Documentation/backend/chronicle/read-models.md
@@ -194,7 +194,7 @@ Key points when using read models in validators:
 - **Async Validation**: Use `MustAsync` for asynchronous validation rules that need to check external systems
 
 > [!NOTE]
-> Read-model injection into validators works when commands run through the Arc command pipeline — minimal-API command endpoints (the default) and `ICommandPipeline` directly. It does **not** work when commands are exposed through MVC controllers, because MVC model validation runs during model binding, before the command context (and therefore the event source id) exists. In that case Arc raises an explicit `ReadModelValidatorRequiresCommandPipeline` error. Expose the command through a minimal-API endpoint, or move the read-model based check into the command's `Handle()` method.
+> Read-model injection into validators works when commands run through the Arc command pipeline — minimal-API command endpoints (the default) and `ICommandPipeline` directly. It does **not** work when commands are exposed through MVC controllers, because MVC model validation runs during model binding, before the command context (and therefore the event source id) exists. In that case the validator cannot be constructed and the request fails with a `ReadModelValidatorRequiresCommandPipeline` error (or, when development-time scope validation is enabled, the underlying scoped-service resolution error). Expose the command through a minimal-API endpoint, or move the read-model based check into the command's `Handle()` method.
 
 For more details on command validation, see the [Validation](../commands/validation.md) documentation.
 

--- a/Documentation/backend/commands/model-bound/index.md
+++ b/Documentation/backend/commands/model-bound/index.md
@@ -38,7 +38,7 @@ using OneOf;
 [Command]
 public record AddItemToCart(string Sku, int Quantity)
 {
-    public Result<ValidationResult, Guid> Handle()
+    public Result<Guid, ValidationResult> Handle()
     {
         if( /* code that checks if product is carried */ )
         {
@@ -65,7 +65,7 @@ using OneOf;
 [Command]
 public record CreateOrder(string CustomerId, List<OrderItem> Items)
 {
-    public Result<ValidationResult, (OrderId, OrderCreated)> Handle()
+    public Result<(OrderId, OrderCreated), ValidationResult> Handle()
     {
         if (!IsValidOrder())
         {
@@ -185,7 +185,7 @@ using OneOf;
 [Command]
 public record ProcessPayment(string OrderId, decimal Amount)
 {
-    public (OrderId, Result<PaymentFailed, PaymentSucceeded>) Handle()
+    public (OrderId, Result<PaymentSucceeded, PaymentFailed>) Handle()
     {
         var orderId = new OrderId(OrderId);
         

--- a/Documentation/backend/commands/response-value-handlers.md
+++ b/Documentation/backend/commands/response-value-handlers.md
@@ -46,7 +46,7 @@ using OneOf;
 [Command]
 public record CreateUser(string Name, string Email)
 {
-    public Result<ValidationResult, UserId> Handle()
+    public Result<UserId, ValidationResult> Handle()
     {
         if (!IsValidEmail(Email))
         {
@@ -128,7 +128,7 @@ When a command handler returns a tuple, the command pipeline intelligently proce
 
 ### Result Processing Behavior
 
-When a command handler returns a `Result<TError, TSuccess>` or `OneOf<T1, T2, ...>` value:
+When a command handler returns a `Result<TSuccess, TError>` or `OneOf<T1, T2, ...>` value:
 
 1. **The inner value** is extracted from the Result/OneOf wrapper
 2. **Value handlers are checked** using the `CanHandle` method on the inner value
@@ -150,7 +150,7 @@ using OneOf;
 [Command]
 public record CreateOrder(string CustomerId, List<OrderItem> Items)
 {
-    public Result<ValidationResult, (OrderId, OrderCreated)> Handle()
+    public Result<(OrderId, OrderCreated), ValidationResult> Handle()
     {
         if (!IsValidOrder())
         {

--- a/Documentation/backend/core/authorization.md
+++ b/Documentation/backend/core/authorization.md
@@ -279,7 +279,7 @@ When authorization fails, Arc.Core automatically returns appropriate HTTP status
 
 ## Custom Authorization Logic
 
-The `[Authorize]` and `[Roles]` attributes handle coarse-grained access — whether the user is authenticated and in the right role. For row-level checks (for example, "you can only update your own orders") put the logic inside `Handle()`: inject `IHttpContextAccessor`, read the current user's claims, and return a `ValidationResult.Error(...)` when the guard fails. Make the return type `Result<ValidationResult, TEvent>` so the framework knows the command can fail validation:
+The `[Authorize]` and `[Roles]` attributes handle coarse-grained access — whether the user is authenticated and in the right role. For row-level checks (for example, "you can only update your own orders") put the logic inside `Handle()`: inject `IHttpContextAccessor`, read the current user's claims, and return a `ValidationResult.Error(...)` when the guard fails. Make the return type `Result<TEvent, ValidationResult>` so the framework knows the command can fail validation:
 
 ```csharp
 using System.Security.Claims;
@@ -290,7 +290,7 @@ using Microsoft.AspNetCore.Http;
 [Command]
 public record UpdateOrder(OrderId Id, string Data)
 {
-    public Result<ValidationResult, OrderUpdated> Handle(
+    public Result<OrderUpdated, ValidationResult> Handle(
         IHttpContextAccessor httpContextAccessor,
         IOrderRepository orders)
     {
@@ -324,7 +324,7 @@ using Microsoft.AspNetCore.Http;
 [Command]
 public record ApproveExpense(ExpenseId Id)
 {
-    public Result<ValidationResult, ExpenseApproved> Handle(
+    public Result<ExpenseApproved, ValidationResult> Handle(
         IHttpContextAccessor httpContextAccessor,
         IExpenseRepository expenses)
     {
@@ -439,7 +439,7 @@ using Microsoft.AspNetCore.Http;
 [Command]
 public record SecureCommand(string Data)
 {
-    public Result<ValidationResult, SecureOperationCompleted> Handle(
+    public Result<SecureOperationCompleted, ValidationResult> Handle(
         IHttpContextAccessor httpContextAccessor)
     {
         var user = httpContextAccessor.HttpContext?.User;

--- a/Documentation/frontend/react/command-form/validation.md
+++ b/Documentation/frontend/react/command-form/validation.md
@@ -264,7 +264,7 @@ CommandForm automatically propagates validation results from backend command han
 [Command]
 public record CreateUser(string Email, string Username)
 {
-    public Result<ValidationResult, UserRegistered> Handle()
+    public Result<UserRegistered, ValidationResult> Handle()
     {
         // Backend validation
         if (Username.Length < 3)

--- a/Documentation/scenarios/provide-data-to-a-command.md
+++ b/Documentation/scenarios/provide-data-to-a-command.md
@@ -61,7 +61,7 @@ public LoanApproved Handle(CreditScore score, RiskBand band) => new(LoanId, scor
 Use `Result<,>` to reject or proceed in one method — return the error to stop, or the value to continue:
 
 ```csharp
-public Result<ValidationResult, CreditScore> Provide(ICreditBureau bureau)
+public Result<CreditScore, ValidationResult> Provide(ICreditBureau bureau)
 {
     var score = bureau.GetScore(Applicant);
     return score is null

--- a/Documentation/scenarios/return-a-result-or-error.md
+++ b/Documentation/scenarios/return-a-result-or-error.md
@@ -18,14 +18,14 @@ Return the shape that matches the outcome:
 | record one event (source from the command's `[Key]`) | the event: `AuthorRegistered Handle()` |
 | record one event against an explicit source | a tuple: `(AuthorId, AuthorRegistered) Handle()` |
 | also hand the caller a value | a tuple of `(result, event)` |
-| reject with a typed failure *or* succeed | `Result<ValidationResult, AuthorRegistered>` |
+| reject with a typed failure *or* succeed | `Result<AuthorRegistered, ValidationResult>` |
 | record several events | return them together as an `IEnumerable<…>` |
 | record nothing | `void` |
 
 The `Result<,>` form is how a handler rejects based on state it had to consult — return `ValidationResult.Error("…")` to fail, or the event to proceed:
 
 ```csharp
-public Result<ValidationResult, AuthorRegistered> Handle(RegisteredAuthorName? existing) =>
+public Result<AuthorRegistered, ValidationResult> Handle(RegisteredAuthorName? existing) =>
     existing is not null && existing.Name != AuthorName.NotSet
         ? ValidationResult.Error("An author with that name is already registered.")
         : new AuthorRegistered(Name);

--- a/Documentation/scenarios/validate-a-command.md
+++ b/Documentation/scenarios/validate-a-command.md
@@ -36,7 +36,7 @@ Arc runs validators *before* it invokes `Handle()`. A command that fails validat
 3. **A rule that depends on existing state → decide inside `Handle()`.** Uniqueness can't be checked against an eventually-consistent read model without a race. Instead, inject the read model Arc resolves for this command's key and return a typed error:
 
    ```csharp
-   public Result<ValidationResult, AuthorRegistered> Handle(RegisteredAuthorName? existing) =>
+   public Result<AuthorRegistered, ValidationResult> Handle(RegisteredAuthorName? existing) =>
        existing is not null && existing.Name != AuthorName.NotSet
            ? ValidationResult.Error("An author with that name is already registered.")
            : new AuthorRegistered(Name);

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/without_a_registered_validator.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/without_a_registered_validator.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Arc.Validation.for_DiscoverableValidators;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+/// <summary>
+/// The end-to-end guarantee for read-model validators: a validator that takes a scoped dependency — the stand-in for
+/// a read model resolved for the command's event source id — runs through the filter even though it is NOT registered
+/// in the container. It is constructed on demand from the command scope, with its dependency resolved from that same
+/// scope, exactly as the command handler and Provide method resolve theirs.
+/// </summary>
+public class without_a_registered_validator : Specification
+{
+    FluentValidationFilter _filter;
+    ServiceProvider _root = null!;
+    CorrelationId _correlationId;
+    CommandResult _result;
+    Exception _exception;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance));
+
+        // The scoped dependency is registered; the validator itself is intentionally NOT registered.
+        _root = new ServiceCollection()
+            .AddScoped(_ => new CommandDependency { IsAllowed = false })
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    async Task Because()
+    {
+        await using var commandScope = _root.CreateAsyncScope();
+        var context = new CommandContext(
+            _correlationId,
+            typeof(CommandWithDependency),
+            new CommandWithDependency(Guid.NewGuid()),
+            [],
+            new(),
+            ServiceProvider: commandScope.ServiceProvider);
+
+        _exception = await Catch.Exception(async () => _result = await _filter.OnExecution(context));
+    }
+
+    void Destroy() => _root.Dispose();
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_run_the_unregistered_validator_against_the_scoped_dependency() => _result.ValidationResults.First().Message.ShouldEqual("The dependency does not allow this command.");
+}

--- a/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/and_the_validator_is_not_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Validation/for_DiscoverableValidators/when_resolving_a_validator/and_the_validator_is_not_registered.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using FluentValidationResult = FluentValidation.Results.ValidationResult;
+
+namespace Cratis.Arc.Validation.for_DiscoverableValidators.when_resolving_a_validator;
+
+/// <summary>
+/// Proves a validator resolves even when it is not registered in the container. The self-binding convention skips
+/// validators with a record-typed constructor parameter (a Chronicle read model), so the validator must be
+/// constructed on demand from the supplied provider, with its dependency resolved from that same provider — the
+/// same way the command handler and Provide method resolve their dependencies.
+/// </summary>
+public class and_the_validator_is_not_registered : Specification
+{
+    DiscoverableValidators _validators;
+    ServiceProvider _provider = null!;
+    bool _resolved;
+    IValidator _validator = null!;
+    FluentValidationResult _result = null!;
+
+    void Establish()
+    {
+        _validators = new DiscoverableValidators(Cratis.Types.Types.Instance);
+
+        // The dependency is registered; the validator itself is deliberately NOT registered.
+        _provider = new ServiceCollection()
+            .AddSingleton(new CommandDependency { IsAllowed = false })
+            .BuildServiceProvider();
+
+        _resolved = _validators.TryGet(typeof(CommandWithDependency), _provider, out _validator!);
+    }
+
+    void Because() =>
+        _result = _validator.Validate(new ValidationContext<CommandWithDependency>(new CommandWithDependency(Guid.NewGuid())));
+
+    void Destroy() => _provider.Dispose();
+
+    [Fact] void should_resolve_the_validator() => _resolved.ShouldBeTrue();
+    [Fact] void should_construct_a_usable_validator() => _validator.ShouldNotBeNull();
+    [Fact] void should_run_the_validator_against_the_resolved_dependency() => _result.IsValid.ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
+++ b/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
@@ -61,11 +61,6 @@ public class DiscoverableValidators : IDiscoverableValidators
                 _ => _);
     }
 
-    /// <summary>
-    /// Gets the discovered validator types.
-    /// </summary>
-    internal IEnumerable<Type> ValidatorTypes => _validatorTypesByModelType.Values;
-
     /// <inheritdoc/>
     public bool TryGet(Type modelType, [MaybeNullWhen(false)] out IValidator validator) =>
         TryGet(modelType, _serviceProviderAccessor(), out validator);
@@ -75,7 +70,11 @@ public class DiscoverableValidators : IDiscoverableValidators
     {
         if (_validatorTypesByModelType.TryGetValue(modelType, out var value))
         {
-            validator = (serviceProvider.GetRequiredService(value) as IValidator)!;
+            // Construct the validator from the supplied (command-scoped) provider rather than requiring it to be
+            // registered. This mirrors how the command handler and Provide method resolve their dependencies, and
+            // it lets a validator take a Chronicle read model — a scoped service the self-binding convention skips
+            // (it has a record-typed constructor parameter) and therefore never registers — as a dependency.
+            validator = (ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, value) as IValidator)!;
             return true;
         }
 

--- a/Source/DotNET/Testing/Commands/CommandScenario.cs
+++ b/Source/DotNET/Testing/Commands/CommandScenario.cs
@@ -134,13 +134,13 @@ public class CommandScenario<TCommand>
 
         Services.AddCratisArcCore();
         IServiceProvider? serviceProvider = null;
+
+        // Validators are not registered here on purpose. The command pipeline constructs them on demand from the
+        // command scope (see DiscoverableValidators.TryGet), so a validator taking a read model resolves the same
+        // way a command handler does — no registration required.
         var discoverableValidators = new DiscoverableValidators(
             Cratis.Types.Types.Instance,
             () => serviceProvider ?? throw new InvalidOperationException("The command scenario service provider has not been built."));
-        foreach (var validatorType in discoverableValidators.ValidatorTypes)
-        {
-            Services.TryAddTransient(validatorType, validatorType);
-        }
 
         if (!hasExplicitDiscoverableValidatorsRegistration)
         {


### PR DESCRIPTION
## Fixed

- Read-model–dependent command validators now resolve through the command pipeline instead of failing with "No service for type … has been registered". A `CommandValidator` can take a read model, projection, or other service as a constructor dependency — resolved for the command's event source id — exactly like the command handler and `Provide` method.

## Changed

- Documentation: corrected `Result<,>` type-parameter order to `Result<TSuccess, TError>` across the command, validation, authorization, and scenario examples.
