### PR TITLE
Add command cancellation token support

### DIFF
--- a/Documentation/backend/commands/command-context.md
+++ b/Documentation/backend/commands/command-context.md
@@ -11,10 +11,12 @@ public record CommandContext(
     CorrelationId CorrelationId, 
     Type Type, 
     object Command, 
-    IEnumerable<object> Dependencies, 
+    IEnumerable<object?> Dependencies,
     CommandContextValues Values,
     ValidationResultSeverity? AllowedSeverity = default,
-    object? Response = default);
+    object? Response = default,
+    IServiceProvider? ServiceProvider = default,
+    CancellationToken CancellationToken = default);
 ```
 
 ### Properties
@@ -24,7 +26,10 @@ public record CommandContext(
 - **Command**: The actual command instance
 - **Dependencies**: The resolved dependencies required to handle the command
 - **Values**: A collection of key-value pairs providing additional context
-- **Response**: The response, **if any**, that is returned as part of the command result.
+- **AllowedSeverity**: The highest validation severity the caller allows before the command short-circuits
+- **Response**: The response, **if any**, that is returned as part of the command result
+- **ServiceProvider**: The scoped service provider used for command execution
+- **CancellationToken**: The cancellation token for the command execution
 
 ## Command Context Values
 

--- a/Documentation/backend/commands/command-pipeline.md
+++ b/Documentation/backend/commands/command-pipeline.md
@@ -76,6 +76,46 @@ public class OrderCreatedReactor
 }
 ```
 
+## Cancellation
+
+HTTP command endpoints pass the request-aborted token into the command execution automatically. That token can be injected into `Provide()` and `Handle()` as a `CancellationToken`.
+
+When you execute commands directly, pass the token to the pipeline:
+
+```csharp
+public class ImportWorker
+{
+    readonly ICommandPipeline _commandPipeline;
+
+    public ImportWorker(ICommandPipeline commandPipeline)
+    {
+        _commandPipeline = commandPipeline;
+    }
+
+    public Task<CommandResult> Import(CatalogId catalogId, CancellationToken cancellationToken) =>
+        _commandPipeline.Execute(new ImportCatalog(catalogId), cancellationToken);
+}
+```
+
+Use the scope-explicit form when the command should share the caller's scoped services:
+
+```csharp
+var result = await _commandPipeline.Execute(
+    new ImportCatalog(catalogId),
+    _serviceProvider,
+    cancellationToken);
+```
+
+If you also use validation severity filtering, pass both values:
+
+```csharp
+var result = await _commandPipeline.Execute(
+    command,
+    _serviceProvider,
+    allowedSeverity: ValidationResultSeverity.Warning,
+    cancellationToken);
+```
+
 ## Command Results
 
 The `ICommandPipeline.Execute()` method returns a `CommandResult` with comprehensive information about the execution:
@@ -307,4 +347,3 @@ If the handler returns no value at all (a `void`-equivalent handler), `Response`
 // Fine when you don't need a typed response
 var result = await _commandPipeline.Execute(new CancelOrder(orderId));
 ```
-

--- a/Documentation/backend/commands/model-bound/index.md
+++ b/Documentation/backend/commands/model-bound/index.md
@@ -222,6 +222,20 @@ public record AddItemToCart(string Sku, int Quantity)
 }
 ```
 
+`CancellationToken` is a special dependency. Arc injects it from the command execution context instead of resolving it from the service collection. HTTP command endpoints use the request-aborted token automatically. Programmatic callers can pass a token through `ICommandPipeline`.
+
+```csharp
+[Command]
+public record ImportCatalog(CatalogId CatalogId)
+{
+    public Task<CatalogSnapshot> Provide(ICatalogs catalogs, CancellationToken cancellationToken) =>
+        catalogs.GetSnapshot(CatalogId, cancellationToken);
+
+    public Task Handle(CatalogSnapshot snapshot, ICatalogImporter importer, CancellationToken cancellationToken) =>
+        importer.Import(snapshot, cancellationToken);
+}
+```
+
 ## Frontend Integration
 
 Model-bound commands work seamlessly with the [proxy generator](../../proxy-generation/index.md), which automatically creates TypeScript proxies for your commands. The generated proxies provide:

--- a/Documentation/scenarios/provide-data-to-a-command.md
+++ b/Documentation/scenarios/provide-data-to-a-command.md
@@ -47,6 +47,24 @@ public LoanApproved Handle(CreditScore score, RiskBand band) => new(LoanId, scor
 
 `Provide` may be synchronous or `async` (`Task<T>` / `ValueTask<T>`).
 
+## Use cancellation when the work can stop
+
+`Provide` and `Handle` can both take a `CancellationToken`. Arc supplies the current command execution token. For HTTP command endpoints, that is the request-aborted token. For direct `ICommandPipeline` execution, pass the token to the pipeline call.
+
+```csharp
+[Command]
+public record ApproveLoan(LoanId LoanId, ApplicantId Applicant)
+{
+    public Task<CreditScore> Provide(ICreditBureau bureau, CancellationToken cancellationToken) =>
+        bureau.GetScore(Applicant, cancellationToken);
+
+    public Task<LoanApproved> Handle(CreditScore creditScore, CancellationToken cancellationToken) =>
+        Task.FromResult(new LoanApproved(LoanId, creditScore));
+}
+```
+
+Use the token for IO or long-running work. You do not register `CancellationToken` in the service container; Arc treats it as part of the command execution context.
+
 ## Short-circuit before `Handle` runs
 
 `Provide` can stop the command before `Handle` is ever called:

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_cancellation_token.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_cancellation_token.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+using FluentValidationResult = FluentValidation.Results.ValidationResult;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_cancellation_token : given.a_fluent_validation_filter
+{
+    IValidator _validator;
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    void Establish()
+    {
+        var command = new TestCommand();
+        _context = new CommandContext(_correlationId, typeof(TestCommand), command, [], new(), CancellationToken: _cancellationTokenSource.Token);
+
+        _validator = Substitute.For<IValidator>();
+        _validator.ValidateAsync(Arg.Any<IValidationContext>(), Arg.Any<CancellationToken>()).Returns(new FluentValidationResult());
+
+        _discoverableValidators.TryGet(typeof(TestCommand), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = _validator;
+                return true;
+            });
+    }
+
+    async Task Because() => await _filter.OnExecution(_context);
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_call_validator_with_the_command_context_cancellation_token() =>
+        _validator.Received(1).ValidateAsync(Arg.Any<IValidationContext>(), _cancellationTokenSource.Token);
+
+    public class TestCommand;
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_handle_takes_cancellation_token.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_handle_takes_cancellation_token.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_handle_takes_cancellation_token : given.a_command_handler_argument_resolver
+{
+    class Handler
+    {
+        public void Handle(CancellationToken cancellationToken) { }
+    }
+
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    CommandHandlerArgumentResolution _result;
+
+    void Establish()
+    {
+        _context = _context with { CancellationToken = _cancellationTokenSource.Token };
+        HandleHasParameters<Handler>();
+        ProvideReturns();
+    }
+
+    async Task Because() => _result = await Resolve();
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_pass_the_command_context_cancellation_token() => _result.Arguments[0].ShouldEqual(_cancellationTokenSource.Token);
+    [Fact] void should_not_resolve_cancellation_token_from_di() => _serviceProvider.DidNotReceive().GetService(typeof(CancellationToken));
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_cancellation_token_is_supplied.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_cancellation_token_is_supplied.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+public class and_a_cancellation_token_is_supplied : given.a_command_pipeline_and_a_handler_for_command
+{
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    CommandContext _capturedContext = null!;
+
+    void Establish() =>
+        _commandFilters.OnExecution(Arg.Do<CommandContext>(context => _capturedContext = context))
+            .Returns(CommandResult.Success(_correlationId));
+
+    async Task Because() => await _commandPipeline.Execute(
+        _command,
+        _serviceProvider,
+        cancellationToken: _cancellationTokenSource.Token);
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_carry_the_cancellation_token_on_the_context() => _capturedContext.CancellationToken.ShouldEqual(_cancellationTokenSource.Token);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipelineCancellationExtensions/when_executing/and_pipeline_does_not_support_cancellation.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipelineCancellationExtensions/when_executing/and_pipeline_does_not_support_cancellation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandPipelineCancellationExtensions.when_executing;
+
+public class and_pipeline_does_not_support_cancellation : Specification
+{
+    ICommandPipeline _pipeline;
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    readonly object _command = new();
+    CommandResult _expectedResult;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _expectedResult = CommandResult.Success(CorrelationId.New());
+        _pipeline = Substitute.For<ICommandPipeline>();
+        _pipeline
+            .Execute(_command, Arg.Any<ValidationResultSeverity?>())
+            .Returns(_expectedResult);
+    }
+
+    async Task Because() => _result = await _pipeline.Execute(_command, _cancellationTokenSource.Token);
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_fall_back_to_the_legacy_pipeline_method() => _result.ShouldEqual(_expectedResult);
+    [Fact] void should_execute_the_legacy_pipeline_method() =>
+        _pipeline.Received(1).Execute(_command, Arg.Any<ValidationResultSeverity?>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipelineCancellationExtensions/when_executing/and_pipeline_supports_cancellation.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipelineCancellationExtensions/when_executing/and_pipeline_supports_cancellation.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandPipelineCancellationExtensions.when_executing;
+
+public class and_pipeline_supports_cancellation : Specification
+{
+    ICommandPipeline _pipeline;
+    ICommandPipelineWithCancellation _cancellationAwarePipeline;
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    readonly object _command = new();
+    CommandResult _expectedResult;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _expectedResult = CommandResult.Success(CorrelationId.New());
+        _pipeline = Substitute.For<ICommandPipeline, ICommandPipelineWithCancellation>();
+        _cancellationAwarePipeline = (ICommandPipelineWithCancellation)_pipeline;
+        _cancellationAwarePipeline
+            .Execute(_command, Arg.Any<ValidationResultSeverity?>(), _cancellationTokenSource.Token)
+            .Returns(_expectedResult);
+    }
+
+    async Task Because() => _result = await _pipeline.Execute(_command, _cancellationTokenSource.Token);
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_execute_with_the_cancellation_aware_pipeline() => _result.ShouldEqual(_expectedResult);
+    [Fact] void should_pass_the_cancellation_token() =>
+        _cancellationAwarePipeline.Received(1).Execute(_command, Arg.Any<ValidationResultSeverity?>(), _cancellationTokenSource.Token);
+    [Fact] void should_not_use_the_legacy_pipeline_method() =>
+        _pipeline.DidNotReceive().Execute(_command, Arg.Any<ValidationResultSeverity?>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/given/a_command_provide_invoker.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/given/a_command_provide_invoker.cs
@@ -16,6 +16,14 @@ public class a_command_provide_invoker : Specification
         _serviceProvider = Substitute.For<IServiceProvider>();
     }
 
-    protected ValueTask<IReadOnlyList<object>> Invoke(object command) =>
-        _invoker.Invoke(new CommandContext(CorrelationId.New(), command.GetType(), command, [], new()), _serviceProvider);
+    protected ValueTask<IReadOnlyList<object>> Invoke(object command, CancellationToken cancellationToken = default) =>
+        _invoker.Invoke(
+            new CommandContext(
+                CorrelationId.New(),
+                command.GetType(),
+                command,
+                [],
+                new(),
+                CancellationToken: cancellationToken),
+            _serviceProvider);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_takes_cancellation_token.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandProvideInvoker/when_invoking/and_provide_takes_cancellation_token.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandProvideInvoker.when_invoking;
+
+public class and_provide_takes_cancellation_token : given.a_command_provide_invoker
+{
+    class Command
+    {
+        public CancellationToken CancellationToken;
+
+        public bool Provide(CancellationToken cancellationToken)
+        {
+            CancellationToken = cancellationToken;
+            return true;
+        }
+    }
+
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    readonly Command _command = new();
+    IReadOnlyList<object> _result;
+
+    async Task Because() => _result = await Invoke(_command, _cancellationTokenSource.Token);
+
+    void Destroy() => _cancellationTokenSource.Dispose();
+
+    [Fact] void should_invoke_provide() => _result[0].ShouldEqual(true);
+    [Fact] void should_pass_the_command_context_cancellation_token() => _command.CancellationToken.ShouldEqual(_cancellationTokenSource.Token);
+    [Fact] void should_not_resolve_cancellation_token_from_di() => _serviceProvider.DidNotReceive().GetService(typeof(CancellationToken));
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_resolving_and_handling_with_cancellation_token.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_a_command_with_a_provide_method/when_resolving_and_handling_with_cancellation_token.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.for_a_command_with_a_provide_method;
+
+public class when_resolving_and_handling_with_cancellation_token : Specification
+{
+    record ProvidedValue(string Value);
+
+    record Command
+    {
+        public CancellationToken ProvideCancellationToken;
+        public CancellationToken HandleCancellationToken;
+
+        public ProvidedValue Provide(CancellationToken cancellationToken)
+        {
+            ProvideCancellationToken = cancellationToken;
+            return new("provided");
+        }
+
+        public string Handle(ProvidedValue provided, CancellationToken cancellationToken)
+        {
+            HandleCancellationToken = cancellationToken;
+            return provided.Value;
+        }
+    }
+
+    readonly CancellationTokenSource _cancellationTokenSource = new();
+    IServiceProvider _serviceProvider;
+    ICommandHandler _handler;
+    CommandHandlerArgumentResolver _resolver;
+    Command _command;
+    object _result;
+
+    void Establish()
+    {
+        _serviceProvider = new ServiceCollection().BuildServiceProvider();
+        _resolver = new CommandHandlerArgumentResolver(new CommandProvideInvoker());
+        _handler = new ModelBoundCommandHandler(typeof(Command), typeof(Command).GetMethod(nameof(Command.Handle))!);
+        _command = new();
+    }
+
+    async Task Because()
+    {
+        var context = new CommandContext(
+            CorrelationId.New(),
+            typeof(Command),
+            _command,
+            [],
+            new(),
+            CancellationToken: _cancellationTokenSource.Token);
+        var resolution = await _resolver.Resolve(_handler, context, _serviceProvider, allowedSeverity: null);
+        context = context with { Dependencies = resolution.Arguments };
+        _result = await _handler.Handle(context);
+    }
+
+    void Destroy()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+        _cancellationTokenSource.Dispose();
+    }
+
+    [Fact] void should_produce_the_result_from_handle() => _result.ShouldEqual("provided");
+    [Fact] void should_pass_the_cancellation_token_to_provide() => _command.ProvideCancellationToken.ShouldEqual(_cancellationTokenSource.Token);
+    [Fact] void should_pass_the_cancellation_token_to_handle() => _command.HandleCancellationToken.ShouldEqual(_cancellationTokenSource.Token);
+}

--- a/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/it_should_register_cancellation_aware_command_pipeline.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_HostBuilderExtensions/when_adding_cratis_arc_core/it_should_register_cancellation_aware_command_pipeline.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.for_HostBuilderExtensions.when_adding_cratis_arc_core;
+
+public class it_should_register_cancellation_aware_command_pipeline : Specification
+{
+    ICommandPipeline _pipeline;
+    ICommandPipelineWithCancellation _cancellationAwarePipeline;
+
+    void Because()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddCratisArcCore()
+            .BuildServiceProvider();
+
+        _pipeline = serviceProvider.GetRequiredService<ICommandPipeline>();
+        _cancellationAwarePipeline = serviceProvider.GetRequiredService<ICommandPipelineWithCancellation>();
+    }
+
+    [Fact] void should_register_the_cancellation_aware_pipeline() => _cancellationAwarePipeline.ShouldNotBeNull();
+    [Fact] void should_use_the_same_pipeline_instance() => ReferenceEquals(_pipeline, _cancellationAwarePipeline).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandContext.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandContext.cs
@@ -17,6 +17,7 @@ namespace Cratis.Arc.Commands;
 /// <param name="AllowedSeverity">The maximum validation result severity level to allow. Validation results with severity higher than this will cause the command to fail.</param>
 /// <param name="Response">The optional response from handling the command, if any.</param>
 /// <param name="ServiceProvider">The <see cref="IServiceProvider"/> scoped to the command, used to resolve scoped collaborators such as validators and read models during the command's lifetime.</param>
+/// <param name="CancellationToken">The cancellation token for the command execution.</param>
 public record CommandContext(
     CorrelationId CorrelationId,
     Type Type,
@@ -25,4 +26,30 @@ public record CommandContext(
     CommandContextValues Values,
     ValidationResultSeverity? AllowedSeverity = default,
     object? Response = default,
-    IServiceProvider? ServiceProvider = default);
+    IServiceProvider? ServiceProvider = default,
+    CancellationToken CancellationToken = default)
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandContext"/> record.
+    /// </summary>
+    /// <param name="correlationId">The correlation ID for the command.</param>
+    /// <param name="type">The type of the command.</param>
+    /// <param name="command">The command instance.</param>
+    /// <param name="dependencies">The dependencies required to handle the command.</param>
+    /// <param name="values">A set of values associated with the command context.</param>
+    /// <param name="allowedSeverity">The maximum validation result severity level to allow. Validation results with severity higher than this will cause the command to fail.</param>
+    /// <param name="response">The optional response from handling the command, if any.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the command, used to resolve scoped collaborators such as validators and read models during the command's lifetime.</param>
+    public CommandContext(
+        CorrelationId correlationId,
+        Type type,
+        object command,
+        IEnumerable<object?> dependencies,
+        CommandContextValues values,
+        ValidationResultSeverity? allowedSeverity,
+        object? response,
+        IServiceProvider? serviceProvider)
+        : this(correlationId, type, command, dependencies, values, allowedSeverity, response, serviceProvider, default)
+    {
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
@@ -112,8 +112,8 @@ public static class CommandEndpointMapper
                     else
                     {
                         commandResult = validateOnly
-                            ? await commandPipeline.Validate(command, context.RequestServices, allowedSeverity)
-                            : await commandPipeline.Execute(command, context.RequestServices, allowedSeverity);
+                            ? await commandPipeline.Validate(command, context.RequestServices, allowedSeverity, context.RequestAborted)
+                            : await commandPipeline.Execute(command, context.RequestServices, allowedSeverity, context.RequestAborted);
                     }
                 }
                 catch (Exception ex)

--- a/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolver.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandHandlerArgumentResolver.cs
@@ -46,11 +46,15 @@ public class CommandHandlerArgumentResolver(ICommandProvideInvoker provideInvoke
 
         // Non-blocking control values (for example warnings) are dropped here, just as the pipeline drops
         // them when filtering by severity, so the resolution reports a clean success.
-        var arguments = BuildArguments(handler, candidates, serviceProvider);
+        var arguments = BuildArguments(handler, candidates, context, serviceProvider);
         return new CommandHandlerArgumentResolution(arguments, CommandResult.Success(context.CorrelationId));
     }
 
-    static object?[] BuildArguments(ICommandHandler handler, List<object> candidates, IServiceProvider serviceProvider)
+    static object?[] BuildArguments(
+        ICommandHandler handler,
+        List<object> candidates,
+        CommandContext context,
+        IServiceProvider serviceProvider)
     {
         var parameters = handler.Parameters.ToArray();
         var arguments = new object?[parameters.Length];
@@ -58,8 +62,12 @@ public class CommandHandlerArgumentResolver(ICommandProvideInvoker provideInvoke
         {
             var parameter = parameters[i];
             var parameterType = parameter.ParameterType;
-            var match = candidates.Find(parameterType.IsInstanceOfType);
-            if (match is not null)
+
+            if (parameterType == typeof(CancellationToken))
+            {
+                arguments[i] = context.CancellationToken;
+            }
+            else if (candidates.Find(parameterType.IsInstanceOfType) is { } match)
             {
                 arguments[i] = match;
                 candidates.Remove(match);

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -33,31 +33,56 @@ public class CommandPipeline(
     ICommandContextValuesBuilder contextValuesBuilder,
     ICommandHandlerArgumentResolver argumentResolver,
     IServiceScopeFactory scopeFactory,
-    IActivitySource<CommandPipeline> activitySource) : ICommandPipeline
+    IActivitySource<CommandPipeline> activitySource) : ICommandPipelineWithCancellation
 {
     /// <inheritdoc/>
     public async Task<CommandResult> Execute(object command, ValidationResultSeverity? allowedSeverity = default)
     {
         using var scope = scopeFactory.CreateScope();
-        return await Execute(command, scope.ServiceProvider, allowedSeverity);
+        return await Execute(command, scope.ServiceProvider, allowedSeverity, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task<CommandResult> Execute(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        return await Execute(command, scope.ServiceProvider, allowedSeverity, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<CommandResult<TResult>> Execute<TResult>(object command, ValidationResultSeverity? allowedSeverity = default)
     {
         using var scope = scopeFactory.CreateScope();
-        return await Execute<TResult>(command, scope.ServiceProvider, allowedSeverity);
+        return await Execute<TResult>(command, scope.ServiceProvider, allowedSeverity, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task<CommandResult<TResult>> Execute<TResult>(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        return await Execute<TResult>(command, scope.ServiceProvider, allowedSeverity, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<CommandResult> Validate(object command, ValidationResultSeverity? allowedSeverity = default)
     {
         using var scope = scopeFactory.CreateScope();
-        return await Validate(command, scope.ServiceProvider, allowedSeverity);
+        return await Validate(command, scope.ServiceProvider, allowedSeverity, CancellationToken.None);
     }
 
     /// <inheritdoc/>
-    public async Task<CommandResult> Execute(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default)
+    public async Task<CommandResult> Validate(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        return await Validate(command, scope.ServiceProvider, allowedSeverity, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<CommandResult> Execute(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default) =>
+        Execute(command, serviceProvider, allowedSeverity, CancellationToken.None);
+
+    /// <inheritdoc/>
+    public async Task<CommandResult> Execute(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
     {
         var correlationId = GetCorrelationId();
         var result = CommandResult.Success(correlationId);
@@ -77,7 +102,8 @@ public class CommandPipeline(
                 [],
                 contextValuesBuilder.Build(command),
                 allowedSeverity,
-                ServiceProvider: serviceProvider);
+                ServiceProvider: serviceProvider,
+                CancellationToken: cancellationToken);
             contextModifier.SetCurrent(commandContext);
             result = await commandFilters.OnExecution(commandContext);
             result = FilterValidationResults(result, allowedSeverity);
@@ -113,9 +139,13 @@ public class CommandPipeline(
     }
 
     /// <inheritdoc/>
-    public async Task<CommandResult<TResult>> Execute<TResult>(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default)
+    public Task<CommandResult<TResult>> Execute<TResult>(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default) =>
+        Execute<TResult>(command, serviceProvider, allowedSeverity, CancellationToken.None);
+
+    /// <inheritdoc/>
+    public async Task<CommandResult<TResult>> Execute<TResult>(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
     {
-        var result = await Execute(command, serviceProvider, allowedSeverity);
+        var result = await Execute(command, serviceProvider, allowedSeverity, cancellationToken);
         if (result is CommandResult<TResult> typed)
         {
             return typed;
@@ -138,7 +168,11 @@ public class CommandPipeline(
     }
 
     /// <inheritdoc/>
-    public async Task<CommandResult> Validate(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default)
+    public Task<CommandResult> Validate(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity = default) =>
+        Validate(command, serviceProvider, allowedSeverity, CancellationToken.None);
+
+    /// <inheritdoc/>
+    public async Task<CommandResult> Validate(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken)
     {
         var correlationId = GetCorrelationId();
         var result = CommandResult.Success(correlationId);
@@ -158,7 +192,8 @@ public class CommandPipeline(
                 [],
                 contextValuesBuilder.Build(command),
                 allowedSeverity,
-                ServiceProvider: serviceProvider);
+                ServiceProvider: serviceProvider,
+                CancellationToken: cancellationToken);
             contextModifier.SetCurrent(commandContext);
 
             // Run only filters (authorization and validation), skip handler execution and argument resolution

--- a/Source/DotNET/Arc.Core/Commands/CommandPipelineCancellationExtensions.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipelineCancellationExtensions.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Extension methods for executing commands with an explicit cancellation token.
+/// </summary>
+public static class CommandPipelineCancellationExtensions
+{
+    /// <summary>
+    /// Executes the given command, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult> Execute(this ICommandPipeline pipeline, object command, CancellationToken cancellationToken) =>
+        pipeline.Execute(command, (ValidationResultSeverity?)default, cancellationToken);
+
+    /// <summary>
+    /// Executes the given command, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult> Execute(
+        this ICommandPipeline pipeline,
+        object command,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Execute(command, allowedSeverity, cancellationToken)
+            : pipeline.Execute(command, allowedSeverity);
+    }
+
+    /// <summary>
+    /// Executes the given command within the provided service scope.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult> Execute(this ICommandPipeline pipeline, object command, IServiceProvider serviceProvider, CancellationToken cancellationToken) =>
+        pipeline.Execute(command, serviceProvider, default, cancellationToken);
+
+    /// <summary>
+    /// Executes the given command within the provided service scope.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult> Execute(
+        this ICommandPipeline pipeline,
+        object command,
+        IServiceProvider serviceProvider,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Execute(command, serviceProvider, allowedSeverity, cancellationToken)
+            : pipeline.Execute(command, serviceProvider, allowedSeverity);
+    }
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult<TResult>> Execute<TResult>(this ICommandPipeline pipeline, object command, CancellationToken cancellationToken) =>
+        pipeline.Execute<TResult>(command, (ValidationResultSeverity?)default, cancellationToken);
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult<TResult>> Execute<TResult>(
+        this ICommandPipeline pipeline,
+        object command,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Execute<TResult>(command, allowedSeverity, cancellationToken)
+            : pipeline.Execute<TResult>(command, allowedSeverity);
+    }
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result within the provided service scope.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult<TResult>> Execute<TResult>(this ICommandPipeline pipeline, object command, IServiceProvider serviceProvider, CancellationToken cancellationToken) =>
+        pipeline.Execute<TResult>(command, serviceProvider, default, cancellationToken);
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result within the provided service scope.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    public static Task<CommandResult<TResult>> Execute<TResult>(
+        this ICommandPipeline pipeline,
+        object command,
+        IServiceProvider serviceProvider,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Execute<TResult>(command, serviceProvider, allowedSeverity, cancellationToken)
+            : pipeline.Execute<TResult>(command, serviceProvider, allowedSeverity);
+    }
+
+    /// <summary>
+    /// Validates the given command without executing it, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    public static Task<CommandResult> Validate(this ICommandPipeline pipeline, object command, CancellationToken cancellationToken) =>
+        pipeline.Validate(command, (ValidationResultSeverity?)default, cancellationToken);
+
+    /// <summary>
+    /// Validates the given command without executing it, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    public static Task<CommandResult> Validate(
+        this ICommandPipeline pipeline,
+        object command,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Validate(command, allowedSeverity, cancellationToken)
+            : pipeline.Validate(command, allowedSeverity);
+    }
+
+    /// <summary>
+    /// Validates the given command without executing it, within the provided service scope.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    public static Task<CommandResult> Validate(this ICommandPipeline pipeline, object command, IServiceProvider serviceProvider, CancellationToken cancellationToken) =>
+        pipeline.Validate(command, serviceProvider, default, cancellationToken);
+
+    /// <summary>
+    /// Validates the given command without executing it, within the provided service scope.
+    /// </summary>
+    /// <param name="pipeline">The <see cref="ICommandPipeline"/>.</param>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    public static Task<CommandResult> Validate(
+        this ICommandPipeline pipeline,
+        object command,
+        IServiceProvider serviceProvider,
+        ValidationResultSeverity? allowedSeverity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(pipeline);
+        return pipeline is ICommandPipelineWithCancellation cancellationAwarePipeline
+            ? cancellationAwarePipeline.Validate(command, serviceProvider, allowedSeverity, cancellationToken)
+            : pipeline.Validate(command, serviceProvider, allowedSeverity);
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandProvideInvoker.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandProvideInvoker.cs
@@ -30,22 +30,27 @@ public class CommandProvideInvoker : ICommandProvideInvoker
             return [];
         }
 
-        var arguments = ResolveArguments(provideMethod, serviceProvider);
+        var arguments = ResolveArguments(context, provideMethod, serviceProvider);
         var invocationResult = Invoke(provideMethod, context.Command, arguments);
         var (_, value) = await AwaitableHelpers.AwaitIfNeeded(invocationResult);
         return Flatten(value);
     }
 
-    static object?[]? ResolveArguments(MethodInfo provideMethod, IServiceProvider serviceProvider)
+    static object?[]? ResolveArguments(CommandContext context, MethodInfo provideMethod, IServiceProvider serviceProvider)
     {
         var parameters = provideMethod.GetParameters();
         return parameters.Length == 0
             ? null
+            : parameters.Select(parameter => ResolveArgument(context, serviceProvider, parameter)).ToArray();
+    }
+
+    static object? ResolveArgument(CommandContext context, IServiceProvider serviceProvider, ParameterInfo parameter) =>
+        parameter.ParameterType == typeof(CancellationToken)
+            ? context.CancellationToken
             : ParameterDependencyResolver.Resolve(
                 serviceProvider,
-                parameters,
-                parameter => new CannotResolveCommandDependency(parameter));
-    }
+                parameter,
+                _ => new CannotResolveCommandDependency(parameter));
 
     static object? Invoke(MethodInfo provideMethod, object command, object?[]? arguments)
     {

--- a/Source/DotNET/Arc.Core/Commands/CommandServiceCollectionExtensions.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandServiceCollectionExtensions.cs
@@ -21,7 +21,9 @@ public static class CommandServiceCollectionExtensions
         services.AddSingleton<CommandContextManager>();
         services.AddSingleton<ICommandContextModifier>(sp => sp.GetRequiredService<CommandContextManager>());
         services.AddSingleton<ICommandContextAccessor>(sp => sp.GetRequiredService<CommandContextManager>());
-        services.AddSingleton<ICommandPipeline, CommandPipeline>();
+        services.AddSingleton<CommandPipeline>();
+        services.AddSingleton<ICommandPipeline>(sp => sp.GetRequiredService<CommandPipeline>());
+        services.AddSingleton<ICommandPipelineWithCancellation>(sp => sp.GetRequiredService<CommandPipeline>());
         services.AddSingleton<ICommandFilters, CommandFilters>();
         services.AddSingleton<ICommandHandlerProviders, CommandHandlerProviders>();
         services.AddSingleton<ICommandResponseValueHandlers, CommandResponseValueHandlers>();

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -31,7 +31,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
         {
             var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
             var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
-            var validationResult = await validator.ValidateAsync(validationContext, CancellationToken.None);
+            var validationResult = await validator.ValidateAsync(validationContext, context.CancellationToken);
             if (!validationResult.IsValid)
             {
                 commandResult.MergeWith(new CommandResult

--- a/Source/DotNET/Arc.Core/Commands/ICommandPipelineWithCancellation.cs
+++ b/Source/DotNET/Arc.Core/Commands/ICommandPipelineWithCancellation.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Defines a command pipeline that can execute commands with an explicit cancellation token.
+/// </summary>
+public interface ICommandPipelineWithCancellation : ICommandPipeline
+{
+    /// <summary>
+    /// Executes the given command, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    Task<CommandResult> Execute(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes the given command within the provided service scope.
+    /// </summary>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the result of executing the command.</returns>
+    Task<CommandResult> Execute(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    Task<CommandResult<TResult>> Execute<TResult>(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes the given command and returns a strongly-typed result within the provided service scope.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the response returned by the command handler.</typeparam>
+    /// <param name="command">The command to execute.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command execution.</param>
+    /// <returns>A <see cref="CommandResult{TResult}"/> representing the result of executing the command.</returns>
+    Task<CommandResult<TResult>> Execute<TResult>(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validates the given command without executing it, creating a dedicated service scope for dependency resolution.
+    /// </summary>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    Task<CommandResult> Validate(object command, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Validates the given command without executing it, within the provided service scope.
+    /// </summary>
+    /// <param name="command">The command to validate.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the current request, used to resolve handler dependencies.</param>
+    /// <param name="allowedSeverity">Optional maximum validation result severity level to allow.</param>
+    /// <param name="cancellationToken">The cancellation token for the command validation.</param>
+    /// <returns>A <see cref="CommandResult"/> representing the validation result.</returns>
+    Task<CommandResult> Validate(object command, IServiceProvider serviceProvider, ValidationResultSeverity? allowedSeverity, CancellationToken cancellationToken);
+}

--- a/Source/DotNET/Arc/Commands/CommandActionFilter.cs
+++ b/Source/DotNET/Arc/Commands/CommandActionFilter.cs
@@ -154,7 +154,8 @@ public class CommandActionFilter(
             commandType,
             command,
             [],
-            values);
+            values,
+            CancellationToken: context.HttpContext.RequestAborted);
 
         contextModifier.SetCurrent(commandContext);
     }


### PR DESCRIPTION
# Summary

Adds cancellation token support through Arc command execution while keeping the existing command pipeline contract compatible.

## Added

- Added `CancellationToken` injection for model-bound command `Provide()` and `Handle()` methods.
- Added cancellation-aware command pipeline overloads for programmatic command execution.

## Changed

- Command validation now receives the command execution cancellation token.
