### PR TITLE
Skip indexer properties in command and query validation

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_indexer_property.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_indexer_property.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_command_having_indexer_property : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+    Exception _exception;
+
+    void Establish()
+    {
+        var command = new CommandWithIndexer(new ThingWithIndexer());
+        _context = new CommandContext(_correlationId, typeof(CommandWithIndexer), command, [], new());
+        _discoverableValidators.TryGet(Arg.Any<Type>(), out Arg.Any<IValidator>()).Returns(false);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => _result = await _filter.OnExecution(_context));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+
+    record CommandWithIndexer(ThingWithIndexer Thing);
+
+    /// <summary>
+    /// A non-enumerable type carrying an indexer — reflecting GetValue(instance) over it without index
+    /// arguments would throw "Parameter count mismatch" if the filter did not skip indexers.
+    /// </summary>
+    public class ThingWithIndexer
+    {
+        public int this[int index] => index;
+
+        public string Name => "ok";
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -69,6 +69,14 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
             {
                 foreach (var property in instanceType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
+                    // Skip indexer properties — they require index arguments, so GetValue(instance)
+                    // without any would throw "Parameter count mismatch". These show up on types such as
+                    // JsonElement (this[int]) that can appear in an object-typed command property graph.
+                    if (property.GetIndexParameters().Length > 0)
+                    {
+                        continue;
+                    }
+
                     var propertyValue = property.GetValue(instance);
                     if (propertyValue is not null)
                     {

--- a/Source/DotNET/Arc.Core/Queries/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Queries/Filters/FluentValidationFilter.cs
@@ -66,6 +66,12 @@ public class FluentValidationFilter(IQueryPerformerProviders queryPerformerProvi
             {
                 foreach (var property in parameterType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
+                    // Skip indexer properties — GetValue without index arguments throws "Parameter count mismatch".
+                    if (property.GetIndexParameters().Length > 0)
+                    {
+                        continue;
+                    }
+
                     var propertyValue = property.GetValue(value);
                     if (propertyValue is not null)
                     {


### PR DESCRIPTION
## Fixed
- Command and query validation no longer throws `Parameter count mismatch` when the parameter graph contains a type with an indexer (for example a `JsonElement` held in an `object`-typed property). The recursive fluent validation filters now skip indexer properties.