### PR TITLE
Handle types that are already the concrete type

### DIFF
--- a/Source/DotNET/MongoDB.Specs/AssemblyInfo.cs
+++ b/Source/DotNET/MongoDB.Specs/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Several specs configure MongoDB through process-wide static state — most notably the naming policy on
+// DatabaseExtensions and the registered convention packs. Running test classes in parallel races on that
+// shared state and produces intermittent failures, so parallelization is disabled for this assembly.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type.cs
@@ -12,6 +12,7 @@ public class when_getting_actual_type : given.a_derived_type_discriminator_conve
 
     void Establish()
     {
+        _derivedTypes.HasDerivatives(typeof(BaseType)).Returns(true);
         _derivedTypes
             .GetDerivedTypeFor(typeof(BaseType), _derivedTypeIdentifier)
             .Returns(typeof(DerivedType));

--- a/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type_for_a_type_without_derivatives.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DerivedTypeDiscriminatorConvention/when_getting_actual_type_for_a_type_without_derivatives.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+
+namespace Cratis.Arc.MongoDB.for_DerivedTypeDiscriminatorConvention;
+
+public class when_getting_actual_type_for_a_type_without_derivatives : given.a_derived_type_discriminator_convention
+{
+    Type _result;
+
+    void Establish() => _derivedTypes.HasDerivatives(typeof(BaseType)).Returns(false);
+
+    void Because()
+    {
+        var document = new BsonDocument { { DerivedTypeDiscriminatorConvention.PropertyName, _derivedTypeIdentifier } };
+        using var reader = new BsonDocumentReader(document);
+        _result = _convention.GetActualType(reader, typeof(BaseType));
+    }
+
+    [Fact] void should_return_the_nominal_type() => _result.ShouldEqual(typeof(BaseType));
+    [Fact] void should_not_resolve_a_derived_type() => _derivedTypes.DidNotReceive().GetDerivedTypeFor(Arg.Any<Type>(), Arg.Any<DerivedTypeId>());
+}

--- a/Source/DotNET/MongoDB/DerivedTypeDiscriminatorConvention.cs
+++ b/Source/DotNET/MongoDB/DerivedTypeDiscriminatorConvention.cs
@@ -39,7 +39,12 @@ public class DerivedTypeDiscriminatorConvention(IDerivedTypes derivedTypes) : ID
         }
 
         bsonReader.ReturnToBookmark(bookmark);
-        return type is null
+
+        // When the nominal type has no registered derivatives it is already the concrete type (for example
+        // a leaf derived type being deserialized after its discriminator was resolved one level up). The
+        // discriminator element may still be present on the document, so only resolve a derived type when
+        // the nominal type actually has derivatives to avoid throwing for an unknown target type.
+        return type is null || !derivedTypes.HasDerivatives(nominalType)
             ? nominalType
             : derivedTypes.GetDerivedTypeFor(nominalType, type);
     }


### PR DESCRIPTION
## Fixed

- Fixes the MongoDB derived type handling so that if a type is already its concrete type, it uses it.
