### PR TITLE
Tolerate any BSON numeric representation when deserializing concepts

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/DoubleConcept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/DoubleConcept.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public record DoubleConcept(double Value) : ConceptAs<double>(Value);

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/IntConcept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/IntConcept.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public record IntConcept(int Value) : ConceptAs<int>(Value);

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/LongConcept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/LongConcept.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public record LongConcept(long Value) : ConceptAs<long>(Value);

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/a_concept_serializer.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/a_concept_serializer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public class a_concept_serializer : Specification
+{
+    protected static T Deserialize<T>(BsonValue storedValue)
+    {
+        var document = new BsonDocument { { "value", storedValue } };
+        using var reader = new BsonDocumentReader(document);
+        reader.ReadStartDocument();
+        reader.ReadName();
+
+        var serializer = new ConceptSerializer<T>();
+        var context = BsonDeserializationContext.CreateRoot(reader);
+        var result = serializer.Deserialize(context, new BsonDeserializationArgs { NominalType = typeof(T) });
+
+        reader.ReadEndDocument();
+        return result;
+    }
+}

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_a_double_concept_stored_as_an_int.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_a_double_concept_stored_as_an_int.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_deserializing_a_double_concept_stored_as_an_int : a_concept_serializer
+{
+    DoubleConcept _result;
+
+    void Because() => _result = Deserialize<DoubleConcept>(42);
+
+    [Fact] void should_coerce_to_the_double_value() => _result.Value.ShouldEqual(42d);
+}

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_a_long_concept_stored_as_a_double.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_a_long_concept_stored_as_a_double.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_deserializing_a_long_concept_stored_as_a_double : a_concept_serializer
+{
+    LongConcept _result;
+
+    void Because() => _result = Deserialize<LongConcept>(42d);
+
+    [Fact] void should_coerce_to_the_long_value() => _result.Value.ShouldEqual(42L);
+}

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_an_int_concept_stored_as_a_double.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_an_int_concept_stored_as_a_double.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_deserializing_an_int_concept_stored_as_a_double : a_concept_serializer
+{
+    IntConcept _result;
+
+    void Because() => _result = Deserialize<IntConcept>(42d);
+
+    [Fact] void should_coerce_to_the_int_value() => _result.Value.ShouldEqual(42);
+}

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_an_int_concept_stored_as_an_int.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_deserializing_an_int_concept_stored_as_an_int.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_deserializing_an_int_concept_stored_as_an_int : a_concept_serializer
+{
+    IntConcept _result;
+
+    void Because() => _result = Deserialize<IntConcept>(42);
+
+    [Fact] void should_read_the_int_value() => _result.Value.ShouldEqual(42);
+}

--- a/Source/DotNET/MongoDB/ConceptSerializer.cs
+++ b/Source/DotNET/MongoDB/ConceptSerializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Cratis.Concepts;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
@@ -154,6 +155,33 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
     /// <inheritdoc/>
     object IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args) => Deserialize(context, args)!;
 
+    /// <summary>
+    /// Reads the numeric value at the reader's current position, tolerating any BSON numeric representation.
+    /// </summary>
+    /// <param name="bsonReader">The <see cref="IBsonReader"/> to read from.</param>
+    /// <returns>The numeric value read, boxed as the CLR type matching its stored BSON representation.</returns>
+    /// <exception cref="UnableToDeserializeValueForConcept">Thrown when the stored BSON type is not numeric.</exception>
+    /// <remarks>
+    /// Values that flow through JSON-based pipelines (for example Chronicle projections that materialize event
+    /// content via <c>ExpandoObject</c>) lose the distinction between integral and floating point numbers and
+    /// are persisted as <see cref="BsonType.Double"/>. Reading them back with a representation-specific reader
+    /// (for example <c>ReadInt32</c>) throws. Reading according to the actual stored BSON type and letting the
+    /// caller convert keeps a concept deserializable regardless of how it was stored.
+    /// </remarks>
+    static object ReadNumeric(ref IBsonReader bsonReader)
+    {
+        var bsonType = bsonReader.GetCurrentBsonType();
+        return bsonType switch
+        {
+            BsonType.Int32 => bsonReader.ReadInt32(),
+            BsonType.Int64 => bsonReader.ReadInt64(),
+            BsonType.Double => bsonReader.ReadDouble(),
+            BsonType.Decimal128 => (decimal)bsonReader.ReadDecimal128(),
+            BsonType.String => double.Parse(bsonReader.ReadString(), NumberStyles.Any, CultureInfo.InvariantCulture),
+            _ => throw new UnableToDeserializeValueForConcept(typeof(object))
+        };
+    }
+
     object GetDeserializedValue(BsonDeserializationContext context, BsonDeserializationArgs args, Type valueType, ref IBsonReader bsonReader)
     {
         var bsonType = bsonReader.CurrentBsonType;
@@ -175,32 +203,32 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
 
         if (valueType == typeof(double))
         {
-            return bsonReader.ReadDouble();
+            return Convert.ToDouble(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(float))
         {
-            return (float)bsonReader.ReadDouble();
+            return Convert.ToSingle(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(int))
         {
-            return bsonReader.ReadInt32();
+            return Convert.ToInt32(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(uint))
         {
-            return (uint)bsonReader.ReadInt64();
+            return Convert.ToUInt32(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(long))
         {
-            return bsonReader.ReadInt64();
+            return Convert.ToInt64(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(ulong))
         {
-            return (ulong)bsonReader.ReadDecimal128();
+            return Convert.ToUInt64(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(bool))
@@ -215,7 +243,7 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
 
         if (valueType == typeof(decimal))
         {
-            return bsonReader.ReadDecimal128();
+            return Convert.ToDecimal(ReadNumeric(ref bsonReader));
         }
 
         if (valueType == typeof(DateTime))


### PR DESCRIPTION
## Fixed

- `ConceptAs<T>` values now deserialize from MongoDB regardless of the stored BSON numeric type. Numeric concepts (for example an `int`-backed concept) read with a representation-specific reader previously threw `ReadInt32 can only be called when CurrentBsonType is Int32, not when CurrentBsonType is Double` when the stored value had a different numeric representation — which happens when integral values flow through JSON-based pipelines (such as Chronicle projections that materialize event content via `ExpandoObject`) and are persisted as `Double`. The value is now read according to its actual stored BSON type and converted to the concept's underlying type.