### PR TITLE
Fix injecting reducer-backed read models into commands

### DIFF
--- a/Documentation/backend/chronicle/read-models.md
+++ b/Documentation/backend/chronicle/read-models.md
@@ -7,18 +7,21 @@ Read Models in Arc provide automatic dependency injection and seamless integrati
 
 ## Overview
 
-Arc automatically registers all read model types and provides them as scoped services in the dependency injection container, tied to the scope the command runs in. When a read model is requested, it uses the resolved identity from the current command context to load the appropriate projection instance. Because `CommandValidator<>`, `Provide()`, and `Handle()` resolve from the same command scope, they receive the same read model instance for the command when it exists.
+Arc automatically registers all read model types and provides them as scoped services in the dependency injection container, tied to the scope the command runs in. When a read model is requested, it uses the resolved identity from the current command context to load the appropriate read model instance — whether that instance is materialized by a projection or a reducer. Because `CommandValidator<>`, `Provide()`, and `Handle()` resolve from the same command scope, they receive the same read model instance for the command when it exists.
 
 A read model can also be missing. A `[Key]` or event source id tells Arc which projection instance to resolve; it does not prove that the projection instance exists. Missing projected state can be a normal business condition, such as "not registered yet", or it can be exceptional, such as a command that targets an event source whose projection is expected to exist. Declare the dependency nullable (`Customer?`, `RoleReadModel?`, and so on) when the command handles absence. Keep it non-nullable when the command requires the projection to exist; if Arc cannot resolve it, the command fails with a clear dependency-resolution error.
 
 ## Automatic Registration
 
-Read models are automatically discovered and registered when you configure Arc. This includes:
+When you add Chronicle to Arc, read models are automatically discovered and registered as command-scoped services. What makes a read model injectable into command-scoped code is that it is **resolvable by key** (the resolved event source id) through Chronicle's read model store. That resolvability comes from a Chronicle backing artifact, so a read model is registered when it has one — **whether or not it is also marked with `[ReadModel]`**:
 
-- Read models from `IProjectionFor<T>` implementations
-- Read models from model-bound projections
+- A fluent `IProjectionFor<T>` projection
+- A model-bound projection
+- An `IReducerFor<T>` reducer
 
-The system will scan for all read model types and register them with the dependency injection container.
+You write the validator, `Provide()`, or `Handle()` dependency the same way in every case — the backing artifact is an implementation detail Arc hides from you.
+
+The `[ReadModel]` attribute alone is **not** enough to make a read model injectable into commands. `[ReadModel]` is an Arc concept used for queries, and it can be backed by stores other than Chronicle (for example Entity Framework Core). A read model has to be resolvable by key for command-scoped injection to make sense, and that key resolution is owned by the backing provider. Chronicle registers the read models it can resolve (the three above); a read model backed by another provider is registered for command injection by that provider, not by Chronicle.
 
 ## Taking Dependencies on Read Models
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/ReducerAccountSummary.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/ReducerAccountSummary.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+using FluentValidation;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario;
+
+/// <summary>
+/// A read model materialized by a reducer (not a projection or model-bound projection).
+/// </summary>
+/// <param name="Balance">The account balance.</param>
+/// <param name="IsFrozen">Whether the account is frozen.</param>
+public record ReducerAccountSummary(decimal Balance, bool IsFrozen);
+
+/// <summary>
+/// The reducer that materializes <see cref="ReducerAccountSummary"/>.
+/// </summary>
+public class ReducerAccountSummaryReducer : IReducerFor<ReducerAccountSummary>;
+
+[Command]
+public record WithdrawFromReducerAccount(EventSourceId EventSourceId)
+{
+    public ReducerFundsWithdrawn Handle() => new();
+}
+
+public class WithdrawFromReducerAccountValidator : CommandValidator<WithdrawFromReducerAccount>
+{
+    public WithdrawFromReducerAccountValidator(ReducerAccountSummary summary) =>
+        RuleFor(command => command.EventSourceId)
+            .Must(_ => !summary.IsFrozen)
+            .WithMessage("Account is frozen.");
+}
+
+[Command]
+public record UseReducerReadModelInHandle(EventSourceId EventSourceId)
+{
+    public ReducerBalanceUsedInHandle Handle(ReducerAccountSummary summary) => new(summary.Balance);
+}
+
+[Command]
+public record UseReducerReadModelInProvide(EventSourceId EventSourceId)
+{
+    public ProvidedReducerBalance Provide(ReducerAccountSummary summary) => new(summary.Balance);
+
+    public ReducerBalanceUsedInProvide Handle(ProvidedReducerBalance balance) => new(balance.Value);
+}
+
+[Command]
+public record UseNullableReducerReadModelInHandle(EventSourceId EventSourceId)
+{
+    public ReducerReadModelAbsence Handle(ReducerAccountSummary? summary) => new(summary is null);
+}
+
+public record ProvidedReducerBalance(decimal Value);
+
+[EventType("c1d2e3f4-0a1b-2c3d-4e5f-60718293a4b5")]
+public record ReducerFundsWithdrawn;
+
+[EventType("d2e3f4a5-1b2c-3d4e-5f60-718293a4b5c6")]
+public record ReducerBalanceUsedInHandle(decimal Balance);
+
+[EventType("e3f4a5b6-2c3d-4e5f-6071-8293a4b5c6d7")]
+public record ReducerBalanceUsedInProvide(decimal Balance);
+
+[EventType("f4a5b6c7-3d4e-5f60-7182-93a4b5c6d7e8")]
+public record ReducerReadModelAbsence(bool WasAbsent);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_handle.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_handle.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_injecting_a_reducer_backed_read_model;
+
+public class into_a_command_handle : Specification
+{
+    CommandScenario<UseReducerReadModelInHandle> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<UseReducerReadModelInHandle>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(ReducerAccountSummary), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new ReducerAccountSummary(250m, false)));
+
+        _scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new UseReducerReadModelInHandle(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_have_appended_the_value_from_the_reducer_backed_read_model() =>
+        await _scenario.ShouldHaveAppendedEvent<UseReducerReadModelInHandle, ReducerBalanceUsedInHandle>(_eventSourceId, @event => @event.Balance == 250m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_provide.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_provide.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_injecting_a_reducer_backed_read_model;
+
+public class into_a_command_provide : Specification
+{
+    CommandScenario<UseReducerReadModelInProvide> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<UseReducerReadModelInProvide>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(ReducerAccountSummary), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new ReducerAccountSummary(175m, false)));
+
+        _scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new UseReducerReadModelInProvide(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_have_appended_the_value_from_the_reducer_backed_read_model() =>
+        await _scenario.ShouldHaveAppendedEvent<UseReducerReadModelInProvide, ReducerBalanceUsedInProvide>(_eventSourceId, @event => @event.Balance == 175m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_validator/and_account_is_active.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_validator/and_account_is_active.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_injecting_a_reducer_backed_read_model.into_a_command_validator;
+
+public class and_account_is_active : Specification
+{
+    CommandScenario<WithdrawFromReducerAccount> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFromReducerAccount>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(ReducerAccountSummary), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new ReducerAccountSummary(100m, false)));
+
+        _scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFromReducerAccount(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_validation_errors() => _result.ValidationResults.ShouldBeEmpty();
+    [Fact] async Task should_have_appended_the_event() => await _scenario.ShouldHaveAppendedEvent<WithdrawFromReducerAccount, ReducerFundsWithdrawn>(_eventSourceId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_validator/and_account_is_frozen.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_command_validator/and_account_is_frozen.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_injecting_a_reducer_backed_read_model.into_a_command_validator;
+
+public class and_account_is_frozen : Specification
+{
+    CommandScenario<WithdrawFromReducerAccount> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFromReducerAccount>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(ReducerAccountSummary), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(new ReducerAccountSummary(100m, true)));
+
+        _scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFromReducerAccount(_eventSourceId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_validation_errors() => _result.ValidationResults.ShouldNotBeEmpty();
+    [Fact] void should_have_validation_error_from_the_reducer_backed_read_model() => _result.ValidationResults.First().Message.ShouldEqual("Account is frozen.");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_nullable_handle_parameter_and_the_read_model_does_not_exist.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_injecting_a_reducer_backed_read_model/into_a_nullable_handle_parameter_and_the_read_model_does_not_exist.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_injecting_a_reducer_backed_read_model;
+
+public class into_a_nullable_handle_parameter_and_the_read_model_does_not_exist : Specification
+{
+    CommandScenario<UseNullableReducerReadModelInHandle> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<UseNullableReducerReadModelInHandle>();
+
+        var readModels = Substitute.For<IReadModels>();
+        readModels
+            .GetInstanceById(typeof(ReducerAccountSummary), _eventSourceId, default)
+            .Returns(Task.FromResult<object>(null!));
+
+        _scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new UseNullableReducerReadModelInHandle(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_inject_null_for_the_missing_reducer_backed_read_model() =>
+        await _scenario.ShouldHaveAppendedEvent<UseNullableReducerReadModelInHandle, ReducerReadModelAbsence>(_eventSourceId, @event => @event.WasAbsent);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ModelBoundReadModel.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ModelBoundReadModel.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+/// <summary>
+/// A read model materialized by a model-bound projection.
+/// </summary>
+/// <param name="Value">The value of the read model.</param>
+public record ModelBoundReadModel(string Value);

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ProjectionForReadModel.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ProjectionForReadModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+/// <summary>
+/// A projection for the <see cref="ProjectionReadModel"/>.
+/// </summary>
+public class ProjectionForReadModel : IProjectionFor<ProjectionReadModel>
+{
+    /// <inheritdoc/>
+    public void Define(IProjectionBuilderFor<ProjectionReadModel> builder)
+    {
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ProjectionReadModel.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ProjectionReadModel.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+/// <summary>
+/// A read model materialized by a projection.
+/// </summary>
+/// <param name="Value">The value of the read model.</param>
+public record ProjectionReadModel(string Value);

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ReducerForReadModel.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ReducerForReadModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+/// <summary>
+/// A reducer for the <see cref="ReducerReadModel"/>.
+/// </summary>
+public class ReducerForReadModel : IReducerFor<ReducerReadModel>;

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ReducerReadModel.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/ReducerReadModel.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions;
+
+/// <summary>
+/// A read model materialized by a reducer.
+/// </summary>
+/// <param name="Value">The value of the read model.</param>
+public record ReducerReadModel(string Value);

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_adding_read_models.cs
@@ -14,8 +14,9 @@ public class when_adding_read_models : Specification
     void Establish()
     {
         var clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
-        clientArtifactsProvider.Projections.Returns([]);
-        clientArtifactsProvider.ModelBoundProjections.Returns([]);
+        clientArtifactsProvider.Projections.Returns([typeof(ProjectionForReadModel)]);
+        clientArtifactsProvider.ModelBoundProjections.Returns([typeof(ModelBoundReadModel)]);
+        clientArtifactsProvider.Reducers.Returns([typeof(ReducerForReadModel)]);
 
         _services = new ServiceCollection();
         _services.AddReadModels(clientArtifactsProvider);
@@ -25,4 +26,13 @@ public class when_adding_read_models : Specification
         _services.ShouldContain(_ =>
             _.ServiceType == typeof(IInterceptReadModel<>) &&
             _.ImplementationType == typeof(ReadModelInterceptor<>));
+
+    [Fact] void should_register_scoped_resolver_for_projection_read_model() =>
+        _services.ShouldContain(_ => _.ServiceType == typeof(ProjectionReadModel) && _.Lifetime == ServiceLifetime.Scoped);
+
+    [Fact] void should_register_scoped_resolver_for_model_bound_read_model() =>
+        _services.ShouldContain(_ => _.ServiceType == typeof(ModelBoundReadModel) && _.Lifetime == ServiceLifetime.Scoped);
+
+    [Fact] void should_register_scoped_resolver_for_reducer_read_model() =>
+        _services.ShouldContain(_ => _.ServiceType == typeof(ReducerReadModel) && _.Lifetime == ServiceLifetime.Scoped);
 }

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/and_the_read_model_is_materialized.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/and_the_read_model_is_materialized.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions.when_resolving_a_reducer_read_model_through_di;
+
+public class and_the_read_model_is_materialized : given.registered_read_models
+{
+    ReducerReadModel _materialized;
+
+    void Establish()
+    {
+        _materialized = new ReducerReadModel("materialized");
+        _readModels.GetInstanceById(typeof(ReducerReadModel), _eventSourceId, default).Returns(Task.FromResult<object>(_materialized));
+    }
+
+    void Because() => ResolveReducerReadModel();
+
+    [Fact] void should_resolve_the_materialized_instance() => _resolved.ShouldEqual(_materialized);
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/and_the_read_model_is_not_materialized.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/and_the_read_model_is_not_materialized.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions.when_resolving_a_reducer_read_model_through_di;
+
+public class and_the_read_model_is_not_materialized : given.registered_read_models
+{
+    void Establish() =>
+        _readModels.GetInstanceById(typeof(ReducerReadModel), _eventSourceId, default).Returns(Task.FromResult<object>(null!));
+
+    void Because() => ResolveReducerReadModel();
+
+    [Fact] void should_resolve_to_null() => _resolved.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/given/registered_read_models.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_a_reducer_read_model_through_di/given/registered_read_models.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Chronicle;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions.when_resolving_a_reducer_read_model_through_di.given;
+
+public class registered_read_models : Specification
+{
+    protected EventSourceId _eventSourceId;
+    protected IReadModels _readModels;
+    protected ServiceProvider _serviceProvider;
+    protected IServiceScope _scope;
+    protected object? _resolved;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _readModels = Substitute.For<IReadModels>();
+
+        var clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
+        clientArtifactsProvider.Projections.Returns([]);
+        clientArtifactsProvider.ModelBoundProjections.Returns([]);
+        clientArtifactsProvider.Reducers.Returns([typeof(ReducerForReadModel)]);
+
+        var services = new ServiceCollection();
+        services.AddReadModels(clientArtifactsProvider);
+        services.AddSingleton(_readModels);
+        services.AddScoped(_ => CreateCommandContext(_eventSourceId));
+
+        _serviceProvider = services.BuildServiceProvider();
+        _scope = _serviceProvider.CreateScope();
+    }
+
+    void Destroy()
+    {
+        _scope?.Dispose();
+        _serviceProvider?.Dispose();
+    }
+
+    protected void ResolveReducerReadModel() =>
+        _resolved = _scope.ServiceProvider.GetService(typeof(ReducerReadModel));
+
+    static CommandContext CreateCommandContext(EventSourceId eventSourceId)
+    {
+        var commandContextValues = new CommandContextValues
+        {
+            { WellKnownCommandContextKeys.EventSourceId, eventSourceId }
+        };
+
+        return new CommandContext(CorrelationId.New(), typeof(TestCommand), new TestCommand(), [], commandContextValues, null);
+    }
+
+    protected record TestCommand;
+}

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Cratis.Chronicle;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Reducers;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -37,24 +38,28 @@ public static class ReadModelServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add to.</param>
     /// <param name="clientArtifactsProvider">The <see cref="IClientArtifactsProvider"/> for client artifacts.</param>
     /// <returns>The service collection for continuation.</returns>
+    /// <remarks>
+    /// A read model is injectable into command-scoped code (a <c>CommandValidator&lt;&gt;</c>, <c>Provide()</c>, or
+    /// <c>Handle()</c>) because it is resolvable by key (the resolved event source id) through <see cref="IReadModels"/>.
+    /// What makes a read model resolvable that way is a Chronicle backing artifact, so this registers every read model
+    /// that has a projection, model-bound projection, or reducer — independent of whether it also carries the Arc-level
+    /// <c>[ReadModel]</c> attribute. It deliberately does not register read models by <c>[ReadModel]</c> alone: that
+    /// attribute is an Arc concept that does not imply Chronicle key resolution, and a read model backed by another
+    /// provider (for example Entity Framework Core) is registered by that provider, not here.
+    /// </remarks>
     public static IServiceCollection AddReadModels(this IServiceCollection services, IClientArtifactsProvider clientArtifactsProvider)
     {
         services.TryAddEnumerable(ServiceDescriptor.Transient(typeof(IInterceptReadModel<>), typeof(ReadModelInterceptor<>)));
 
-        var readModelTypesFromProjections = clientArtifactsProvider.Projections
-            .Select(projectionType =>
-            {
-                var projectionInterface = projectionType.GetInterfaces()
-                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IProjectionFor<>));
-                return projectionInterface?.GetGenericArguments()[0];
-            })
-            .Where(type => type?.IsClass == true && !type.IsAbstract)
-            .Cast<Type>();
-
         var modelBoundReadModels = clientArtifactsProvider.ModelBoundProjections
             .Where(type => type.IsClass && !type.IsAbstract);
-        var readModelTypes = readModelTypesFromProjections
+
+        // A read model is registered for command-scope resolution because it is resolvable by key through
+        // IReadModels. That resolvability comes from a Chronicle backing artifact, so the set is the union of the
+        // read model types behind each backing kind. Adding a future backing kind is one more ReadModelTargetsFrom.
+        var readModelTypes = ReadModelTargetsFrom(clientArtifactsProvider.Projections, typeof(IProjectionFor<>))
             .Concat(modelBoundReadModels)
+            .Concat(ReadModelTargetsFrom(clientArtifactsProvider.Reducers, typeof(IReducerFor<>)))
             .Distinct()
             .ToArray();
         foreach (var readModelType in readModelTypes)
@@ -95,6 +100,21 @@ public static class ReadModelServiceCollectionExtensions
             ? readModel
             : ReleaseReadModel(readModels, readModelType, readModel);
     }
+
+    /// <summary>
+    /// Extracts the read model target types behind a set of backing artifacts that implement a given open generic
+    /// interface (for example <see cref="IProjectionFor{T}"/> or <see cref="IReducerFor{T}"/>).
+    /// </summary>
+    /// <param name="artifactTypes">The backing artifact types to inspect.</param>
+    /// <param name="openGenericInterface">The open generic interface whose single type argument is the read model type.</param>
+    /// <returns>The concrete read model types behind the artifacts.</returns>
+    static IEnumerable<Type> ReadModelTargetsFrom(IEnumerable<Type> artifactTypes, Type openGenericInterface) =>
+        artifactTypes
+            .Select(artifactType => artifactType.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == openGenericInterface)
+                ?.GetGenericArguments()[0])
+            .Where(type => type?.IsClass == true && !type.IsAbstract)
+            .Cast<Type>();
 
     static object ReleaseReadModel(IReadModels readModels, Type readModelType, object readModel)
     {


### PR DESCRIPTION
## Fixed
- Injecting a reducer-backed (`IReducerFor<T>`) read model into a command's `CommandValidator<>`, `Provide()`, or `Handle()` no longer fails at runtime. Reducer-backed read models are now registered for command-scope resolution and resolve by key just like projection-backed and model-bound read models, including the nullable "does not exist" behavior.