### PR TITLE
Fix CommandForm currentValues binding

### DIFF
--- a/Source/JavaScript/Arc.React.MVVM/for_withViewModel/when_exporting_observer.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_withViewModel/when_exporting_observer.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { observer } from '../index';
+
+describe('when exporting observer', () => {
+    it('should export the mobx observer function', () => {
+        observer.should.be.a('function');
+    });
+});

--- a/Source/JavaScript/Arc.React.MVVM/index.ts
+++ b/Source/JavaScript/Arc.React.MVVM/index.ts
@@ -15,6 +15,7 @@ export * from './IHandleQueryParams';
 export * from './params';
 export * from './queryParams';
 export * from './props';
+export { observer } from 'mobx-react';
 
 export {
     browser,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -129,8 +129,8 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
     const valuesFromCurrentValues = useMemo(() => {
         if (!props.currentValues) return {};
 
-        const tempCommand = new props.command();
-        const commandProperties = ((tempCommand as Record<string, unknown>).properties || []) as string[];
+        const tempCommand = new props.command() as Command;
+        const commandProperties = tempCommand.propertyDescriptors.map(propertyDescriptor => propertyDescriptor.name);
         const extracted: Partial<TCommand> = {};
 
         commandProperties.forEach((propertyName: string) => {

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/TestCommand.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/TestCommand.ts
@@ -29,10 +29,6 @@ export class TestCommand extends Command<TestCommandContent> {
     email?: string;
     age?: number;
 
-    get properties(): string[] {
-        return ['name', 'email', 'age'];
-    }
-
     get requestParameters(): string[] {
         return [];
     }

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { CommandForm, useCommandFormContext, useCommandInstance } from '../CommandForm';
+import { Command } from '@cratis/arc/commands';
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { a_command_form_context } from './given/a_command_form_context';
+import { given } from '../../../given';
+
+class RequiredNameCommand extends Command {
+    readonly route = '/api/test';
+    readonly propertyDescriptors: PropertyDescriptor[] = [
+        new PropertyDescriptor('name', String, false)
+    ];
+
+    name = '';
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+describe("when currentValues are used without fields", given(a_command_form_context, context => {
+    let capturedCommand: RequiredNameCommand | null = null;
+    let capturedIsValid: boolean | undefined;
+
+    const ContextCapture = () => {
+        capturedCommand = useCommandInstance<RequiredNameCommand>();
+        capturedIsValid = useCommandFormContext().isValid;
+        return React.createElement('div');
+    };
+
+    beforeEach(() => {
+        capturedCommand = null;
+        capturedIsValid = undefined;
+
+        render(
+            React.createElement(
+                CommandForm,
+                {
+                    command: RequiredNameCommand,
+                    currentValues: { name: 'Jane' }
+                },
+                React.createElement(ContextCapture)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+    });
+
+    it("should set command properties from currentValues", () => {
+        capturedCommand!.name.should.equal('Jane');
+    });
+
+    it("should report the form as valid", async () => {
+        await waitFor(() => {
+            expect(capturedIsValid).toBe(true);
+        }, { timeout: 2000 });
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_initializing_with_current_values.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_initializing_with_current_values.ts
@@ -2,33 +2,64 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { CommandForm, useCommandInstance } from '../CommandForm';
+import { asCommandFormField } from '../asCommandFormField';
 import { TestCommand } from './TestCommand';
 import { a_command_form_context } from './given/a_command_form_context';
 import { given } from '../../../given';
 
+const SimpleTextField = asCommandFormField<{ value: unknown; onChange: (value: unknown) => void; invalid: boolean; required: boolean; errors: string[]; 'data-testid'?: string }>(
+    (props) => {
+        return React.createElement('input', {
+            type: 'text',
+            value: (props.value ?? '') as string | number,
+            onChange: props.onChange,
+            'data-testid': props['data-testid']
+        });
+    },
+    {
+        defaultValue: '',
+        extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value
+    }
+);
+
 describe("when initializing with current values", given(a_command_form_context, context => {
     let capturedCommand: TestCommand | null = null;
+    let renderResult: ReturnType<typeof render>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         const TestComponent = () => {
             const command = useCommandInstance<TestCommand>();
             capturedCommand = command;
             return React.createElement('div');
         };
 
-        render(
+        renderResult = render(
             React.createElement(
                 CommandForm,
                 {
                     command: TestCommand,
                     currentValues: { name: 'Jane', age: 30 }
                 },
-                React.createElement(TestComponent)
+                React.createElement(TestComponent),
+                React.createElement(SimpleTextField, {
+                    value: (c: TestCommand) => c.name,
+                    title: 'Name',
+                    'data-testid': 'name-input'
+                }),
+                React.createElement(SimpleTextField, {
+                    value: (c: TestCommand) => c.age,
+                    title: 'Age',
+                    'data-testid': 'age-input'
+                })
             ),
             { wrapper: context.createWrapper() }
         );
+
+        await waitFor(() => {
+            expect(capturedCommand!.name).toBe('Jane');
+        });
     });
 
     it("should set name from current values", () => {
@@ -37,5 +68,13 @@ describe("when initializing with current values", given(a_command_form_context, 
 
     it("should set age from current values", () => {
         capturedCommand!.age!.should.equal(30);
+    });
+
+    it("should render field values from current values", () => {
+        const nameInput = renderResult.getByTestId('name-input') as HTMLInputElement;
+        const ageInput = renderResult.getByTestId('age-input') as HTMLInputElement;
+
+        nameInput.value.should.equal('Jane');
+        ageInput.value.should.equal('30');
     });
 }));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_validateOnInit_is_true_with_currentValues.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_validateOnInit_is_true_with_currentValues.ts
@@ -29,10 +29,6 @@ class ValidatedTestCommand extends Command {
     name = '';
     email = '';
 
-    get properties(): string[] {
-        return ['name', 'email'];
-    }
-
     get requestParameters(): string[] {
         return [];
     }


### PR DESCRIPTION
## Summary
- Use command propertyDescriptors when applying CommandForm currentValues
- Add regression coverage for edit-form prefill, no-field currentValues validation, and currentValues validation without legacy properties getters
- Re-export mobx observer from arc.react.mvvm for child view-model components

## Verification
- yarn test -- commands/CommandForm/for_CommandForm/when_initializing_with_current_values.ts commands/CommandForm/for_CommandForm/when_currentValues_changes.ts commands/CommandForm/for_CommandForm/when_initial_values_and_current_values_both_provided.ts commands/CommandForm/for_CommandForm/when_validateOnInit_is_true_with_currentValues.ts commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
- yarn test -- for_withViewModel/when_exporting_observer.ts
- yarn tsc -p Source/JavaScript/Arc.React/tsconfig.json --noEmit
- yarn tsc -p Source/JavaScript/Arc.React.MVVM/tsconfig.json --noEmit
- yarn build (Source/JavaScript/Arc.React)
- yarn build (Source/JavaScript/Arc.React.MVVM)
