### PR TITLE
Revalidate CommandForm currentValues updates

### DIFF
--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -166,6 +166,18 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
     const lastServerValidateVersion = React.useRef<number>(-1);
     const serverValidateThrottleTimer = React.useRef<NodeJS.Timeout | null>(null);
 
+    const validateSilently = useCallback(async (showErrors: boolean) => {
+        if (commandInstance && typeof (commandInstance as Record<string, unknown>).validate === 'function') {
+            const validationResult = await ((commandInstance as Record<string, unknown>).validate as () => Promise<ICommandResult<unknown>>)();
+            if (validationResult) {
+                setSilentValidationResult(validationResult);
+                if (showErrors) {
+                    setCommandResult(validationResult);
+                }
+            }
+        }
+    }, [commandInstance]);
+
     // Update command values when mergedInitialValues changes (e.g., when data loads asynchronously)
     // When using currentValues, always update when they change (reactive mode for editing)
     // When using initialValues only, set values once on mount
@@ -182,25 +194,17 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
             setCommandValues(mergedInitialValues as TCommand);
         }
 
-        // Always run silent client validation on init to determine if the form is valid.
+        // Always run silent client validation on init and after currentValues changes to determine if the form is valid.
         // This ensures isValid reflects the real validity state from the first render,
         // even when no error messages are shown yet.
         // Error messages are only rendered (via commandResult) when validateOnInit is true.
-        if (!initializedRef.current && commandInstance && typeof (commandInstance as Record<string, unknown>).validate === 'function') {
+        if (!initializedRef.current) {
             initializedRef.current = true;
-            void (async () => {
-                const validationResult = await ((commandInstance as Record<string, unknown>).validate as () => Promise<ICommandResult<unknown>>)();
-                if (validationResult) {
-                    setSilentValidationResult(validationResult);
-                    if (props.validateOnInit) {
-                        setCommandResult(validationResult);
-                    }
-                }
-            })();
-        } else if (!initializedRef.current) {
-            initializedRef.current = true;
+            void validateSilently(props.validateOnInit ?? false);
+        } else if (hasCurrentValues) {
+            void validateSilently(props.validateOnInit ?? false);
         }
-    }, [mergedInitialValues, props.validateOnInit, props.currentValues, commandInstance, setCommandValues]);
+    }, [mergedInitialValues, props.validateOnInit, props.currentValues, setCommandValues, validateSilently]);
 
     // isValid is driven exclusively by silentValidationResult which is updated on mount and
     // after every field value change. commandResult only controls error message display.

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { CommandForm, useCommandFormContext, useCommandInstance } from '../CommandForm';
 import { Command } from '@cratis/arc/commands';
 import { PropertyDescriptor } from '@cratis/arc/reflection';
@@ -60,6 +60,113 @@ describe("when currentValues are used without fields", given(a_command_form_cont
     it("should report the form as valid", async () => {
         await waitFor(() => {
             expect(capturedIsValid).toBe(true);
+        }, { timeout: 2000 });
+    });
+}));
+
+describe("when currentValues change without fields", given(a_command_form_context, context => {
+    let capturedCommand: RequiredNameCommand | null = null;
+    let capturedIsValid: boolean | undefined;
+    let renderResult: ReturnType<typeof render>;
+
+    const ContextCapture = () => {
+        capturedCommand = useCommandInstance<RequiredNameCommand>();
+        capturedIsValid = useCommandFormContext().isValid;
+        return React.createElement('div');
+    };
+
+    const TestWrapper = () => {
+        const [currentValues, setCurrentValues] = useState({ name: '' });
+
+        return React.createElement(
+            CommandForm,
+            {
+                command: RequiredNameCommand,
+                currentValues
+            },
+            React.createElement(ContextCapture),
+            React.createElement('button', {
+                type: 'button',
+                onClick: () => setCurrentValues({ name: 'Jane' }),
+                'data-testid': 'set-valid-values'
+            }, 'Set valid values')
+        );
+    };
+
+    beforeEach(async () => {
+        capturedCommand = null;
+        capturedIsValid = undefined;
+
+        renderResult = render(
+            React.createElement(TestWrapper),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => {
+            expect(capturedIsValid).toBe(false);
+        }, { timeout: 2000 });
+
+        fireEvent.click(renderResult.getByTestId('set-valid-values'));
+    });
+
+    it("should update command properties from new currentValues", async () => {
+        await waitFor(() => {
+            expect(capturedCommand!.name).toBe('Jane');
+        }, { timeout: 2000 });
+    });
+
+    it("should revalidate the command and report the form as valid", async () => {
+        await waitFor(() => {
+            expect(capturedIsValid).toBe(true);
+        }, { timeout: 2000 });
+    });
+}));
+
+describe("when currentValues become invalid without fields", given(a_command_form_context, context => {
+    let capturedIsValid: boolean | undefined;
+    let renderResult: ReturnType<typeof render>;
+
+    const ContextCapture = () => {
+        capturedIsValid = useCommandFormContext().isValid;
+        return React.createElement('div');
+    };
+
+    const TestWrapper = () => {
+        const [currentValues, setCurrentValues] = useState({ name: 'Jane' });
+
+        return React.createElement(
+            CommandForm,
+            {
+                command: RequiredNameCommand,
+                currentValues
+            },
+            React.createElement(ContextCapture),
+            React.createElement('button', {
+                type: 'button',
+                onClick: () => setCurrentValues({ name: '' }),
+                'data-testid': 'set-invalid-values'
+            }, 'Set invalid values')
+        );
+    };
+
+    beforeEach(async () => {
+        capturedIsValid = undefined;
+
+        renderResult = render(
+            React.createElement(TestWrapper),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => {
+            expect(capturedIsValid).toBe(true);
+        }, { timeout: 2000 });
+
+        fireEvent.click(renderResult.getByTestId('set-invalid-values'));
+    });
+
+    it("should revalidate the command and report the form as invalid", async () => {
+        await waitFor(() => {
+            expect(capturedIsValid).toBe(false);
         }, { timeout: 2000 });
     });
 }));


### PR DESCRIPTION
## Summary
- Re-run silent command validation after reactive currentValues updates
- Keep CommandForm isValid accurate for no-field/custom-control dialogs when external state changes
- Add regressions for invalid-to-valid and valid-to-invalid currentValues changes without fields

## Verification
- yarn test (Source/JavaScript/Arc.React)
- yarn tsc -p Source/JavaScript/Arc.React/tsconfig.json --noEmit
- yarn build (Source/JavaScript/Arc.React)
