### PR TITLE
Align command validation and currentValues nullish handling

### DIFF
--- a/Documentation/frontend/react/command-form/validation.md
+++ b/Documentation/frontend/react/command-form/validation.md
@@ -183,8 +183,11 @@ Mark fields as required using the `required` prop:
 
 Required fields:
 - Show visual indicator when invalid
-- Prevent form submission when empty
-- Display error messages when validation fails
+- Mark field controls as required
+- Display error messages when validation rules fail
+- Should be paired with explicit command validation rules when empty strings must be invalid
+
+Non-nullable command properties are treated as required for command payload presence, but empty strings are valid string values unless a validation rule rejects them. Use `[Required]`, FluentValidation `NotEmpty()`, or generated client validators when empty or whitespace-only strings should fail before submit.
 
 ## Automatic Error Display
 
@@ -292,7 +295,7 @@ public record CreateUser(string Email, string Username)
 ```
 
 When the form is submitted:
-1. Frontend validation runs first (required, type checking)
+1. Generated frontend validation rules run first
 2. Command is sent to backend if frontend validation passes
 3. Backend validation rules execute
 4. Validation errors are returned and displayed in the form

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -134,7 +134,7 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
         const extracted: Partial<TCommand> = {};
 
         commandProperties.forEach((propertyName: string) => {
-            if ((props.currentValues as Record<string, unknown>)[propertyName] !== undefined) {
+            if (Object.prototype.hasOwnProperty.call(props.currentValues, propertyName)) {
                 (extracted as Record<string, unknown>)[propertyName] = (props.currentValues as Record<string, unknown>)[propertyName];
             }
         });

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_are_used_without_fields.ts
@@ -4,13 +4,14 @@
 import React, { useState } from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { CommandForm, useCommandFormContext, useCommandInstance } from '../CommandForm';
-import { Command } from '@cratis/arc/commands';
+import { Command, CommandValidator } from '@cratis/arc/commands';
 import { PropertyDescriptor } from '@cratis/arc/reflection';
 import { a_command_form_context } from './given/a_command_form_context';
 import { given } from '../../../given';
 
 class RequiredNameCommand extends Command {
     readonly route = '/api/test';
+    readonly validation = new RequiredNameCommandValidator();
     readonly propertyDescriptors: PropertyDescriptor[] = [
         new PropertyDescriptor('name', String, false)
     ];
@@ -23,6 +24,13 @@ class RequiredNameCommand extends Command {
 
     constructor() {
         super(Object, false);
+    }
+}
+
+class RequiredNameCommandValidator extends CommandValidator<RequiredNameCommand> {
+    constructor() {
+        super();
+        this.ruleFor(c => c.name).notEmpty();
     }
 }
 

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_changes.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_currentValues_changes.ts
@@ -82,3 +82,93 @@ describe("when currentValues changes", given(a_command_form_context, context => 
         input.value.should.equal('Updated Name');
     });
 }));
+
+describe("when currentValues clear a property to null", given(a_command_form_context, context => {
+    let capturedCommand: TestCommand | null = null;
+    let renderResult: ReturnType<typeof render>;
+
+    beforeEach(async () => {
+        const TestWrapper = () => {
+            const [currentData, setCurrentData] = useState<Partial<TestCommand>>({ name: 'Initial Name' });
+
+            const TestComponent = () => {
+                const command = useCommandInstance<TestCommand>();
+                capturedCommand = command;
+                return React.createElement('button', {
+                    onClick: () => setCurrentData({ name: null as unknown as string }),
+                    'data-testid': 'clear-button'
+                }, 'Clear');
+            };
+
+            return React.createElement(
+                CommandForm,
+                { command: TestCommand, currentValues: currentData },
+                React.createElement(TestComponent)
+            );
+        };
+
+        renderResult = render(
+            React.createElement(TestWrapper),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => {
+            return capturedCommand !== null;
+        });
+
+        fireEvent.click(renderResult.getByTestId('clear-button'));
+
+        await waitFor(() => {
+            expect(capturedCommand!.name).toBeNull();
+        });
+    });
+
+    it("should update command instance with null value", () => {
+        expect(capturedCommand!.name).toBeNull();
+    });
+}));
+
+describe("when currentValues clear a property to undefined", given(a_command_form_context, context => {
+    let capturedCommand: TestCommand | null = null;
+    let renderResult: ReturnType<typeof render>;
+
+    beforeEach(async () => {
+        const TestWrapper = () => {
+            const [currentData, setCurrentData] = useState<Partial<TestCommand>>({ name: 'Initial Name' });
+
+            const TestComponent = () => {
+                const command = useCommandInstance<TestCommand>();
+                capturedCommand = command;
+                return React.createElement('button', {
+                    onClick: () => setCurrentData({ name: undefined }),
+                    'data-testid': 'clear-button'
+                }, 'Clear');
+            };
+
+            return React.createElement(
+                CommandForm,
+                { command: TestCommand, currentValues: currentData },
+                React.createElement(TestComponent)
+            );
+        };
+
+        renderResult = render(
+            React.createElement(TestWrapper),
+            { wrapper: context.createWrapper() }
+        );
+
+        await waitFor(() => {
+            return capturedCommand !== null;
+        });
+
+        fireEvent.click(renderResult.getByTestId('clear-button'));
+
+        await waitFor(() => {
+            expect(capturedCommand!.name).toBeUndefined();
+        });
+    });
+
+    it("should update command instance with undefined value", () => {
+        expect(capturedCommand!.name).toBeUndefined();
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/for_useCommand/when_setting_values.ts
+++ b/Source/JavaScript/Arc.React/commands/for_useCommand/when_setting_values.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { useCommand } from '../useCommand';
+import { FakeCommand, FakeCommandContent } from './FakeCommand';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+
+describe('when setting command values', () => {
+    let capturedCommand: FakeCommand | null = null;
+    let renderResult: ReturnType<typeof render>;
+
+    const initialValues: FakeCommandContent = {
+        someProperty: 'initial-value',
+        anotherProperty: 42
+    };
+
+    const TestComponent = () => {
+        const [command, setCommandValues] = useCommand(FakeCommand, initialValues);
+        capturedCommand = command;
+
+        return React.createElement(
+            React.Fragment,
+            null,
+            React.createElement('button', {
+                onClick: () => setCommandValues({ someProperty: null as unknown as string }),
+                'data-testid': 'set-null'
+            }, 'Set null'),
+            React.createElement('button', {
+                onClick: () => setCommandValues({ someProperty: undefined }),
+                'data-testid': 'set-undefined'
+            }, 'Set undefined'),
+            React.createElement('button', {
+                onClick: () => setCommandValues({ anotherProperty: 24 }),
+                'data-testid': 'set-omitted'
+            }, 'Set omitted')
+        );
+    };
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com'
+    };
+
+    beforeEach(() => {
+        capturedCommand = null;
+        renderResult = render(
+            React.createElement(
+                ArcContext.Provider,
+                { value: config },
+                React.createElement(TestComponent)
+            )
+        );
+    });
+
+    it('should set explicit null values', async () => {
+        fireEvent.click(renderResult.getByTestId('set-null'));
+
+        await waitFor(() => {
+            expect(capturedCommand!.someProperty).toBeNull();
+        });
+    });
+
+    it('should set explicit undefined values', async () => {
+        fireEvent.click(renderResult.getByTestId('set-undefined'));
+
+        await waitFor(() => {
+            expect(capturedCommand!.someProperty).toBeUndefined();
+        });
+    });
+
+    it('should leave omitted properties unchanged', async () => {
+        fireEvent.click(renderResult.getByTestId('set-omitted'));
+
+        await waitFor(() => {
+            expect(capturedCommand!.anotherProperty).toBe(24);
+        });
+        capturedCommand!.someProperty!.should.equal('initial-value');
+    });
+});

--- a/Source/JavaScript/Arc.React/commands/useCommand.ts
+++ b/Source/JavaScript/Arc.React/commands/useCommand.ts
@@ -57,7 +57,7 @@ export function useCommand<
     const setCommandValues = useCallback((values: TCommandContent) => {
         const valuesRecord = values as Record<string, unknown>;
         command!.current!.propertyDescriptors.forEach((propertyDescriptor) => {
-            if (valuesRecord[propertyDescriptor.name] !== undefined && valuesRecord[propertyDescriptor.name] != null) {
+            if (Object.prototype.hasOwnProperty.call(valuesRecord, propertyDescriptor.name)) {
                 (command.current as Record<string, unknown>)[propertyDescriptor.name] = valuesRecord[propertyDescriptor.name];
             }
         });

--- a/Source/JavaScript/Arc/commands/Command.ts
+++ b/Source/JavaScript/Arc/commands/Command.ts
@@ -135,7 +135,7 @@ export abstract class Command<TCommandContent = object, TCommandResponse = objec
         this.propertyDescriptors.forEach(propertyDescriptor => {
             if (!propertyDescriptor.isOptional && !this.requestParameters.includes(propertyDescriptor.name)) {
                 const value = this[propertyDescriptor.name];
-                if (value === undefined || value === null || value === '') {
+                if (value === undefined || value === null) {
                     validationErrors.push(new ValidationResult(
                         ValidationResultSeverity.Error,
                         `${propertyDescriptor.name} is required`,

--- a/Source/JavaScript/Arc/commands/for_Command/when_executing/with_empty_required_string_property.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_executing/with_empty_required_string_property.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+import { a_command } from '../given/a_command';
+
+describe("when executing with empty required string property", given(class extends a_command {
+    constructor() {
+        super();
+        this.command.someProperty = '';
+    }
+}, context => {
+    let result: CommandResult<object>;
+    const responseData = {
+        correlationId: '12345678-1234-1234-1234-123456789012',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        response: {}
+    };
+
+    beforeEach(async () => {
+        context.fetchStub.resolves({
+            status: 200,
+            json: async () => responseData
+        });
+
+        result = await context.command.execute();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should call fetch", () => context.fetchStub.calledOnce.should.be.true);
+    it("should return valid result", () => result.isValid.should.be.true);
+    it("should send empty string value", () => {
+        const call = context.fetchStub.getCall(0);
+        const body = JSON.parse(call.args[1].body);
+        body.someProperty.should.equal('');
+    });
+}));

--- a/Source/JavaScript/Arc/commands/for_Command/when_executing/with_null_required_property.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_executing/with_null_required_property.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+import { a_command } from '../given/a_command';
+
+describe("when executing with null required property", given(class extends a_command {
+    constructor() {
+        super();
+        this.command.someProperty = null as unknown as string;
+    }
+}, context => {
+    let result: CommandResult<object>;
+
+    beforeEach(async () => {
+        result = await context.command.execute();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should not call fetch", () => context.fetchStub.called.should.be.false);
+    it("should return invalid result", () => result.isValid.should.be.false);
+    it("should have validation error", () => result.validationResults.length.should.equal(1));
+    it("should have validation message for property", () => result.validationResults[0].message.should.equal('someProperty is required'));
+    it("should have validation member for property", () => result.validationResults[0].members[0].should.equal('someProperty'));
+}));

--- a/Source/JavaScript/Arc/commands/for_Command/when_validating/with_empty_required_string_property.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_validating/with_empty_required_string_property.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+import { a_command } from '../given/a_command';
+
+describe("when validating with empty required string property", given(class extends a_command {
+    constructor() {
+        super();
+        this.command.someProperty = '';
+    }
+}, context => {
+    let result: CommandResult<object>;
+    const responseData = {
+        correlationId: '12345678-1234-1234-1234-123456789012',
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        response: {}
+    };
+
+    beforeEach(async () => {
+        context.fetchStub.resolves({
+            status: 200,
+            json: async () => responseData
+        });
+
+        result = await context.command.validate();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should call server", () => context.fetchStub.calledOnce.should.be.true);
+    it("should call validation endpoint", () => context.fetchStub.getCall(0).args[0].toString().should.equal('http://localhost/api/test-route/validate'));
+    it("should return valid result", () => result.isValid.should.be.true);
+    it("should send empty string value", () => {
+        const call = context.fetchStub.getCall(0);
+        const body = JSON.parse(call.args[1].body);
+        body.someProperty.should.equal('');
+    });
+}));

--- a/Source/JavaScript/Arc/commands/for_Command/when_validating/with_null_required_property.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_validating/with_null_required_property.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+import { a_command } from '../given/a_command';
+
+describe("when validating with null required property", given(class extends a_command {
+    constructor() {
+        super();
+        this.command.someProperty = null as unknown as string;
+    }
+}, context => {
+    let result: CommandResult<object>;
+
+    beforeEach(async () => {
+        result = await context.command.validate();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should not call server", () => context.fetchStub.called.should.be.false);
+    it("should return invalid result", () => result.isValid.should.be.false);
+    it("should have validation error", () => result.validationResults.length.should.equal(1));
+    it("should have validation message for property", () => result.validationResults[0].message.should.equal('someProperty is required'));
+    it("should have validation member for property", () => result.validationResults[0].members[0].should.equal('someProperty'));
+}));


### PR DESCRIPTION
# Summary

Fixes two command correctness issues in Arc React forms and dialogs:

- Empty string values were rejected by core required-property validation even when no explicit empty-string validator existed, making client validation stricter than server/domain validation.
- Reactive `currentValues` / `useCommand` syncing ignored explicit `null` and `undefined` values, so cleared external state could leave stale command values for validation and submit.

## Fixed

- Fixed command required-property validation to treat only `null` and `undefined` as missing, letting explicit validators decide whether empty strings are invalid. (#2307)
- Fixed `currentValues` and `useCommand` value syncing so explicit `null` and `undefined` values clear command properties instead of leaving stale values. (#2307)

## Changed

- Clarified CommandForm validation docs to distinguish required field metadata from explicit empty-string validation rules. (#2307)