### PR TITLE
Add Arc Roslyn analyzers and bundle all analyzers into the Cratis package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,8 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.33.11" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.15.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.15.0" />
+    <!-- Architecture analyzers — only restored when IncludeArchitectureAnalyzers=true (see Cratis.csproj). Update once published. -->
+    <PackageVersion Include="Cratis.Architecture.CodeAnalysis" Version="1.0.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.70" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+    <!-- Allow pinning vulnerable transitive packages to patched versions via PackageVersion entries below. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Transitive security pins -->
+    <!-- SQLitePCLRaw 2.1.10/2.1.11 (pulled in transitively by EF Core Sqlite) has a high-severity advisory
+         (GHSA-2m69-gcr7-jv3q). Pin the native library to the patched release. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Chronicle" Version="15.33.11" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.33.11" />

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -56,7 +56,8 @@ public static class TestProject
             MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location),
             MetadataReference.CreateFromFile(systemRuntime.Location),
             MetadataReference.CreateFromFile(typeof(FluentValidation.AbstractValidator<>).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(Commands.ModelBound.CommandAttribute).Assembly.Location)
+            MetadataReference.CreateFromFile(typeof(Commands.ModelBound.CommandAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Cratis.Concepts.ConceptAs<>).Assembly.Location)
         ];
     }
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ConceptRecordAnalyzer/when_concept_is_a_class.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ConceptRecordAnalyzer/when_concept_is_a_class.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ConceptRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ConceptRecordAnalyzer;
+
+public class when_concept_is_a_class
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public class {|#0:AuthorId|} : ConceptAs<System.Guid>
+    {
+    }
+}",
+        VerifyCS.Diagnostic("ARC0009")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("AuthorId"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ConceptRecordAnalyzer/when_concept_is_a_record.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ConceptRecordAnalyzer/when_concept_is_a_record.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ConceptRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ConceptRecordAnalyzer;
+
+public class when_concept_is_a_record
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record AuthorId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_command_is_a_class.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_command_is_a_class.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ModelBoundRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ModelBoundRecordAnalyzer;
+
+public class when_command_is_a_class
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public class {|#0:RegisterAuthor|}
+    {
+        public string Name { get; set; }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0007")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("RegisterAuthor"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_command_is_a_record.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_command_is_a_record.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ModelBoundRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ModelBoundRecordAnalyzer;
+
+public class when_command_is_a_record
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name);
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_readmodel_is_a_class.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_readmodel_is_a_class.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ModelBoundRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ModelBoundRecordAnalyzer;
+
+public class when_readmodel_is_a_class
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Queries.ModelBound;
+
+namespace TestNamespace
+{
+    [ReadModel]
+    public class {|#0:AuthorDetails|}
+    {
+        public string Name { get; set; }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0008")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("AuthorDetails"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_readmodel_is_a_record.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ModelBoundRecordAnalyzer/when_readmodel_is_a_record.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ModelBoundRecordAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ModelBoundRecordAnalyzer;
+
+public class when_readmodel_is_a_record
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Queries.ModelBound;
+
+namespace TestNamespace
+{
+    [ReadModel]
+    public record AuthorDetails(string Name);
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,6 @@ ARC0003|Arc|Error|Handle() must be on [Command] type
 ARC0004|Arc|Error|[Command] type must have public Handle() method
 ARC0005|Arc|Warning|Value produced by Provide is not consumed by Handle
 ARC0006|Arc|Warning|Command-scoped read model can be missing
+ARC0007|Arc|Warning|Command should be declared as a record
+ARC0008|Arc|Warning|ReadModel should be declared as a record
+ARC0009|Arc|Warning|Concept should be declared as a record

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ConceptRecordAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ConceptRecordAnalyzer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that ensures concepts deriving from ConceptAs&lt;T&gt; are declared as records.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ConceptRecordAnalyzer : DiagnosticAnalyzer
+{
+    const string ConceptAsTypeName = "ConceptAs";
+    const string ConceptsNamespace = "Cratis.Concepts";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARC0009_ConceptShouldBeRecord];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (namedTypeSymbol.TypeKind != TypeKind.Class || namedTypeSymbol.IsRecord)
+        {
+            return;
+        }
+
+        if (!InheritsFromConceptAs(namedTypeSymbol))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARC0009_ConceptShouldBeRecord,
+            namedTypeSymbol.Locations[0],
+            namedTypeSymbol.Name));
+    }
+
+    static bool InheritsFromConceptAs(INamedTypeSymbol typeSymbol)
+    {
+        var current = typeSymbol.BaseType;
+        while (current is not null)
+        {
+            if (current.Name == ConceptAsTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == ConceptsNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -82,5 +82,41 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Make the read model parameter nullable when absence is part of the command's valid behavior. Keep it non-nullable when absence should fail as a required dependency, or inject IReadModels for explicit existence checks.");
 
+    /// <summary>
+    /// ARC0007: Command should be declared as a record.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0007_CommandShouldBeRecord = new(
+        id: "ARC0007",
+        title: "Command should be declared as a record",
+        messageFormat: "Command '{0}' is declared as a class. Declare it as a record for value equality, immutability, and concise syntax.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Commands are immutable data structures and should be declared as records. Records give value equality, immutability, and concise positional syntax that the model-bound command pipeline relies on. Change the 'class' declaration to 'record'.");
+
+    /// <summary>
+    /// ARC0008: ReadModel should be declared as a record.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0008_ReadModelShouldBeRecord = new(
+        id: "ARC0008",
+        title: "ReadModel should be declared as a record",
+        messageFormat: "ReadModel '{0}' is declared as a class. Declare it as a record for value equality, immutability, and concise syntax.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Read models are immutable projections of events and should be declared as records. Records give value equality, immutability, and concise positional syntax. Change the 'class' declaration to 'record'.");
+
+    /// <summary>
+    /// ARC0009: Concept should be declared as a record.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0009_ConceptShouldBeRecord = new(
+        id: "ARC0009",
+        title: "Concept should be declared as a record",
+        messageFormat: "Concept '{0}' inherits ConceptAs<T> but is declared as a class. Declare it as a record so value equality and immutability work as intended.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Concepts inherit ConceptAs<T> to wrap a primitive in a strongly-typed domain value. They must be declared as positional records so that value equality, immutability, and the implicit conversions behave correctly. Change the 'class' declaration to 'record'.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ModelBoundRecordAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ModelBoundRecordAnalyzer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that ensures model-bound command and read model types are declared as records.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ModelBoundRecordAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string ReadModelAttributeName = "Cratis.Arc.Queries.ModelBound.ReadModelAttribute";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
+        DiagnosticDescriptors.ARC0007_CommandShouldBeRecord,
+        DiagnosticDescriptors.ARC0008_ReadModelShouldBeRecord
+    ];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (namedTypeSymbol.IsRecord)
+        {
+            return;
+        }
+
+        if (HasAttribute(namedTypeSymbol, CommandAttributeName))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARC0007_CommandShouldBeRecord,
+                namedTypeSymbol.Locations[0],
+                namedTypeSymbol.Name));
+        }
+        else if (HasAttribute(namedTypeSymbol, ReadModelAttributeName))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARC0008_ReadModelShouldBeRecord,
+                namedTypeSymbol.Locations[0],
+                namedTypeSymbol.Name));
+        }
+    }
+
+    static bool HasAttribute(INamedTypeSymbol typeSymbol, string attributeFullName) =>
+        typeSymbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == attributeFullName);
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -56,7 +56,9 @@ public static class TestProject
             MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location),
             MetadataReference.CreateFromFile(systemRuntime.Location),
             MetadataReference.CreateFromFile(typeof(Aggregates.AggregateRoot).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(Cratis.Chronicle.Events.EventContext).Assembly.Location)
+            MetadataReference.CreateFromFile(typeof(Cratis.Chronicle.Events.EventContext).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Cratis.Chronicle.EventSequences.EventForEventSourceId).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Cratis.Arc.Commands.ModelBound.CommandAttribute).Assembly.Location)
         ];
     }
 }

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_only_event_for_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_only_event_for_event_source_id.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_handle_returns_only_event_for_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    public record AuthorRegistered(string Name);
+
+    [Command]
+    public record RegisterAuthor(EventSourceId First, EventSourceId Second)
+    {
+        public EventForEventSourceId Handle() => new(First, new AuthorRegistered(""John""));
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_implements_can_provide_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_implements_can_provide_event_source_id.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_implements_can_provide_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(EventSourceId First, EventSourceId Second) : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => First;
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_event_source_ids_without_interface.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_event_source_ids_without_interface.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_multiple_event_source_ids_without_interface : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [Command]
+    public record {|#0:RegisterAuthor|}(EventSourceId First, EventSourceId Second);
+}",
+                VerifyCS.Diagnostic("ARCCHR0002")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("RegisterAuthor")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_implicit_conversion_ids_without_interface.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_multiple_implicit_conversion_ids_without_interface.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_multiple_implicit_conversion_ids_without_interface : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    public record AuthorId(string Value)
+    {
+        public static implicit operator EventSourceId(AuthorId id) => new EventSourceId(id.Value);
+    }
+
+    [Command]
+    public record RegisterAuthor(AuthorId First, AuthorId Second);
+}",
+                VerifyCS.Diagnostic("ARCCHR0002")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithArguments("RegisterAuthor")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_single_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_single_event_source_id.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_single_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(EventSourceId Id, string Name);
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_type_is_not_a_command.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_type_is_not_a_command.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_type_is_not_a_command : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    public record AuthorPair(EventSourceId First, EventSourceId Second);
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_id_is_specified.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_id_is_specified.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.EventTypeIdArgumentAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_EventTypeIdArgumentAnalyzer.when_validating_event_type_attribute;
+
+public class and_id_is_specified : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [{|#0:EventType(""author-registered"")|}]
+    public record AuthorRegistered(string Name);
+}",
+                VerifyCS.Diagnostic("ARCCHR0004")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("AuthorRegistered")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_no_arguments_are_specified.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_no_arguments_are_specified.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.EventTypeIdArgumentAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_EventTypeIdArgumentAnalyzer.when_validating_event_type_attribute;
+
+public class and_no_arguments_are_specified : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [EventType]
+    public record AuthorRegistered(string Name);
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_only_generation_is_specified.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_EventTypeIdArgumentAnalyzer/when_validating_event_type_attribute/and_only_generation_is_specified.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.EventTypeIdArgumentAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_EventTypeIdArgumentAnalyzer.when_validating_event_type_attribute;
+
+public class and_only_generation_is_specified : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    [EventType(generation: 2)]
+    public record AuthorRegistered(string Name);
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_non_reactor_injects_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_non_reactor_injects_event_log.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorEventLogInjectionAnalyzer.when_validating_reactor_dependencies;
+
+public class and_non_reactor_injects_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    public class SomeService(IEventLog eventLog)
+    {
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_reactor_does_not_inject_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_reactor_does_not_inject_event_log.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorEventLogInjectionAnalyzer.when_validating_reactor_dependencies;
+
+public class and_reactor_does_not_inject_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Reactors;
+
+namespace TestNamespace
+{
+    public interface INotifications { }
+
+    public class AuthorNotifier(INotifications notifications) : IReactor
+    {
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_reactor_injects_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorEventLogInjectionAnalyzer/when_validating_reactor_dependencies/and_reactor_injects_event_log.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorEventLogInjectionAnalyzer.when_validating_reactor_dependencies;
+
+public class and_reactor_injects_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    public class AuthorNotifier(IEventLog {|#0:eventLog|}) : IReactor
+    {
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0003")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("AuthorNotifier", "eventLog")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,6 @@
 Rule ID|Category|Severity|Notes
 --------|----------|----------|--------------------
 ARCCHR0001|Arc.Chronicle|Error|Incorrect AggregateRoot event handler signature
+ARCCHR0002|Arc.Chronicle|Warning|Command has ambiguous event source id and should implement ICanProvideEventSourceId
+ARCCHR0003|Arc.Chronicle|Warning|Reactor must not inject IEventLog
+ARCCHR0004|Arc.Chronicle|Warning|[EventType] should not specify an explicit id

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that warns when a command has multiple event source id candidates but does not declare which one to use.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string EventsNamespace = "Cratis.Chronicle.Events";
+    const string EventSequencesNamespace = "Cratis.Chronicle.EventSequences";
+    const string KeysNamespace = "Cratis.Chronicle.Keys";
+    const string EventSourceIdTypeName = "EventSourceId";
+    const string KeyAttributeName = "KeyAttribute";
+    const string CanProvideEventSourceIdName = "ICanProvideEventSourceId";
+    const string EventForEventSourceIdName = "EventForEventSourceId";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0002_AmbiguousCommandEventSourceId];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (namedTypeSymbol.TypeKind != TypeKind.Class)
+        {
+            return;
+        }
+
+        if (!HasAttribute(namedTypeSymbol, CommandAttributeName))
+        {
+            return;
+        }
+
+        if (ImplementsCanProvideEventSourceId(namedTypeSymbol))
+        {
+            return;
+        }
+
+        var candidates = FindEventSourceIdCandidates(namedTypeSymbol).ToArray();
+
+        if (candidates.Length < 2)
+        {
+            return;
+        }
+
+        if (HandleReturnsOnlyEventForEventSourceId(namedTypeSymbol))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARCCHR0002_AmbiguousCommandEventSourceId,
+            namedTypeSymbol.Locations[0],
+            namedTypeSymbol.Name,
+            string.Join(", ", candidates.Select(candidate => candidate.Name))));
+    }
+
+    static IEnumerable<IPropertySymbol> FindEventSourceIdCandidates(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(property =>
+                !property.IsStatic &&
+                property.DeclaredAccessibility == Accessibility.Public &&
+                IsEventSourceIdCandidate(property));
+
+    static bool IsEventSourceIdCandidate(IPropertySymbol property) =>
+        HasAttribute(property, KeysNamespace, KeyAttributeName) ||
+        IsOrDerivesFromEventSourceId(property.Type) ||
+        HasImplicitConversionToEventSourceId(property.Type);
+
+    static bool IsOrDerivesFromEventSourceId(ITypeSymbol? type)
+    {
+        var current = type;
+        while (current is not null)
+        {
+            if (current.Name == EventSourceIdTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == EventsNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    static bool HasImplicitConversionToEventSourceId(ITypeSymbol? type)
+    {
+        var current = type;
+        while (current is not null)
+        {
+            var hasConversion = current.GetMembers()
+                .OfType<IMethodSymbol>()
+                .Any(method =>
+                    method.MethodKind == MethodKind.Conversion &&
+                    method.Name == "op_Implicit" &&
+                    IsOrDerivesFromEventSourceId(method.ReturnType));
+
+            if (hasConversion)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    static bool ImplementsCanProvideEventSourceId(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.AllInterfaces.Any(@interface =>
+            @interface.Name == CanProvideEventSourceIdName &&
+            @interface.ContainingNamespace?.ToDisplayString() == EventsNamespace);
+
+    static bool HandleReturnsOnlyEventForEventSourceId(INamedTypeSymbol typeSymbol)
+    {
+        var handleMethods = typeSymbol.GetMembers("Handle")
+            .OfType<IMethodSymbol>()
+            .Where(method =>
+                method.MethodKind == MethodKind.Ordinary &&
+                method.DeclaredAccessibility == Accessibility.Public &&
+                !method.IsStatic)
+            .ToArray();
+
+        return handleMethods.Length > 0 && handleMethods.All(ReturnsOnlyEventForEventSourceId);
+    }
+
+    static bool ReturnsOnlyEventForEventSourceId(IMethodSymbol method)
+    {
+        var returnType = UnwrapTask(method.ReturnType);
+        if (returnType is null)
+        {
+            return false;
+        }
+
+        return IsEventForEventSourceId(returnType) || IsSequenceOfEventForEventSourceId(returnType);
+    }
+
+    static ITypeSymbol? UnwrapTask(ITypeSymbol returnType)
+    {
+        if (returnType is INamedTypeSymbol namedType &&
+            namedType.Name == "Task" &&
+            namedType.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+        {
+            return namedType.TypeArguments.Length == 1 ? namedType.TypeArguments[0] : null;
+        }
+
+        return returnType;
+    }
+
+    static bool IsEventForEventSourceId(ITypeSymbol type) =>
+        type.Name == EventForEventSourceIdName &&
+        type.ContainingNamespace?.ToDisplayString() == EventSequencesNamespace;
+
+    static bool IsSequenceOfEventForEventSourceId(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return IsEventForEventSourceId(arrayType.ElementType);
+        }
+
+        if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
+        {
+            return namedType.TypeArguments.Length == 1 && IsEventForEventSourceId(namedType.TypeArguments[0]);
+        }
+
+        return false;
+    }
+
+    static bool HasAttribute(ISymbol symbol, string fullyQualifiedName) =>
+        symbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == fullyQualifiedName);
+
+    static bool HasAttribute(ISymbol symbol, string @namespace, string typeName) =>
+        symbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.Name == typeName &&
+            attribute.AttributeClass?.ContainingNamespace?.ToDisplayString() == @namespace);
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
@@ -22,5 +22,41 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Event handler methods (typically named 'On') on AggregateRoot types must accept an event parameter and optionally an EventContext parameter, and return void or Task.");
 
+    /// <summary>
+    /// ARCCHR0002: Command has ambiguous event source id with multiple candidate properties.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0002_AmbiguousCommandEventSourceId = new(
+        id: "ARCCHR0002",
+        title: "Command has ambiguous event source id and should implement ICanProvideEventSourceId",
+        messageFormat: "Command '{0}' has multiple event source id candidate properties ({1}) but does not implement ICanProvideEventSourceId. Implement ICanProvideEventSourceId to make the default event source id explicit.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When a command exposes more than one property that can resolve to an EventSourceId (an EventSourceId, an EventSourceId<T>, a type with an implicit conversion to EventSourceId, or a [Key]-marked property), the framework resolves the event source id from the first matching property, which is ambiguous. Implement ICanProvideEventSourceId to declare which value to use. This is not required when the command's Handle method returns only EventForEventSourceId events, since each such event carries its own event source id.");
+
+    /// <summary>
+    /// ARCCHR0003: Reactor must not inject IEventLog.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0003_ReactorMustNotInjectEventLog = new(
+        id: "ARCCHR0003",
+        title: "Reactor must not inject IEventLog",
+        messageFormat: "Reactor '{0}' injects IEventLog through parameter '{1}'. Return events from the handler method (Task<TEvent>, Task<ReactorSideEffect>, or a collection) instead of appending through IEventLog directly.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Reactors observe events and produce side effects; they must not append to the event log directly. To produce new events, return them from the handler method as Task<TEvent>, Task<ReactorSideEffect>, or a collection thereof. To trigger work in another slice, inject ICommandPipeline and execute a command. Injecting IEventLog couples the reactor to the event log and bypasses the side-effect pipeline.");
+
+    /// <summary>
+    /// ARCCHR0004: [EventType] should not specify an explicit id.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0004_EventTypeShouldNotSpecifyId = new(
+        id: "ARCCHR0004",
+        title: "[EventType] should not specify an explicit id",
+        messageFormat: "Event type '{0}' specifies an explicit id on [EventType]. Remove the id argument — the type name is used as the identifier automatically.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The [EventType] attribute derives its identifier from the type name by convention, so an explicit id should not be passed. Use a bare [EventType]. The generation argument is still allowed for event evolution.");
+
     const string Category = "Arc.Chronicle";
 }

--- a/Source/DotNET/Chronicle.CodeAnalysis/EventTypeIdArgumentAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/EventTypeIdArgumentAnalyzer.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that warns when the [EventType] attribute specifies an explicit id argument.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class EventTypeIdArgumentAnalyzer : DiagnosticAnalyzer
+{
+    const string EventTypeAttributeName = "Cratis.Chronicle.Events.EventTypeAttribute";
+    const string IdParameterName = "id";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0004_EventTypeShouldNotSpecifyId];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
+    }
+
+    static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+    {
+        var attribute = (AttributeSyntax)context.Node;
+
+        if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol is not IMethodSymbol constructor ||
+            constructor.ContainingType?.ToDisplayString() != EventTypeAttributeName)
+        {
+            return;
+        }
+
+        if (!SpecifiesId(attribute.ArgumentList.Arguments))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARCCHR0004_EventTypeShouldNotSpecifyId,
+            attribute.GetLocation(),
+            GetTargetTypeName(attribute)));
+    }
+
+    static bool SpecifiesId(SeparatedSyntaxList<AttributeArgumentSyntax> arguments) =>
+        arguments.Any(argument =>
+            argument.NameColon is null ||
+            argument.NameColon.Name.Identifier.Text == IdParameterName);
+
+    static string GetTargetTypeName(AttributeSyntax attribute) =>
+        attribute.Parent?.Parent is BaseTypeDeclarationSyntax typeDeclaration
+            ? typeDeclaration.Identifier.Text
+            : "event";
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/ReactorEventLogInjectionAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/ReactorEventLogInjectionAnalyzer.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that warns when a reactor injects <c>IEventLog</c> instead of returning side-effect events.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReactorEventLogInjectionAnalyzer : DiagnosticAnalyzer
+{
+    const string ReactorInterfaceName = "IReactor";
+    const string ReactorsNamespace = "Cratis.Chronicle.Reactors";
+    const string EventLogInterfaceName = "IEventLog";
+    const string EventSequencesNamespace = "Cratis.Chronicle.EventSequences";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0003_ReactorMustNotInjectEventLog];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (namedTypeSymbol.TypeKind != TypeKind.Class || !IsReactor(namedTypeSymbol))
+        {
+            return;
+        }
+
+        foreach (var constructor in namedTypeSymbol.InstanceConstructors)
+        {
+            foreach (var parameter in constructor.Parameters.Where(parameter => IsEventLog(parameter.Type)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ARCCHR0003_ReactorMustNotInjectEventLog,
+                    parameter.Locations[0],
+                    namedTypeSymbol.Name,
+                    parameter.Name));
+            }
+        }
+    }
+
+    static bool IsReactor(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.AllInterfaces.Any(@interface =>
+            @interface.Name == ReactorInterfaceName &&
+            @interface.ContainingNamespace?.ToDisplayString() == ReactorsNamespace);
+
+    static bool IsEventLog(ITypeSymbol type)
+    {
+        if (type.Name == EventLogInterfaceName &&
+            type.ContainingNamespace?.ToDisplayString() == EventSequencesNamespace)
+        {
+            return true;
+        }
+
+        return type.AllInterfaces.Any(@interface =>
+            @interface.Name == EventLogInterfaceName &&
+            @interface.ContainingNamespace?.ToDisplayString() == EventSequencesNamespace);
+    }
+}

--- a/Source/DotNET/Cratis/Cratis.csproj
+++ b/Source/DotNET/Cratis/Cratis.csproj
@@ -25,8 +25,73 @@
     <ItemGroup>
         <PackageReference Include="Cratis.Chronicle.AspNetCore" />
     </ItemGroup>
+
+    <!-- Bundle every Cratis Roslyn analyzer into this meta package so that a single reference to Cratis
+         brings the full set of analyzers. NuGet marks analyzer assets as private by default, so analyzers
+         from dependency packages do not flow transitively to consumers of this package. We therefore pack
+         the analyzer assemblies directly into analyzers/dotnet/cs. -->
+    <ItemGroup>
+        <!-- In-repo analyzers and generators. Referenced so they are built before this project packs. -->
+        <ProjectReference Include="../Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj"
+                          OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <ProjectReference Include="../Arc.Core.Generators/Arc.Core.Generators.csproj"
+                          OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <ProjectReference Include="../Chronicle.CodeAnalysis/Chronicle.CodeAnalysis.csproj"
+                          OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    </ItemGroup>
+
+    <!-- External analyzer packages: resolve their restored package path so the analyzer assemblies can be repacked. -->
+    <ItemGroup>
+        <PackageReference Include="Cratis.Fundamentals" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="Cratis.Metrics.Roslyn" GeneratePathProperty="true" PrivateAssets="all" />
+    </ItemGroup>
+
     <ItemGroup>
         <None Include="GlobalUsings.cs" Pack="true" PackagePath="contentFiles/cs/any" />
         <None Include="build/Cratis.props" Pack="true" PackagePath="build;buildTransitive" />
+
+        <!-- In-repo analyzers (ARC*, ARCCHR*) and the Arc source generator. -->
+        <None Include="../Arc.Core.CodeAnalysis/bin/$(Configuration)/netstandard2.0/Cratis.Arc.Core.CodeAnalysis.dll"
+              Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+        <None Include="../Arc.Core.Generators/bin/$(Configuration)/netstandard2.0/Cratis.Arc.Core.Generators.dll"
+              Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+        <None Include="../Chronicle.CodeAnalysis/bin/$(Configuration)/netstandard2.0/Cratis.Arc.Chronicle.CodeAnalysis.dll"
+              Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
+
+    <!-- Architecture analyzers (CRARCH*) live in the separate Cratis.Architecture repository and ship as the
+         Cratis.Architecture.CodeAnalysis package. Enable once that package is published by setting
+         IncludeArchitectureAnalyzers=true (and the version in Directory.Packages.props). -->
+    <ItemGroup Condition="'$(IncludeArchitectureAnalyzers)' == 'true'">
+        <PackageReference Include="Cratis.Architecture.CodeAnalysis" GeneratePathProperty="true" PrivateAssets="all" />
+    </ItemGroup>
+
+    <!-- The path properties generated for external analyzer packages ($(PkgCratis_*)) are only populated in the
+         per-TFM inner builds, not in the outer (TargetFramework-less) build where pack gathers framework-agnostic
+         None items. We therefore add the external analyzer assemblies through TargetsForTfmSpecificContentInPackage,
+         emitting them once (during the net10.0 inner build) since analyzer assemblies are framework-agnostic. -->
+    <PropertyGroup>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddExternalAnalyzersToPackage</TargetsForTfmSpecificContentInPackage>
+    </PropertyGroup>
+
+    <Target Name="AddExternalAnalyzersToPackage" Condition="'$(TargetFramework)' == 'net10.0'">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(PkgCratis_Fundamentals)/analyzers/dotnet/cs/Cratis.Fundamentals.TypeDiscovery.Generator.dll"
+                                    Condition="'$(PkgCratis_Fundamentals)' != ''">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="$(PkgCratis_Metrics_Roslyn)/analyzers/dotnet/cs/Cratis.Metrics.Roslyn.dll"
+                                    Condition="'$(PkgCratis_Metrics_Roslyn)' != ''">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="$(PkgCratis_Metrics_Roslyn)/analyzers/dotnet/cs/Handlebars.dll"
+                                    Condition="'$(PkgCratis_Metrics_Roslyn)' != ''">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="$(PkgCratis_Architecture_CodeAnalysis)/analyzers/dotnet/cs/Cratis.Architecture.CodeAnalysis.dll"
+                                    Condition="'$(IncludeArchitectureAnalyzers)' == 'true' and '$(PkgCratis_Architecture_CodeAnalysis)' != ''">
+                <PackagePath>analyzers/dotnet/cs</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
# Summary

A single reference to the `Cratis` package now ships the full set of Cratis Roslyn analyzers, and several new analyzers guide developers and AI toward idiomatic Arc code.

## Added

- `ARC0007` analyzer — warns when a `[Command]` is declared as a class instead of a record.
- `ARC0008` analyzer — warns when a `[ReadModel]` is declared as a class instead of a record.
- `ARC0009` analyzer — warns when a `ConceptAs<T>` is declared as a class instead of a record.
- `ARCCHR0002` analyzer — warns when a `[Command]` has multiple event source id candidates (`EventSourceId`, `EventSourceId<T>`, a type with an implicit conversion to `EventSourceId`, or `[Key]`) but does not implement `ICanProvideEventSourceId`; exempt when `Handle` returns only `EventForEventSourceId`.
- `ARCCHR0003` analyzer — warns when a reactor injects `IEventLog` instead of returning side-effect events.
- `ARCCHR0004` analyzer — warns when `[EventType]` specifies an explicit id (the type name is the identifier); `generation` stays allowed.

## Changed

- The `Cratis` meta package now bundles every Cratis analyzer (Arc, Arc.Chronicle, the Arc source generator, the Fundamentals type discovery generator, and the Metrics analyzer), so installing `Cratis` enables all analyzers without referencing the sub-packages directly.