### PR TITLE
Fix infinite recursion validating commands with cyclic object graphs

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_json_object_property.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_json_object_property.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_command_having_json_object_property : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+    Exception _exception;
+
+    void Establish()
+    {
+        // JsonNode children hold a back-reference to their parent, forming a cycle in the object graph.
+        // Walking it without cycle detection recurses forever and overflows the stack.
+        var payload = new JsonObject
+        {
+            ["id"] = "abc",
+            ["nested"] = new JsonObject { ["value"] = 42 }
+        };
+        var command = new CommandWithJsonObject(payload);
+        _context = new CommandContext(_correlationId, typeof(CommandWithJsonObject), command, [], new());
+        _discoverableValidators.TryGet(Arg.Any<Type>(), out Arg.Any<IValidator>()).Returns(false);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => _result = await _filter.OnExecution(_context));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+
+    record CommandWithJsonObject(JsonObject Payload);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_self_referential_object_graph.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_command_having_self_referential_object_graph.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
+
+public class with_command_having_self_referential_object_graph : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+    Exception _exception;
+
+    void Establish()
+    {
+        var node = new Node("root");
+        node.Child = new Node("child") { Parent = node }; // node <-> child cycle
+
+        var command = new CommandWithGraph(node);
+        _context = new CommandContext(_correlationId, typeof(CommandWithGraph), command, [], new());
+        _discoverableValidators.TryGet(Arg.Any<Type>(), out Arg.Any<IValidator>()).Returns(false);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => _result = await _filter.OnExecution(_context));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+
+    record CommandWithGraph(Node Root);
+
+    /// <summary>
+    /// A mutable node whose <see cref="Parent"/> and <see cref="Child"/> form a reference cycle —
+    /// the same shape that JsonNode's parent back-reference produces.
+    /// </summary>
+    /// <param name="name">The name of the node.</param>
+    public class Node(string name)
+    {
+        public string Name => name;
+        public Node? Parent { get; set; }
+        public Node? Child { get; set; }
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -18,15 +18,27 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
     public async Task<CommandResult> OnExecution(CommandContext context)
     {
         var commandResult = CommandResult.Success(context.CorrelationId);
-        commandResult.MergeWith(await Validate(context, context.Command));
+        commandResult.MergeWith(await Validate(context, context.Command, new HashSet<object>(ReferenceEqualityComparer.Instance)));
         return commandResult;
     }
 
-    async Task<CommandResult> Validate(CommandContext context, object instance)
+    async Task<CommandResult> Validate(CommandContext context, object instance, HashSet<object> visited)
     {
         var commandResult = CommandResult.Success(context.CorrelationId);
 
         var instanceType = instance.GetType();
+
+        // Guard against cycles in arbitrary object graphs. Some types — notably
+        // System.Text.Json.Nodes.JsonNode — hold a back-reference from every child to its parent, so
+        // blindly walking child properties would recurse forever and overflow the stack. Only reference
+        // types can participate in a cycle; value types are boxed afresh on each access, so tracking them
+        // would never dedupe and would only add overhead. ReferenceEqualityComparer keys on identity, so
+        // distinct-but-equal instances (e.g. two equal concept values in a list) are still each validated.
+        if (!instanceType.IsValueType && !visited.Add(instance))
+        {
+            return commandResult;
+        }
+
         if (TryGetValidator(context, instanceType, out var validator))
         {
             var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
@@ -63,7 +75,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                 foreach (var element in (System.Collections.IEnumerable)instance)
                 {
                     if (element is null) continue;
-                    commandResult.MergeWith(await Validate(context, element));
+                    commandResult.MergeWith(await Validate(context, element, visited));
                 }
             }
             else
@@ -81,7 +93,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                     var propertyValue = property.GetValue(instance);
                     if (propertyValue is not null)
                     {
-                        commandResult.MergeWith(await Validate(context, propertyValue));
+                        commandResult.MergeWith(await Validate(context, propertyValue, visited));
                     }
                 }
             }


### PR DESCRIPTION
## Fixed
- Commands with a property holding a cyclic or arbitrary object graph (for example `System.Text.Json.Nodes.JsonObject`, whose child nodes back-reference their parent) no longer crash command execution with a stack overflow / HTTP 500. Nested validator behavior is unchanged.