### PR TITLE
Fix Cratis meta-package and Chronicle consumption for downstream apps

### DIFF
--- a/Directory.Packages.NET8-9.props
+++ b/Directory.Packages.NET8-9.props
@@ -6,8 +6,8 @@
         <PackageVersion Update="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.16" />
         <PackageVersion Update="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
         <PackageVersion Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-        <PackageVersion Update="Microsoft.Extensions.Logging" Version="10.0.8" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+        <PackageVersion Update="Microsoft.Extensions.Logging" Version="10.0.9" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
         <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="10.0.8" />
         <PackageVersion Update="Microsoft.Build.Framework" Version="18.6.3" />
         <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="18.6.3" />
@@ -15,9 +15,9 @@
              This causes NSubstitute/Castle.DynamicProxy failures in tests when 9.x version is used.
              Only apply the 9.x override for non-test projects. -->
         <PackageVersion Update="System.Text.Json" Version="10.0.8" Condition="'$(IsTestProject)' != 'true'" />
-        <PackageVersion Update="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
+        <PackageVersion Update="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
         <PackageVersion Update="Microsoft.Extensions.Telemetry" Version="10.6.0" />
-        <PackageVersion Update="Microsoft.Extensions.Hosting" Version="10.0.8" />
+        <PackageVersion Update="Microsoft.Extensions.Hosting" Version="10.0.9" />
         <PackageVersion Update="Microsoft.Extensions.Resilience" Version="10.6.0" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.NET8.props
+++ b/Directory.Packages.NET8.props
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
         <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.27" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.NET9.props
+++ b/Directory.Packages.NET9.props
@@ -2,9 +2,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
         <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     </ItemGroup>
    
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,26 +11,31 @@
          (GHSA-2m69-gcr7-jv3q). Pin the native library to the patched release. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.33.11" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.33.11" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.33.11" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.15.1" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.15.0" />
+    <!-- Floor must be the released Chronicle whose IEventSequence.AppendMany/Append signature Arc compiles
+         against. 15.35.0 added a trailing optional 'Subject? subject' parameter to AppendMany/Append; Arc
+         compiled against an older signature would bind to a method that no longer exists at runtime and throw
+         MissingMethodException. Keep this floor at the version Arc is built against so a mismatch fails
+         'dotnet restore' instead of crashing at runtime. See AppendMany signature guard spec. -->
+    <PackageVersion Include="Cratis.Chronicle" Version="15.35.0" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.35.0" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.35.0" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.0" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.0" />
     <!-- Architecture analyzers — only restored when IncludeArchitectureAnalyzers=true (see Cratis.csproj). Update once published. -->
     <PackageVersion Include="Cratis.Architecture.CodeAnalysis" Version="1.0.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.70" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.6.3" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />

--- a/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/Directory.Build.props
+++ b/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/MetaConsumerApp.csproj
+++ b/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/MetaConsumerApp.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+
+    <!-- Reproduces the meta-package double-load: a consumer that references the Cratis meta package AND a package
+         that transitively brings Cratis.Arc.Core (Cratis.Arc.MongoDB -> Cratis.Arc.Core). Both deliver the Arc
+         source generator, which without the de-duplication target in Cratis.props would run twice and fail with
+         CS0101. The [ReadModel] below makes the generator emit GeneratedQueryMetadata as well as the marker, so
+         this exercises the full generated output, not just the marker. -->
+    <ItemGroup>
+        <PackageReference Include="Cratis" Version="1.0.0" />
+        <PackageReference Include="Cratis.Arc.MongoDB" Version="1.0.0" />
+    </ItemGroup>
+</Project>

--- a/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/SampleMetaReadModel.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/MetaConsumerApp/SampleMetaReadModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries.ModelBound;
+
+namespace MetaConsumerApp;
+
+[ReadModel]
+public record SampleMetaReadModel(string City)
+{
+    public static SampleMetaReadModel GetByName(string city) => new(city);
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/CratisMetaConsumerBuildResult.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/CratisMetaConsumerBuildResult.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+/// <summary>
+/// Represents the result of building a consumer that references both the Cratis meta package and Cratis.Arc.MongoDB
+/// from locally packed nupkgs.
+/// </summary>
+/// <param name="buildSucceeded">Whether the consumer build completed successfully.</param>
+/// <param name="buildOutput">The combined standard output and error of the consumer build.</param>
+/// <param name="workingDirectory">The temporary working directory used by the integration scenario.</param>
+public sealed class CratisMetaConsumerBuildResult(
+    bool buildSucceeded,
+    string buildOutput,
+    string workingDirectory)
+{
+    /// <summary>
+    /// Gets a value indicating whether the consumer build completed successfully.
+    /// </summary>
+    public bool BuildSucceeded { get; } = buildSucceeded;
+
+    /// <summary>
+    /// Gets the combined standard output and error of the consumer build.
+    /// </summary>
+    public string BuildOutput { get; } = buildOutput;
+
+    /// <summary>
+    /// Gets the temporary working directory used by the integration scenario.
+    /// </summary>
+    public string WorkingDirectory { get; } = workingDirectory;
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/CratisMetaConsumerBuildScenario.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/Testing/CratisMetaConsumerBuildScenario.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+/// <summary>
+/// Packs the Cratis meta package and Cratis.Arc.MongoDB (with their in-repo dependencies) into a local feed and
+/// builds a consumer that references both, reproducing the analyzer double-load that caused CS0101.
+/// </summary>
+internal static class CratisMetaConsumerBuildScenario
+{
+    /// <summary>
+    /// The in-repo package closure a consumer of Cratis + Cratis.Arc.MongoDB pulls. Externals (Cratis.Chronicle,
+    /// Cratis.Fundamentals, MongoDB.Driver, ...) are restored from nuget.org.
+    /// </summary>
+    static readonly string[] _projectsToPack =
+    [
+        Path.Combine("Source", "DotNET", "Arc.Core", "Arc.Core.csproj"),
+        Path.Combine("Source", "DotNET", "Arc", "Arc.csproj"),
+        Path.Combine("Source", "DotNET", "Chronicle", "Chronicle.csproj"),
+        Path.Combine("Source", "DotNET", "Swagger", "Swagger.csproj"),
+        Path.Combine("Source", "DotNET", "Tools", "ProxyGenerator.Build", "ProxyGenerator.Build.csproj"),
+        Path.Combine("Source", "DotNET", "MongoDB", "MongoDB.csproj"),
+        Path.Combine("Source", "DotNET", "Cratis", "Cratis.csproj"),
+    ];
+
+    /// <summary>
+    /// Packs the closure into a local feed, restores the consumer from it, and builds the consumer.
+    /// </summary>
+    /// <returns>A <see cref="CratisMetaConsumerBuildResult"/> describing whether the consumer built and its output.</returns>
+    /// <exception cref="MetaConsumerIntegrationFailure">Thrown when packing or restoring the consumer fails (the build itself does not throw — its outcome is the result under test).</exception>
+    public static CratisMetaConsumerBuildResult Execute()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var workingDirectory = Path.Combine(Path.GetTempPath(), "Cratis.Arc.MetaConsumer.Integration", Guid.NewGuid().ToString("N"));
+        var packageDirectory = Path.Combine(workingDirectory, "packages");
+        var restoredPackagesDirectory = Path.Combine(workingDirectory, "restored-packages");
+        var consumerSourceDirectory = Path.Combine(repositoryRoot, "Source", "DotNET", "Arc.Core.Generators.Integration", "MetaConsumerApp");
+        var consumerWorkingDirectory = Path.Combine(workingDirectory, "MetaConsumerApp");
+
+        Directory.CreateDirectory(packageDirectory);
+        Directory.CreateDirectory(restoredPackagesDirectory);
+        CopyDirectory(consumerSourceDirectory, consumerWorkingDirectory);
+
+        foreach (var project in _projectsToPack)
+        {
+            RunDotNet(repositoryRoot, $"pack \"{Path.Combine(repositoryRoot, project)}\" -c Release --output \"{packageDirectory}\" -p:IncludeSymbols=false -p:IncludeSource=false", throwOnFailure: true);
+        }
+
+        var consumerProjectPath = Path.Combine(consumerWorkingDirectory, "MetaConsumerApp.csproj");
+        RunDotNet(consumerWorkingDirectory, $"restore \"{consumerProjectPath}\" --source \"{packageDirectory}\" --source https://api.nuget.org/v3/index.json --packages \"{restoredPackagesDirectory}\"", throwOnFailure: true);
+
+        var (exitCode, output) = RunDotNet(consumerWorkingDirectory, $"build \"{consumerProjectPath}\" --no-restore", throwOnFailure: false);
+
+        return new(exitCode == 0, output, workingDirectory);
+    }
+
+    static string GetRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Arc.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new MetaConsumerIntegrationFailure("Could not locate the repository root from the integration spec output directory.");
+    }
+
+    static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        Directory.CreateDirectory(destinationDirectory);
+
+        foreach (var file in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            // Skip any previously built output so the consumer builds from a clean state.
+            var relativePath = Path.GetRelativePath(sourceDirectory, file);
+            if (relativePath.StartsWith($"bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                relativePath.StartsWith($"obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                relativePath.StartsWith($"Generated{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var destinationPath = Path.Combine(destinationDirectory, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+            File.Copy(file, destinationPath, overwrite: true);
+        }
+    }
+
+    static (int ExitCode, string Output) RunDotNet(string workingDirectory, string arguments, bool throwOnFailure)
+    {
+        using var process = new Process
+        {
+            StartInfo = new()
+            {
+                FileName = "dotnet",
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            }
+        };
+
+        process.Start();
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        var standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        var standardOutput = standardOutputTask.GetAwaiter().GetResult();
+        var standardError = standardErrorTask.GetAwaiter().GetResult();
+        var output = $"{standardOutput}{Environment.NewLine}{standardError}";
+
+        if (throwOnFailure && process.ExitCode != 0)
+        {
+            throw new MetaConsumerIntegrationFailure($"dotnet {arguments} failed with exit code {process.ExitCode}.{Environment.NewLine}{output}");
+        }
+
+        return (process.ExitCode, output);
+    }
+
+    /// <summary>
+    /// The exception that is thrown when the Cratis meta consumer integration scenario cannot complete its prerequisites.
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    sealed class MetaConsumerIntegrationFailure(string message) : Exception(message);
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_CratisMetaConsumer/CratisMetaConsumerBuildFixture.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_CratisMetaConsumer/CratisMetaConsumerBuildFixture.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Core.Generators.Integration.Specs.Testing;
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.for_CratisMetaConsumer;
+
+/// <summary>
+/// Executes the Cratis + Cratis.Arc.MongoDB consumer build scenario once for the test class.
+/// </summary>
+public sealed class CratisMetaConsumerBuildFixture
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CratisMetaConsumerBuildFixture"/> class.
+    /// </summary>
+    public CratisMetaConsumerBuildFixture() => Result = CratisMetaConsumerBuildScenario.Execute();
+
+    /// <summary>
+    /// Gets the result of packing the meta-package closure and building the consumer from the packed nupkgs.
+    /// </summary>
+    public CratisMetaConsumerBuildResult Result { get; }
+}

--- a/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_CratisMetaConsumer/when_building_a_consumer_referencing_cratis_and_arc_mongodb.cs
+++ b/Source/DotNET/Arc.Core.Generators.Integration/Specs/for_CratisMetaConsumer/when_building_a_consumer_referencing_cratis_and_arc_mongodb.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Core.Generators.Integration.Specs.for_CratisMetaConsumer;
+
+/// <summary>
+/// Verifies that a project referencing both the Cratis meta package and Cratis.Arc.MongoDB builds cleanly, proving
+/// the analyzer de-duplication target in Cratis.props collapses the duplicate Arc source generator that would
+/// otherwise run twice and fail with CS0101 'Cratis.Arc.Generated.GeneratedMarker'.
+/// </summary>
+/// <param name="fixture">The fixture that executes the consumer build scenario once for the test class.</param>
+public class when_building_a_consumer_referencing_cratis_and_arc_mongodb(CratisMetaConsumerBuildFixture fixture) : IClassFixture<CratisMetaConsumerBuildFixture>
+{
+    readonly Testing.CratisMetaConsumerBuildResult _buildResult = fixture.Result;
+
+    /// <summary>
+    /// Verifies that the consumer referencing both Cratis and Cratis.Arc.MongoDB builds successfully.
+    /// </summary>
+    [Fact]
+    public void should_build_successfully() => _buildResult.BuildSucceeded.ShouldBeTrue();
+
+    /// <summary>
+    /// Verifies that the consumer build does not fail with a duplicate generated type error.
+    /// </summary>
+    [Fact]
+    public void should_not_emit_a_duplicate_definition_error() => _buildResult.BuildOutput.ShouldNotContain("CS0101");
+}

--- a/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/Testing/GeneratorTestHelper.cs
@@ -34,6 +34,27 @@ public static class GeneratorTestHelper
     }
 
     /// <summary>
+    /// Compiles the supplied source texts together and returns the resulting compilation diagnostics.
+    /// </summary>
+    /// <param name="sources">The C# source texts to compile in a single compilation.</param>
+    /// <returns>The <see cref="Diagnostic"/> entries produced by the compilation.</returns>
+    /// <remarks>
+    /// Used to prove that generated output stays collision-proof when the same generator is loaded more than once
+    /// in a single compilation — passing the same generated source twice must not produce a CS0101 duplicate
+    /// definition error.
+    /// </remarks>
+    public static ImmutableArray<Diagnostic> Compile(params string[] sources)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            sources.Select(source => CSharpSyntaxTree.ParseText(source)),
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        return compilation.GetDiagnostics();
+    }
+
+    /// <summary>
     /// Gets generated source text for a file with a specific hint name.
     /// </summary>
     /// <param name="result">The generator run result.</param>

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_class_without_read_model_attribute_exists.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_class_without_read_model_attribute_exists.cs
@@ -26,6 +26,6 @@ public class and_class_without_read_model_attribute_exists : Specification
     }
 
     [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
-    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static partial class GeneratedMarker");
     [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
 }

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_no_types_exist.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_no_types_exist.cs
@@ -18,6 +18,6 @@ public class and_no_types_exist : Specification
     }
 
     [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
-    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static partial class GeneratedMarker");
     [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
 }

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_read_model_exists_with_no_valid_query_methods.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_generating_without_read_models/and_read_model_exists_with_no_valid_query_methods.cs
@@ -29,6 +29,6 @@ public class and_read_model_exists_with_no_valid_query_methods : Specification
     }
 
     [Fact] void should_generate_only_marker_source() => _result.GeneratedTrees.Length.ShouldEqual(1);
-    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static class GeneratedMarker");
+    [Fact] void should_generate_marker_type() => _generatedSource.ShouldContain("public static partial class GeneratedMarker");
     [Fact] void should_have_no_diagnostics() => _result.Diagnostics.Length.ShouldEqual(0);
 }

--- a/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_the_marker_is_emitted_more_than_once_in_a_compilation.cs
+++ b/Source/DotNET/Arc.Core.Generators.Specs/for_QueryMetadataGenerator/when_the_marker_is_emitted_more_than_once_in_a_compilation.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Arc.Generators.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Generators.for_QueryMetadataGenerator;
+
+/// <summary>
+/// Reproduces the meta-package double-load scenario at the generated-output level: when the Arc generator assembly
+/// is loaded from more than one analyzer path in a single compilation, the unconditional marker type is emitted
+/// twice. Declaring it <c>partial</c> must let the duplicate declarations merge instead of failing with CS0101.
+/// </summary>
+public class when_the_marker_is_emitted_more_than_once_in_a_compilation : Specification
+{
+    string _markerSource;
+    ImmutableArray<Diagnostic> _diagnostics;
+
+    void Establish()
+    {
+        var result = GeneratorTestHelper.RunGenerator(string.Empty);
+        _markerSource = GeneratorTestHelper.GetGeneratedSourceByHintName(result, "CratisArcGeneratedMarker.g.cs");
+    }
+
+    void Because() => _diagnostics = GeneratorTestHelper.Compile(_markerSource, _markerSource);
+
+    [Fact] void should_declare_the_marker_as_partial() => _markerSource.ShouldContain("partial class GeneratedMarker");
+    [Fact] void should_not_produce_a_duplicate_definition_error() => _diagnostics.Any(diagnostic => diagnostic.Id == "CS0101").ShouldBeFalse();
+    [Fact] void should_compile_without_errors() => _diagnostics.Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
+++ b/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
@@ -204,7 +204,13 @@ public class QueryMetadataGenerator : IIncrementalGenerator
         .AppendLine("/// <summary>")
         .AppendLine("/// Marker type that confirms Arc source generators have run for the assembly.")
         .AppendLine("/// </summary>")
-        .AppendLine("public static class GeneratedMarker")
+
+        // Declared 'partial' so that if the same generator assembly is loaded from more than one analyzer path
+        // in a single compilation (e.g. a consumer referencing both the Cratis meta package and a package that
+        // also ships this generator), the duplicate marker declarations merge into one type instead of failing
+        // the build with CS0101. The primary fix de-duplicates the analyzer references (see Cratis.props), but
+        // this keeps the generated output collision-proof regardless of how the analyzer is delivered.
+        .AppendLine("public static partial class GeneratedMarker")
         .AppendLine("{")
         .AppendLine("}")
         .ToString();

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_containing_event_for_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_containing_event_for_event_source_id.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_handle_returns_tuple_containing_event_for_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    public record RegistrationResponse(string Status);
+    public record AuthorRegistered(string Name);
+
+    [Command]
+    public record RegisterAuthor(EventSourceId First, EventSourceId Second)
+    {
+        public (RegistrationResponse, EventForEventSourceId) Handle() =>
+            (new RegistrationResponse(""ok""), new EventForEventSourceId(First, new AuthorRegistered(""John"")));
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_with_generated_event_source_id.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_with_generated_event_source_id.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_handle_returns_tuple_with_generated_event_source_id : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Collections.Generic;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    public record AuthorId(Guid Value) : EventSourceId<Guid>(Value);
+    public record AuthorRegistered(string Name);
+
+    [Command]
+    public record RegisterAuthor(EventSourceId First, EventSourceId Second)
+    {
+        public (AuthorId, IEnumerable<object>) Handle() => (new AuthorId(Guid.NewGuid()), new object[] { new AuthorRegistered(""John"") });
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_without_an_event_source.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventSourceIdAnalyzer/when_validating_event_source_id/and_handle_returns_tuple_without_an_event_source.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventSourceIdAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventSourceIdAnalyzer.when_validating_event_source_id;
+
+public class and_handle_returns_tuple_without_an_event_source : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+
+namespace TestNamespace
+{
+    public record RegistrationResponse(string Status);
+
+    [Command]
+    public record {|#0:RegisterAuthor|}(EventSourceId First, EventSourceId Second)
+    {
+        public (RegistrationResponse, RegistrationResponse) Handle() =>
+            (new RegistrationResponse(""a""), new RegistrationResponse(""b""));
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0002")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("RegisterAuthor")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandEventSourceIdAnalyzer.cs
@@ -59,7 +59,7 @@ public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (HandleReturnsOnlyEventForEventSourceId(namedTypeSymbol))
+        if (HandleReturnsExplicitEventSource(namedTypeSymbol))
         {
             return;
         }
@@ -129,7 +129,7 @@ public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
             @interface.Name == CanProvideEventSourceIdName &&
             @interface.ContainingNamespace?.ToDisplayString() == EventsNamespace);
 
-    static bool HandleReturnsOnlyEventForEventSourceId(INamedTypeSymbol typeSymbol)
+    static bool HandleReturnsExplicitEventSource(INamedTypeSymbol typeSymbol)
     {
         var handleMethods = typeSymbol.GetMembers("Handle")
             .OfType<IMethodSymbol>()
@@ -139,10 +139,10 @@ public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
                 !method.IsStatic)
             .ToArray();
 
-        return handleMethods.Length > 0 && handleMethods.All(ReturnsOnlyEventForEventSourceId);
+        return handleMethods.Length > 0 && handleMethods.All(ReturnsExplicitEventSource);
     }
 
-    static bool ReturnsOnlyEventForEventSourceId(IMethodSymbol method)
+    static bool ReturnsExplicitEventSource(IMethodSymbol method)
     {
         var returnType = UnwrapTask(method.ReturnType);
         if (returnType is null)
@@ -150,7 +150,34 @@ public class CommandEventSourceIdAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        return IsEventForEventSourceId(returnType) || IsSequenceOfEventForEventSourceId(returnType);
+        if (IsEventForEventSourceId(returnType) || IsSequenceOfEventForEventSourceId(returnType))
+        {
+            return true;
+        }
+
+        return TupleProvidesExplicitEventSource(returnType);
+    }
+
+    static bool TupleProvidesExplicitEventSource(ITypeSymbol returnType)
+    {
+        if (returnType is not INamedTypeSymbol { IsTupleType: true } tuple)
+        {
+            return false;
+        }
+
+        var elements = tuple.TupleElements;
+
+        // A returned or generated EventForEventSourceId (or a sequence of them) carries its own event source id,
+        // regardless of which position it sits in the tuple.
+        if (elements.Any(element => IsEventForEventSourceId(element.Type) || IsSequenceOfEventForEventSourceId(element.Type)))
+        {
+            return true;
+        }
+
+        // New-stream create: the first element is the event source id — a concept deriving from EventSourceId<T> —
+        // so the event source is the returned/generated id rather than a command property. ICanProvideEventSourceId
+        // is neither needed nor implementable there.
+        return elements.Length > 0 && IsOrDerivesFromEventSourceId(elements[0].Type);
     }
 
     static ITypeSymbol? UnwrapTask(ITypeSymbol returnType)

--- a/Source/DotNET/Chronicle.Specs/Commands/for_ChronicleAppendContract/when_verifying_the_overloads_the_command_pipeline_binds_to.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_ChronicleAppendContract/when_verifying_the_overloads_the_command_pipeline_binds_to.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_ChronicleAppendContract;
+
+/// <summary>
+/// Guards the <see cref="IEventSequence"/> contract that the Arc command append pipeline binds to at compile time.
+/// </summary>
+/// <remarks>
+/// Arc.dll bakes calls to specific <c>AppendMany</c>/<c>Append</c> overloads (see
+/// <c>EventsCommandResponseValueHandler</c> and the single-event append path). Optional parameters are part of a
+/// single method signature, so a trailing optional added or removed in Chronicle produces a *different* method —
+/// Arc compiled against the old signature then throws <c>MissingMethodException</c> against a Chronicle that ships
+/// the new one. This is exactly the regression that the Chronicle floor in <c>Directory.Packages.props</c> guards.
+/// These facts fail at build time the moment the contract drifts, forcing the append call site and the Chronicle
+/// floor to be reviewed together on the next Chronicle bump instead of crashing real consumers at runtime.
+/// </remarks>
+public class when_verifying_the_overloads_the_command_pipeline_binds_to : Specification
+{
+    MethodInfo? _appendMany;
+    MethodInfo? _append;
+
+    void Because()
+    {
+        var methods = typeof(IEventSequence).GetMethods();
+
+        _appendMany = methods.FirstOrDefault(method =>
+            method.Name == "AppendMany" &&
+            method.GetParameters() is { Length: > 1 } parameters &&
+            parameters[1].ParameterType == typeof(IEnumerable<object>));
+
+        _append = methods.FirstOrDefault(method =>
+            method.Name == "Append" &&
+            method.GetParameters() is { Length: > 1 } parameters &&
+            parameters[1].ParameterType == typeof(object));
+    }
+
+    [Fact] void should_expose_the_append_many_collection_overload() => _appendMany.ShouldNotBeNull();
+    [Fact] void should_expose_the_single_append_overload() => _append.ShouldNotBeNull();
+
+    [Fact] void should_keep_the_append_many_signature_the_pipeline_binds_to() =>
+        string.Join(',', _appendMany!.GetParameters().Select(parameter => parameter.Name))
+            .ShouldEqual("eventSourceId,events,eventStreamType,eventStreamId,eventSourceType,correlationId,tags,concurrencyScope,occurred,subject");
+
+    [Fact] void should_keep_the_append_signature_the_pipeline_binds_to() =>
+        string.Join(',', _append!.GetParameters().Select(parameter => parameter.Name))
+            .ShouldEqual("eventSourceId,event,eventStreamType,eventStreamId,eventSourceType,correlationId,tags,concurrencyScope,occurred,subject");
+}

--- a/Source/DotNET/Cratis/build/Cratis.props
+++ b/Source/DotNET/Cratis/build/Cratis.props
@@ -2,4 +2,58 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\..\contentFiles\cs\any\GlobalUsings.cs" Link="GlobalUsings.Cratis.cs" Visible="false" />
   </ItemGroup>
+
+  <!--
+    The Cratis meta package bundles every Cratis Roslyn analyzer/generator into analyzers/dotnet/cs so a single
+    reference to Cratis brings the full set. Some of those same analyzer assemblies (e.g. the Arc source generator
+    and the Fundamentals type-discovery generator) ALSO ship in the individual packages (Cratis.Arc.Core,
+    Cratis.Fundamentals, ...). A consumer that references Cratis AND any package that brings one of those
+    individual packages — directly or transitively (Cratis.Arc.MongoDB -> Cratis.Arc.Core, for example) — ends up
+    with the same generator assembly on two analyzer paths. Roslyn loads each path as a distinct generator and runs
+    it twice, so every unconditionally-generated type is emitted twice and the build fails with CS0101
+    (e.g. 'Cratis.Arc.Generated.GeneratedMarker' already contains a definition).
+
+    De-duplicate @(Analyzer) by file name (keeping the first occurrence) just before compilation. Because this runs
+    in every consumer of the Cratis meta package via buildTransitive, duplicate analyzer DLLs collapse to one
+    regardless of how they were restored. Filename-keyed de-duplication is not expressible with the built-in item
+    functions (which compare by full path), so a tiny inline task does it.
+  -->
+  <UsingTask TaskName="CratisDeduplicateAnalyzersByFileName"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <Analyzers ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Result ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          var seenFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+          var kept = new List<Microsoft.Build.Framework.ITaskItem>();
+          foreach (var analyzer in Analyzers)
+          {
+              var fileName = Path.GetFileName(analyzer.ItemSpec);
+              if (seenFileNames.Add(fileName))
+              {
+                  kept.Add(analyzer);
+              }
+          }
+          Result = kept.ToArray();
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="CratisDeduplicateAnalyzers" BeforeTargets="CoreCompile">
+    <CratisDeduplicateAnalyzersByFileName Analyzers="@(Analyzer)">
+      <Output TaskParameter="Result" ItemName="_CratisDedupedAnalyzer" />
+    </CratisDeduplicateAnalyzersByFileName>
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" />
+      <Analyzer Include="@(_CratisDedupedAnalyzer)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Makes Arc consumable again from the `Cratis` meta package alongside Arc.Chronicle. Arc 20.44.0 broke real consumers at build and runtime; this restores a clean restore-build-run path against released Chronicle.

## Changed

- Raised the minimum required `Cratis.Chronicle` to `15.35.0`.

## Fixed

- Building a project that references the `Cratis` meta package together with a package that transitively brings `Cratis.Arc.Core` (such as `Cratis.Arc.MongoDB`) no longer fails with `CS0101 'Cratis.Arc.Generated.GeneratedMarker'` caused by the Arc source generator being loaded and run twice.
- Arc no longer throws `MissingMethodException` at runtime against released Chronicle. The Chronicle floor now matches the `AppendMany`/`Append` overloads Arc actually calls, so an incompatible Chronicle version fails `dotnet restore` instead of crashing at runtime.
- The `ARCCHR0002` analyzer no longer reports an ambiguous command event source id when the command's `Handle` supplies the event source explicitly through a tuple return — including new-stream-create commands that return a generated id deriving from `EventSourceId<T>`.
