### PR TITLE
Add JsonObjectBsonSerializer for MongoDB

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/given/a_json_object_bson_serializer.cs
+++ b/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/given/a_json_object_bson_serializer.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.given;
+
+public class a_json_object_bson_serializer : Specification
+{
+    protected static JsonObject Deserialize(BsonValue storedValue)
+    {
+        var document = new BsonDocument { { "value", storedValue } };
+        using var reader = new BsonDocumentReader(document);
+        reader.ReadStartDocument();
+        reader.ReadName();
+
+        var serializer = new JsonObjectBsonSerializer();
+        var context = BsonDeserializationContext.CreateRoot(reader);
+        var result = serializer.Deserialize(context, new BsonDeserializationArgs { NominalType = typeof(JsonObject) });
+
+        reader.ReadEndDocument();
+        return result;
+    }
+
+    protected static BsonDocument Serialize(JsonObject value)
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        var serializer = new JsonObjectBsonSerializer();
+        var context = BsonSerializationContext.CreateRoot(writer);
+        serializer.Serialize(context, new BsonSerializationArgs { NominalType = typeof(JsonObject) }, value);
+        return document;
+    }
+}

--- a/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_deserializing/a_bson_document.cs
+++ b/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_deserializing/a_bson_document.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.given;
+using MongoDB.Bson;
+
+namespace Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.when_deserializing;
+
+public class a_bson_document : a_json_object_bson_serializer
+{
+    JsonObject _result;
+
+    void Because() => _result = Deserialize(new BsonDocument { { "name", "test" }, { "count", 42 } });
+
+    [Fact] void should_contain_the_name_property() => _result["name"]!.GetValue<string>().ShouldEqual("test");
+    [Fact] void should_contain_the_count_property() => _result["count"]!.GetValue<int>().ShouldEqual(42);
+}

--- a/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_deserializing/a_null_bson_value.cs
+++ b/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_deserializing/a_null_bson_value.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.given;
+using MongoDB.Bson;
+
+namespace Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.when_deserializing;
+
+public class a_null_bson_value : a_json_object_bson_serializer
+{
+    JsonObject _result;
+
+    void Because() => _result = Deserialize(BsonNull.Value);
+
+    [Fact] void should_return_an_empty_json_object() => _result.ShouldBeEmpty();
+}

--- a/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_serializing/a_json_object.cs
+++ b/Source/DotNET/MongoDB.Specs/for_JsonObjectBsonSerializer/when_serializing/a_json_object.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.given;
+using MongoDB.Bson;
+
+namespace Cratis.Arc.MongoDB.for_JsonObjectBsonSerializer.when_serializing;
+
+public class a_json_object : a_json_object_bson_serializer
+{
+    BsonDocument _result;
+    JsonObject _input;
+
+    void Establish() => _input = new JsonObject { { "name", "test" }, { "count", 42 } };
+
+    void Because() => _result = Serialize(_input);
+
+    [Fact] void should_contain_the_name_property() => _result["name"].AsString.ShouldEqual("test");
+    [Fact] void should_contain_the_count_property() => _result["count"].AsInt32.ShouldEqual(42);
+}

--- a/Source/DotNET/MongoDB/JsonObjectBsonSerializer.cs
+++ b/Source/DotNET/MongoDB/JsonObjectBsonSerializer.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Cratis.Arc.MongoDB;
+
+/// <summary>
+/// MongoDB BSON serializer for <see cref="JsonObject"/>.
+/// </summary>
+/// <remarks>
+/// Read models persisted through Arc.MongoDB are serialized with the MongoDB BSON serializers. The driver has no
+/// built-in support for <see cref="JsonObject"/>, so without this it falls back to dictionary serialization and
+/// fails on read because <see cref="JsonObject"/> has no parameterless constructor. This bridges BSON and
+/// <see cref="JsonObject"/> by round-tripping through a <see cref="BsonDocument"/>.
+/// </remarks>
+public class JsonObjectBsonSerializer : SerializerBase<JsonObject>
+{
+    static readonly JsonWriterSettings _relaxedJson = new() { OutputMode = JsonOutputMode.RelaxedExtendedJson };
+
+    /// <inheritdoc/>
+    public override JsonObject Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        if (context.Reader.GetCurrentBsonType() == BsonType.Null)
+        {
+            context.Reader.ReadNull();
+            return [];
+        }
+
+        var document = BsonDocumentSerializer.Instance.Deserialize(context, args);
+        return JsonNode.Parse(document.ToJson(_relaxedJson))!.AsObject();
+    }
+
+    /// <inheritdoc/>
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, JsonObject value)
+    {
+        if (value is null)
+        {
+            context.Writer.WriteNull();
+            return;
+        }
+
+        BsonDocumentSerializer.Instance.Serialize(context, args, BsonDocument.Parse(value.ToJsonString()));
+    }
+}

--- a/Source/DotNET/MongoDB/MongoDBDefaults.cs
+++ b/Source/DotNET/MongoDB/MongoDBDefaults.cs
@@ -63,6 +63,8 @@ public static class MongoDBDefaults
                 .RegisterSerializer(new LineStringSerializer());
             BsonSerializer
                 .RegisterSerializer(new PolygonSerializer());
+            BsonSerializer
+                .RegisterSerializer(new JsonObjectBsonSerializer());
 
             // When you have types with properties defined as object but could hold a Guid, the GuidRepresentation gets by default set to Unspecified.
             // By adding an object serializer for object configured explicitly with the Standard representation it should get serialized correctly and not throw an exception.


### PR DESCRIPTION
## Added
- Read models with `JsonObject` properties can now be persisted and queried through Arc.MongoDB without falling back to broken dictionary serialization.