### PR TITLE
Add read model state seeding to command scenarios

### DIFF
--- a/Documentation/backend/testing/chronicle.md
+++ b/Documentation/backend/testing/chronicle.md
@@ -25,11 +25,12 @@ Or via the meta-package:
 
 ## Basic Usage
 
-Use the same `CommandScenario<TCommand>` class as for non-Chronicle commands. When the Chronicle testing package is present, four extension properties are available directly on the scenario:
+Use the same `CommandScenario<TCommand>` class as for non-Chronicle commands. When the Chronicle testing package is present, these extension properties are available directly on the scenario:
 
 | Property | Type | Purpose |
 | -------- | ---- | ------- |
-| `EventScenario` | `EventScenario` | The full scenario object — use for seeding via `Given` |
+| `Given` | `CommandScenarioChronicleGivenBuilder<TCommand>` | Seed the read model state a command observes — `Given.ForEventSource(id).Events(...)` or `.ReadModel(...)` |
+| `EventScenario` | `EventScenario` | The full event scenario — use `EventScenario.Given` to seed the event log |
 | `EventLog` | `IEventLog` | The in-memory event log — use for appending and assertions |
 | `EventSequence` | `IEventSequence` | The same instance as `EventLog` — use with Chronicle's assertion helpers |
 | `AppendedEvents` | `IReadOnlyList<AppendedEventWithResult>` | The events captured during command execution |
@@ -173,23 +174,50 @@ void should_have_exactly_two_events() =>
 
 ## Testing Commands That Take Read Model Dependencies
 
-`CommandScenario<TCommand>` also supports direct read model dependencies in command handlers and validators, using the same convention-based registration as runtime (`IProjectionFor<T>` and model-bound projections).
+A command handler, `Provide` method, or `CommandValidator<T>` can take a read model as a parameter — Arc resolves it for the command's event source id exactly as it does at runtime (`IProjectionFor<T>`, `IReducerFor<T>`, and model-bound projections). To test such a command you need to control what that read model contains, and the awkward way is to hand-mock `IReadModels`.
 
-In tests, you can keep things deterministic by overriding `IReadModels` and returning the instance you want for the current event source id:
+`_scenario.Given.ForEventSource(id)` does it for you, two ways: seed the **events** the read model is built from, or pin a materialized **instance** directly.
+
+### Seeding Read Model State from Events
+
+State the events that happened for the event source. Any read model a command injects for that source is materialized from those events through its own reducer or projection — you never name the read model type here, just as you never do in production:
 
 ```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+public class when_withdrawing_with_sufficient_funds : Specification
+{
+    readonly EventSourceId _accountId = EventSourceId.New();
+    readonly CommandScenario<Withdraw> _scenario = new();
+    CommandResult _result = default!;
 
-var scenario = new CommandScenario<UseReadModelDependencyCommand>();
-var readModels = Substitute.For<IReadModels>();
+    void Establish() =>
+        _scenario.Given
+            .ForEventSource(_accountId)
+            .Events(new MoneyDeposited(100m), new MoneyDeposited(50m));
 
-readModels
-    .GetInstanceById(typeof(AccountBalanceReadModel), Arg.Any<ReadModelKey>(), default)
-    .Returns(Task.FromResult<object>(new AccountBalanceReadModel(42m)));
+    async Task Because() =>
+        _result = await _scenario.Execute(new Withdraw(_accountId, 120m));
 
-scenario.Services.Replace(ServiceDescriptor.Singleton<IReadModels>(readModels));
+    [Fact] void should_succeed() =>
+        _result.ShouldBeSuccessful();
+}
 ```
+
+Events are the facts; read models are derived from them. One `Events(...)` call feeds *every* read model built from those events: if the command injects both an `AccountBalance` and an `AccountStatement`, both are materialized from the same events — no read model type appears in the test.
+
+This is distinct from `_scenario.EventScenario.Given` above: that seeds the event **log** (prior facts the handler may read or append against); this seeds the **read model state** the command observes through its injected parameters.
+
+### Pinning a Read Model Instance
+
+When you would rather assert against a known value than express the events behind it, pin the instance directly. The read model type is inferred from the value:
+
+```csharp
+void Establish() =>
+    _scenario.Given
+        .ForEventSource(_accountId)
+        .ReadModel(new AccountBalance(150m));
+```
+
+A read model seeded for one event source is not visible to a command targeting another: resolving an unseeded source yields `null`, so a command that injects a nullable read model parameter sees `null`, exactly as in production.
 
 ## Multiple Events
 
@@ -230,13 +258,14 @@ When `Cratis.Arc.Chronicle.Testing` is referenced, `ChronicleCommandScenarioExte
 - `IEventTypes` → discovered from the assemblies loaded in the test process (same convention used in production)
 - `IEventLog` → backed by the real in-process Chronicle kernel (no server required)
 - `IEventSequence` → the same in-process instance
-- `IReadModels` and convention-registered read model services → enabling direct read model dependencies in handlers and validators
+- `IReadModels` → resolves a command's injected read models from the state seeded with the `Given` builder — by projecting seeded events on demand, or from a pinned instance — enabling direct read model dependencies in handlers, validators, and `Provide` methods
 
-It also populates the scenario context with an `EventScenario` instance, which is exposed through C# 14 extension properties:
+It also populates the scenario context, exposed through C# 14 extension properties:
 
 | Property | Type | Purpose |
 | -------- | ---- | ------- |
-| `EventScenario` | `EventScenario` | The full scenario, including the `Given` builder for seeding events |
+| `Given` | `CommandScenarioChronicleGivenBuilder<TCommand>` | The given builder for seeding read model state — `ForEventSource(id).Events(...)` or `.ReadModel(...)` |
+| `EventScenario` | `EventScenario` | The full scenario, including the `Given` builder for seeding the event log |
 | `EventLog` | `IEventLog` | Shortcut to `EventScenario.EventLog` for Chronicle's own assertion helpers |
 | `EventSequence` | `IEventSequence` | Shortcut to `EventScenario.EventSequence` for Chronicle's assertion helpers |
 | `AppendedEvents` | `IReadOnlyList<AppendedEventWithResult>` | All events captured during command execution, used by `ShouldHaveAppendedEvent` and `ShouldHaveTailSequenceNumber` |

--- a/Documentation/backend/testing/index.md
+++ b/Documentation/backend/testing/index.md
@@ -23,7 +23,7 @@ The `CommandScenario<TCommand>` class is the single entry point for all command 
 | Topic | Description |
 | ------- | ----------- |
 | [Command Scenarios](./command-scenario.md) | How to test commands with `CommandScenario<TCommand>` and the `CommandResult` assertion helpers. |
-| [Chronicle Extension](./chronicle.md) | How the Chronicle in-memory event log activates automatically and how to seed events and assert against the log. |
+| [Chronicle Extension](./chronicle.md) | How the Chronicle in-memory event log activates automatically, how to seed events and read model state, and how to assert against the log. |
 
 ## Quick Start
 

--- a/Documentation/scenarios/test-a-command.md
+++ b/Documentation/scenarios/test-a-command.md
@@ -52,4 +52,5 @@ The `CommandResult` assertion helpers — `ShouldBeSuccessful`, `ShouldHaveValid
 ## See also
 
 - [Command Scenarios](/arc/backend/testing/command-scenario/) — the full API and every assertion helper.
+- [Testing Chronicle commands](/arc/backend/testing/chronicle/) — seed the read model state a command reads (from events or a pinned instance) and assert the events it appended.
 - [Testing](/arc/backend/testing/) — the testing packages and the Chronicle in-memory event log.

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/LedgerBalance.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/LedgerBalance.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+using FluentValidation;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario;
+
+/// <summary>
+/// A read model materialized from ledger events by a reducer, used to verify the events-based
+/// read model seeding path of a command scenario.
+/// </summary>
+public record LedgerBalance
+{
+    /// <summary>
+    /// Gets the current balance.
+    /// </summary>
+    public decimal Balance { get; init; }
+}
+
+/// <summary>
+/// The reducer that materializes <see cref="LedgerBalance"/> from ledger events.
+/// </summary>
+public class LedgerBalanceReducer : IReducerFor<LedgerBalance>
+{
+    public LedgerBalance Credited(LedgerCredited @event, LedgerBalance? current) =>
+        new() { Balance = (current?.Balance ?? 0m) + @event.Amount };
+
+    public LedgerBalance Debited(LedgerDebited @event, LedgerBalance? current) =>
+        new() { Balance = (current?.Balance ?? 0m) - @event.Amount };
+}
+
+[Command]
+public record SettleLedger(EventSourceId EventSourceId)
+{
+    public LedgerSettled Handle(LedgerBalance balance) => new(balance.Balance);
+}
+
+public class SettleLedgerValidator : CommandValidator<SettleLedger>
+{
+    public SettleLedgerValidator(LedgerBalance balance) =>
+        RuleFor(command => command.EventSourceId)
+            .Must(_ => balance.Balance > 0)
+            .WithMessage("Ledger has no funds to settle.");
+}
+
+/// <summary>
+/// A read model materialized from ledger events by a reducer, but without a parameterless constructor — used to
+/// verify that the events-based seeding path materializes a read model that cannot be created by convention.
+/// </summary>
+/// <param name="Balance">The current balance.</param>
+public record StatementBalance(decimal Balance);
+
+/// <summary>
+/// The reducer that materializes <see cref="StatementBalance"/> from ledger events.
+/// </summary>
+public class StatementBalanceReducer : IReducerFor<StatementBalance>
+{
+    public StatementBalance Credited(LedgerCredited @event, StatementBalance? current) =>
+        new((current?.Balance ?? 0m) + @event.Amount);
+}
+
+[Command]
+public record SettleStatement(EventSourceId EventSourceId)
+{
+    public LedgerSettled Handle(StatementBalance balance) => new(balance.Balance);
+}
+
+[Command]
+public record SummarizeLedger(EventSourceId EventSourceId)
+{
+    public LedgerSummarized Handle(LedgerBalance balance, StatementBalance statement) => new(balance.Balance, statement.Balance);
+}
+
+[EventType("1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d")]
+public record LedgerCredited(decimal Amount);
+
+[EventType("4d5e6f70-8192-4d0e-9f1a-2b3c4d5e6f80")]
+public record LedgerSummarized(decimal BalanceTotal, decimal StatementTotal);
+
+[EventType("2b3c4d5e-6f70-4b8c-9d0e-1f2a3b4c5d6e")]
+public record LedgerDebited(decimal Amount);
+
+[EventType("3c4d5e6f-7081-4c9d-0e1f-2a3b4c5d6e7f")]
+public record LedgerSettled(decimal Balance);

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/feeding_multiple_read_models.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/feeding_multiple_read_models.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_from_events;
+
+public class feeding_multiple_read_models : Specification
+{
+    CommandScenario<SummarizeLedger> _scenario;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<SummarizeLedger>();
+        _scenario.Given.ForEventSource(_eventSourceId).Events(new LedgerCredited(10m));
+    }
+
+    async Task Because() => await _scenario.Execute(new SummarizeLedger(_eventSourceId));
+
+    [Fact] async Task should_materialize_every_read_model_built_from_the_events_without_naming_any() =>
+        await _scenario.ShouldHaveAppendedEvent<SummarizeLedger, LedgerSummarized>(
+            _eventSourceId,
+            @event => @event.BalanceTotal == 10m && @event.StatementTotal == 10m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/for_a_read_model_without_a_parameterless_constructor.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/for_a_read_model_without_a_parameterless_constructor.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_from_events;
+
+public class for_a_read_model_without_a_parameterless_constructor : Specification
+{
+    CommandScenario<SettleStatement> _scenario;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<SettleStatement>();
+        _scenario.Given.ForEventSource(_eventSourceId).Events(new LedgerCredited(7m));
+    }
+
+    async Task Because() => await _scenario.Execute(new SettleStatement(_eventSourceId));
+
+    [Fact] async Task should_materialize_the_read_model_from_the_events() =>
+        await _scenario.ShouldHaveAppendedEvent<SettleStatement, LedgerSettled>(_eventSourceId, @event => @event.Balance == 7m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_handle.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_handle.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_from_events;
+
+public class into_a_command_handle : Specification
+{
+    CommandScenario<SettleLedger> _scenario;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<SettleLedger>();
+        _scenario.Given.ForEventSource(_eventSourceId).Events(new LedgerCredited(40m), new LedgerCredited(2m));
+    }
+
+    async Task Because() => await _scenario.Execute(new SettleLedger(_eventSourceId));
+
+    [Fact] async Task should_inject_the_read_model_materialized_from_the_events() =>
+        await _scenario.ShouldHaveAppendedEvent<SettleLedger, LedgerSettled>(_eventSourceId, @event => @event.Balance == 42m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_validator/and_state_allows_command.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_validator/and_state_allows_command.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_from_events.into_a_command_validator;
+
+public class and_state_allows_command : Specification
+{
+    CommandScenario<SettleLedger> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<SettleLedger>();
+        _scenario.Given.ForEventSource(_eventSourceId).Events(new LedgerCredited(42m));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new SettleLedger(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_have_appended_the_event() => await _scenario.ShouldHaveAppendedEvent<SettleLedger, LedgerSettled>(_eventSourceId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_validator/and_state_rejects_command.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_from_events/into_a_command_validator/and_state_rejects_command.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_from_events.into_a_command_validator;
+
+public class and_state_rejects_command : Specification
+{
+    CommandScenario<SettleLedger> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<SettleLedger>();
+        _scenario.Given.ForEventSource(_eventSourceId).Events(new LedgerCredited(40m), new LedgerDebited(40m));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new SettleLedger(_eventSourceId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_validation_error_from_the_materialized_read_model() => _result.ValidationResults.First().Message.ShouldEqual("Ledger has no funds to settle.");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/and_command_targets_a_different_event_source.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/and_command_targets_a_different_event_source.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_instance;
+
+public class and_command_targets_a_different_event_source : Specification
+{
+    CommandScenario<UseNullableReducerReadModelInHandle> _scenario;
+    EventSourceId _seededEventSourceId;
+    EventSourceId _commandEventSourceId;
+
+    void Establish()
+    {
+        _seededEventSourceId = EventSourceId.New();
+        _commandEventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<UseNullableReducerReadModelInHandle>();
+        _scenario.Given.ForEventSource(_seededEventSourceId).ReadModel(new ReducerAccountSummary(100m, false));
+    }
+
+    async Task Because() => await _scenario.Execute(new UseNullableReducerReadModelInHandle(_commandEventSourceId));
+
+    [Fact] async Task should_inject_null_because_nothing_is_seeded_for_the_command_event_source() =>
+        await _scenario.ShouldHaveAppendedEvent<UseNullableReducerReadModelInHandle, ReducerReadModelAbsence>(_commandEventSourceId, @event => @event.WasAbsent);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_handle.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_handle.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_instance;
+
+public class into_a_command_handle : Specification
+{
+    CommandScenario<UseReadModelDependencyCommand> _scenario;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<UseReadModelDependencyCommand>();
+        _scenario.Given.ForEventSource(_eventSourceId).ReadModel(new AccountBalanceReadModel(42m));
+    }
+
+    async Task Because() => await _scenario.Execute(new UseReadModelDependencyCommand(_eventSourceId));
+
+    [Fact] async Task should_inject_the_seeded_read_model_into_the_handler() =>
+        await _scenario.ShouldHaveAppendedEvent<UseReadModelDependencyCommand, ReadModelDependencyUsed>(_eventSourceId, @event => @event.Balance == 42m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_provide.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_provide.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_instance;
+
+public class into_a_command_provide : Specification
+{
+    CommandScenario<ProvideReadModelDependencyCommand> _scenario;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<ProvideReadModelDependencyCommand>();
+        _scenario.Given.ForEventSource(_eventSourceId).ReadModel(new AccountBalanceReadModel(42m));
+    }
+
+    async Task Because() => await _scenario.Execute(new ProvideReadModelDependencyCommand(_eventSourceId));
+
+    [Fact] async Task should_inject_the_seeded_read_model_into_provide() =>
+        await _scenario.ShouldHaveAppendedEvent<ProvideReadModelDependencyCommand, ReadModelDependencyProvided>(_eventSourceId, @event => @event.Balance == 42m);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_validator/and_state_allows_command.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_validator/and_state_allows_command.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_instance.into_a_command_validator;
+
+public class and_state_allows_command : Specification
+{
+    CommandScenario<WithdrawFunds> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFunds>();
+        _scenario.Given.ForEventSource(_eventSourceId).ReadModel(new AccountBalanceReadModel(100m));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFunds(_eventSourceId));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_have_appended_the_event() => await _scenario.ShouldHaveAppendedEvent<WithdrawFunds, FundsWithdrawn>(_eventSourceId);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_validator/and_state_rejects_command.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_CommandScenario/when_seeding_read_model_instance/into_a_command_validator/and_state_rejects_command.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_CommandScenario.when_seeding_read_model_instance.into_a_command_validator;
+
+public class and_state_rejects_command : Specification
+{
+    CommandScenario<WithdrawFunds> _scenario;
+    CommandResult _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scenario = new CommandScenario<WithdrawFunds>();
+        _scenario.Given.ForEventSource(_eventSourceId).ReadModel(new AccountBalanceReadModel(0m));
+    }
+
+    async Task Because() => _result = await _scenario.Execute(new WithdrawFunds(_eventSourceId));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_validation_error_from_the_seeded_read_model() => _result.ValidationResults.First().Message.ShouldEqual("Account has insufficient funds.");
+    [Fact] void should_not_have_appended_events() => _scenario.AppendedEvents.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle.Testing/Commands/ChronicleCommandScenarioExtender.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/ChronicleCommandScenarioExtender.cs
@@ -7,6 +7,7 @@ using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Testing;
 using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Testing.ReadModels;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Arc.Chronicle.Testing.Commands;
@@ -40,22 +41,29 @@ public class ChronicleCommandScenarioExtender : ICommandScenarioExtender
     /// </summary>
     public const string AppendedEventsKey = "Chronicle.AppendedEvents";
 
+    /// <summary>
+    /// The context key used to store the <see cref="CommandScenarioReadModels"/> that seeded read model state is held in.
+    /// </summary>
+    internal const string ReadModelsKey = "Chronicle.ReadModels";
+
     /// <inheritdoc/>
     public void Extend(IServiceCollection services, IDictionary<string, object> context)
     {
         var eventScenario = new EventScenario();
         var appendedEvents = new List<AppendedEventWithResult>();
+        var readModels = new CommandScenarioReadModels(new ReadModelsForTesting(Defaults.Instance.EventStore.ReadModels));
 
         eventScenario.EventLog.AppendOperations.Subscribe(appendedEvents.AddRange);
 
         services.AddSingleton(Defaults.Instance.EventTypes);
         services.AddSingleton(eventScenario.EventLog);
         services.AddSingleton(eventScenario.EventSequence);
-        services.AddSingleton<IReadModels>(_ => Defaults.Instance.EventStore.ReadModels);
+        services.AddSingleton<IReadModels>(readModels);
         services.AddReadModels(Defaults.Instance.ClientArtifactsProvider);
-        services.AddSingleton<IEventStore>(_ => new EventStoreForScenario(eventScenario));
+        services.AddSingleton<IEventStore>(_ => new EventStoreForScenario(eventScenario, readModels));
 
         context[ContextKey] = eventScenario;
         context[AppendedEventsKey] = appendedEvents;
+        context[ReadModelsKey] = readModels;
     }
 }

--- a/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioChronicleExtensions.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioChronicleExtensions.cs
@@ -51,5 +51,11 @@ public static class CommandScenarioChronicleExtensions
         /// </remarks>
         public IReadOnlyList<AppendedEventWithResult> AppendedEvents =>
             (List<AppendedEventWithResult>)scenario.Context[ChronicleCommandScenarioExtender.AppendedEventsKey];
+
+        /// <summary>
+        /// Gets the Chronicle-specific given builder for setting up command scenario state.
+        /// </summary>
+        public CommandScenarioChronicleGivenBuilder<TCommand> Given =>
+            new(scenario);
     }
 }

--- a/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioChronicleGivenBuilder.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioChronicleGivenBuilder.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+/// <summary>
+/// Provides Chronicle-specific given setup for a <see cref="CommandScenario{TCommand}"/>.
+/// </summary>
+/// <typeparam name="TCommand">Type of command the scenario is for.</typeparam>
+public sealed class CommandScenarioChronicleGivenBuilder<TCommand>
+{
+    readonly CommandScenario<TCommand> _scenario;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandScenarioChronicleGivenBuilder{TCommand}"/> class.
+    /// </summary>
+    /// <param name="scenario">The command scenario to set up.</param>
+    internal CommandScenarioChronicleGivenBuilder(CommandScenario<TCommand> scenario) =>
+        _scenario = scenario;
+
+    /// <summary>
+    /// Selects the event source id to set up read model state for.
+    /// </summary>
+    /// <param name="eventSourceId">The event source id.</param>
+    /// <returns>A builder for seeding events or a pinned read model instance for the selected source.</returns>
+    public CommandScenarioSourceGivenBuilder<TCommand> ForEventSource(EventSourceId eventSourceId) =>
+        new(_scenario, eventSourceId);
+}

--- a/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioReadModels.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioReadModels.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Testing.ReadModels;
+
+namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+/// <summary>
+/// An <see cref="IReadModels"/> for command scenarios that resolves a read model either from a pinned instance or by
+/// projecting seeded events through the read model's own reducer or projection — keyed by event source id.
+/// </summary>
+/// <param name="inner">The inner <see cref="IReadModels"/> to delegate non-resolution operations to.</param>
+/// <remarks>
+/// Seeding events is deliberately type-agnostic: a test states the events that happened for an event source, and any
+/// read model a command injects for that source is materialized from those events on demand — mirroring how the real
+/// system derives read models from the event log. Pinned instances take precedence when a test wants to assert against
+/// a specific read model value directly.
+/// </remarks>
+internal sealed class CommandScenarioReadModels(IReadModels inner) : IReadModels
+{
+    readonly Dictionary<(Type ReadModelType, string EventSourceId), object> _instances = [];
+    readonly Dictionary<string, List<object>> _events = [];
+
+    /// <inheritdoc/>
+    public IMaterializedReadModels Materialized => inner.Materialized;
+
+    /// <summary>
+    /// Pins a materialized read model instance for an event source id.
+    /// </summary>
+    /// <param name="readModelType">The read model type.</param>
+    /// <param name="eventSourceId">The event source id to associate the instance with.</param>
+    /// <param name="instance">The read model instance.</param>
+    public void SeedInstance(Type readModelType, EventSourceId eventSourceId, object instance) =>
+        _instances[(readModelType, eventSourceId.Value)] = instance;
+
+    /// <summary>
+    /// Seeds events for an event source id that read models are materialized from on demand.
+    /// </summary>
+    /// <param name="eventSourceId">The event source id the events happened for.</param>
+    /// <param name="events">The events to seed.</param>
+    public void SeedEvents(EventSourceId eventSourceId, IEnumerable<object> events)
+    {
+        if (!_events.TryGetValue(eventSourceId.Value, out var seeded))
+        {
+            seeded = [];
+            _events[eventSourceId.Value] = seeded;
+        }
+
+        seeded.AddRange(events);
+    }
+
+    /// <inheritdoc/>
+    public async Task<object> GetInstanceById(Type readModelType, ReadModelKey key, ReadModelSessionId? sessionId = null)
+    {
+        if (_instances.TryGetValue((readModelType, key.Value), out var instance))
+        {
+            return instance;
+        }
+
+        if (_events.TryGetValue(key.Value, out var events))
+        {
+            return (await ProjectReadModel(readModelType, new EventSourceId(key.Value), events))!;
+        }
+
+        // Nothing seeded for this event source id: the read model does not exist. Command-scoped code can inject a
+        // nullable read model and treat null as "does not exist", exactly as in production. We do not fall through to
+        // the inner read models, which would require a live Chronicle backing store that a command scenario has not.
+        return null!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<TReadModel> GetInstanceById<TReadModel>(ReadModelKey key, ReadModelSessionId? sessionId = null) =>
+        (TReadModel)await GetInstanceById(typeof(TReadModel), key, sessionId);
+
+    /// <inheritdoc/>
+    public Task Register() => inner.Register();
+
+    /// <inheritdoc/>
+    public Task Register<TReadModel>() => inner.Register<TReadModel>();
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<TReadModel>> GetInstances<TReadModel>(EventCount? eventCount = null) => inner.GetInstances<TReadModel>(eventCount);
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<ReadModelSnapshot<TReadModel>>> GetSnapshotsById<TReadModel>(ReadModelKey readModelKey) => inner.GetSnapshotsById<TReadModel>(readModelKey);
+
+    /// <inheritdoc/>
+    public IObservable<ReadModelChangeset<TReadModel>> Watch<TReadModel>() => inner.Watch<TReadModel>();
+
+    /// <inheritdoc/>
+    public IReadModelWatcher<TReadModel> GetWatcherFor<TReadModel>() => inner.GetWatcherFor<TReadModel>();
+
+    /// <inheritdoc/>
+    public Task DehydrateSession(ReadModelSessionId sessionId, Type readModelType, ReadModelKey readModelKey) => inner.DehydrateSession(sessionId, readModelType, readModelKey);
+
+    /// <inheritdoc/>
+    public Task<TReadModel> Release<TReadModel>(TReadModel instance) => inner.Release(instance);
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<TReadModel>> Release<TReadModel>(IEnumerable<TReadModel> instances) => inner.Release(instances);
+
+    static async Task<object?> ProjectReadModel(Type readModelType, EventSourceId eventSourceId, IEnumerable<object> events)
+    {
+        // ReadModelScenario<T> is Chronicle's own engine for materializing a read model from events through its real
+        // reducer or projection — we build on it here rather than reimplementing projection. Reflection is used only
+        // because it is generic and the read model type is known at runtime. We read the materialized Instance and
+        // deliberately do NOT route through its ReadModels facade: that facade throws ("Read model returned null")
+        // when a read model does not exist instead of returning null, which would break the nullable "does not exist"
+        // semantics command-scoped code relies on.
+        var scenarioType = typeof(ReadModelScenario<>).MakeGenericType(readModelType);
+        var scenario = Activator.CreateInstance(scenarioType, CreateSeed(readModelType))!;
+
+        var processTask = (Task)scenarioType.GetMethod("ProcessEventsFor")!.Invoke(scenario, [eventSourceId, events])!;
+        await processTask;
+
+        return scenarioType.GetProperty("Instance")!.GetValue(scenario);
+    }
+
+    static object CreateSeed(Type readModelType)
+    {
+        try
+        {
+            return Activator.CreateInstance(readModelType)!;
+        }
+        catch (MissingMethodException)
+        {
+            return RuntimeHelpers.GetUninitializedObject(readModelType);
+        }
+    }
+}

--- a/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioSourceGivenBuilder.cs
+++ b/Source/DotNET/Chronicle.Testing/Commands/CommandScenarioSourceGivenBuilder.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Testing.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Testing.Commands;
+
+/// <summary>
+/// Provides read model state setup for a specific event source id.
+/// </summary>
+/// <typeparam name="TCommand">Type of command the scenario is for.</typeparam>
+public sealed class CommandScenarioSourceGivenBuilder<TCommand>
+{
+    readonly CommandScenario<TCommand> _scenario;
+    readonly EventSourceId _eventSourceId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandScenarioSourceGivenBuilder{TCommand}"/> class.
+    /// </summary>
+    /// <param name="scenario">The command scenario to seed into.</param>
+    /// <param name="eventSourceId">The event source id to set up state for.</param>
+    internal CommandScenarioSourceGivenBuilder(CommandScenario<TCommand> scenario, EventSourceId eventSourceId)
+    {
+        _scenario = scenario;
+        _eventSourceId = eventSourceId;
+    }
+
+    /// <summary>
+    /// Seeds the events that happened for the event source. Any read model a command injects for this source is
+    /// materialized from these events through its own reducer or projection — no read model type is named here.
+    /// </summary>
+    /// <param name="events">The events that happened, in order.</param>
+    public void Events(params object[] events) =>
+        ReadModels().SeedEvents(_eventSourceId, events);
+
+    /// <summary>
+    /// Pins a materialized read model instance for the event source, used when a test wants the command to observe a
+    /// specific read model value directly instead of deriving it from events.
+    /// </summary>
+    /// <typeparam name="TReadModel">Type of read model to pin. Inferred from <paramref name="readModel"/>.</typeparam>
+    /// <param name="readModel">The read model instance.</param>
+    public void ReadModel<TReadModel>(TReadModel readModel)
+        where TReadModel : class =>
+        ReadModels().SeedInstance(typeof(TReadModel), _eventSourceId, readModel);
+
+    CommandScenarioReadModels ReadModels() =>
+        (CommandScenarioReadModels)_scenario.Context[ChronicleCommandScenarioExtender.ReadModelsKey];
+}

--- a/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
+++ b/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
@@ -25,7 +25,8 @@ namespace Cratis.Arc.Chronicle.Testing;
 /// Represents an <see cref="IEventStore"/> backed by an in-memory <see cref="EventScenario"/>.
 /// </summary>
 /// <param name="eventScenario">The in-memory <see cref="EventScenario"/> to route operations through.</param>
-internal sealed class EventStoreForScenario(EventScenario eventScenario) : IEventStore
+/// <param name="readModels">The read models to expose through the event store.</param>
+internal sealed class EventStoreForScenario(EventScenario eventScenario, IReadModels readModels) : IEventStore
 {
     /// <inheritdoc/>
     public EventStoreName Name => "test-event-store";
@@ -80,8 +81,7 @@ internal sealed class EventStoreForScenario(EventScenario eventScenario) : IEven
         throw new NotSupportedException("Failed partitions are not supported for command scenarios.");
 
     /// <inheritdoc/>
-    public IReadModels ReadModels =>
-        throw new NotSupportedException("Read models are not supported for command scenarios.");
+    public IReadModels ReadModels => readModels;
 
     /// <inheritdoc/>
     public IEventSeeding Seeding =>


### PR DESCRIPTION
## Added

- Command scenario tests can seed the read model state a command observes from events — `Given.ForEventSource(id).Events(...)` materializes any read model the command injects for that source through its own reducer or projection, with no read model type named.
- Command scenario tests can pin a read model instance directly for a command with `Given.ForEventSource(id).ReadModel(instance)`.
