### PR TITLE
Fix Publish workflow skipping dependency-only PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,11 @@ on:
       - "**"
     paths:
       - "Source/**"
+      - "Directory.Build.props"
+      - "Directory.Packages.props"
+      - "Directory.Packages.*.props"
+      - "package.json"
+      - "global.json"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Fixed
- Dependency-only PRs (bumping `Directory.Packages.props` or `package.json`) no longer silently skip the release/publish pipeline.

## Summary
The `Publish` workflow only triggers on PRs that touch `Source/**`. PRs that exclusively bump versions in root manifests (`Directory.Packages.props`, `package.json`) never matched that filter, so the workflow never ran at all — no release, no NuGet/npm publish, even when labeled `patch`. This has silently happened before (#2185, #2246) and required a manual `workflow_dispatch` to recover; this time #2316 and #2317 went unreleased. Widen the `paths` filter to also include the root dependency/version manifests that actually drive these releases.