### PR TITLE
Fix Microsoft.OpenApi high-severity vulnerability blocking builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,9 @@
     <!-- SQLitePCLRaw 2.1.10/2.1.11 (pulled in transitively by EF Core Sqlite) has a high-severity advisory
          (GHSA-2m69-gcr7-jv3q). Pin the native library to the patched release. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <!-- Microsoft.OpenApi 2.0.0 (pulled in transitively by Microsoft.AspNetCore.OpenApi) has a high-severity
+         advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Chronicle" Version="15.38.0" />
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.38.0" />


### PR DESCRIPTION
## Fixed
- Resolved a high-severity vulnerability (GHSA-v5pm-xwqc-g5wc) in the transitive `Microsoft.OpenApi` dependency by pinning it to the patched `2.7.5` release.

## Summary
`Microsoft.AspNetCore.OpenApi` transitively pulls in `Microsoft.OpenApi` 2.0.0, which has a known high-severity advisory for circular schema references terminating OpenAPI parsing. NuGetAudit treats this as a build error (`NU1903`), which has been silently failing the daily `Update Packages` workflow since the advisory was published, and blocks any Release-configuration build outright.