### PR TITLE
Fix MA0206 unnecessary-braces violations blocking Release builds

### DIFF
--- a/Source/DotNET/Arc.Core/Authorization/AmbiguousAuthorizationLevel.cs
+++ b/Source/DotNET/Arc.Core/Authorization/AmbiguousAuthorizationLevel.cs
@@ -11,6 +11,4 @@ namespace Cratis.Arc.Authorization;
 /// </summary>
 /// <param name="member">The member with ambiguous authorization.</param>
 public class AmbiguousAuthorizationLevel(MemberInfo member)
-    : Exception($"Member '{member.DeclaringType?.FullName}.{member.Name}' has both [Authorize] and [AllowAnonymous] attributes defined, which is ambiguous.")
-{
-}
+    : Exception($"Member '{member.DeclaringType?.FullName}.{member.Name}' has both [Authorize] and [AllowAnonymous] attributes defined, which is ambiguous.");

--- a/Source/DotNET/Arc.Core/Commands/CannotResolveCommandDependency.cs
+++ b/Source/DotNET/Arc.Core/Commands/CannotResolveCommandDependency.cs
@@ -10,6 +10,4 @@ namespace Cratis.Arc.Commands;
 /// </summary>
 /// <param name="parameter">The parameter that could not be resolved.</param>
 public class CannotResolveCommandDependency(ParameterInfo parameter)
-    : Exception($"Cannot invoke '{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name}' because its required dependency '{parameter.ParameterType.FullName}' for parameter '{parameter.Name}' could not be resolved or resolved to null. If this is a Chronicle read model that may not exist, declare the parameter as nullable ('{parameter.ParameterType.Name}?') to receive null, or inject IReadModels and check existence explicitly.")
-{
-}
+    : Exception($"Cannot invoke '{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name}' because its required dependency '{parameter.ParameterType.FullName}' for parameter '{parameter.Name}' could not be resolved or resolved to null. If this is a Chronicle read model that may not exist, declare the parameter as nullable ('{parameter.ParameterType.Name}?') to receive null, or inject IReadModels and check existence explicitly.");

--- a/Source/DotNET/Arc.Core/Identity/MultipleIdentityDetailsProvidersFound.cs
+++ b/Source/DotNET/Arc.Core/Identity/MultipleIdentityDetailsProvidersFound.cs
@@ -10,6 +10,4 @@ namespace Cratis.Arc.Identity;
 /// Initializes a new instance of the <see cref="MultipleIdentityDetailsProvidersFound"/> class.
 /// </remarks>
 /// <param name="types">Types that were found.</param>
-public class MultipleIdentityDetailsProvidersFound(IEnumerable<Type> types) : Exception($"There should only be one implementation of `{nameof(IProvideIdentityDetails)}` found {string.Join(',', types.Select(_ => _.FullName))}")
-{
-}
+public class MultipleIdentityDetailsProvidersFound(IEnumerable<Type> types) : Exception($"There should only be one implementation of `{nameof(IProvideIdentityDetails)}` found {string.Join(',', types.Select(_ => _.FullName))}");

--- a/Source/DotNET/Arc.Core/Validation/CannotResolveValidatorDependency.cs
+++ b/Source/DotNET/Arc.Core/Validation/CannotResolveValidatorDependency.cs
@@ -11,6 +11,4 @@ namespace Cratis.Arc.Validation;
 /// <param name="validatorType">The validator type that could not be constructed.</param>
 /// <param name="parameter">The dependency parameter that could not be resolved.</param>
 public class CannotResolveValidatorDependency(Type validatorType, ParameterInfo parameter)
-    : Exception($"Cannot construct validator '{validatorType.FullName}' because its required dependency '{parameter.ParameterType.FullName}' for parameter '{parameter.Name}' could not be resolved or resolved to null. If this is a Chronicle read model that may not exist, declare the parameter as nullable ('{parameter.ParameterType.Name}?') to receive null, or inject IReadModels and check existence explicitly.")
-{
-}
+    : Exception($"Cannot construct validator '{validatorType.FullName}' because its required dependency '{parameter.ParameterType.FullName}' for parameter '{parameter.Name}' could not be resolved or resolved to null. If this is a Chronicle read model that may not exist, declare the parameter as nullable ('{parameter.ParameterType.Name}?') to receive null, or inject IReadModels and check existence explicitly.");

--- a/Source/DotNET/Arc.Core/Validation/DiscoverableValidatorMustImplementAbstractValidator.cs
+++ b/Source/DotNET/Arc.Core/Validation/DiscoverableValidatorMustImplementAbstractValidator.cs
@@ -11,6 +11,4 @@ namespace Cratis.Arc.Validation;
 /// </remarks>
 /// <param name="type">Validator type that is invalid.</param>
 public class DiscoverableValidatorMustImplementAbstractValidator(Type type)
-    : Exception($"Discoverable validator of type '{type.FullName}' does not derive from AbstractValidator<>, suggest using either BaseValidator<>, DiscoverableValidator<>, CommandValidator<>, QueryValidator<>, ConceptValidator<> or the AbstractValidator<> as base type.")
-{
-}
+    : Exception($"Discoverable validator of type '{type.FullName}' does not derive from AbstractValidator<>, suggest using either BaseValidator<>, DiscoverableValidator<>, CommandValidator<>, QueryValidator<>, ConceptValidator<> or the AbstractValidator<> as base type.");

--- a/Source/DotNET/Chronicle/Aggregates/UnableToResolveAggregateRootFromCommandContext.cs
+++ b/Source/DotNET/Chronicle/Aggregates/UnableToResolveAggregateRootFromCommandContext.cs
@@ -11,6 +11,4 @@ namespace Cratis.Arc.Chronicle.Aggregates;
 /// </remarks>
 /// <param name="aggregateRootType">The type of aggregate root that could not be resolved.</param>
 public class UnableToResolveAggregateRootFromCommandContext(Type aggregateRootType) :
-    Exception($"Unable to resolve aggregate root of type '{aggregateRootType.FullName}' from current command context. Ensure that the command has either one property that is of derivative of EventSourceId or a property marked with [Key] attribute and that a command context is available.")
-{
-}
+    Exception($"Unable to resolve aggregate root of type '{aggregateRootType.FullName}' from current command context. Ensure that the command has either one property that is of derivative of EventSourceId or a property marked with [Key] attribute and that a command context is available.");

--- a/Source/DotNET/Chronicle/Commands/MissingEventSourceIdInCommandContext.cs
+++ b/Source/DotNET/Chronicle/Commands/MissingEventSourceIdInCommandContext.cs
@@ -10,6 +10,4 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// </summary>
 /// <param name="commandType">The command type that was being processed.</param>
 public class MissingEventSourceIdInCommandContext(Type commandType)
-    : Exception($"No event source id found in command context for command of type '{commandType.FullName}'. Ensure that a {nameof(ICommandContextValuesProvider)} is registered that provides the event source id.")
-{
-}
+    : Exception($"No event source id found in command context for command of type '{commandType.FullName}'. Ensure that a {nameof(ICommandContextValuesProvider)} is registered that provides the event source id.");

--- a/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/TestDbContexts.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/for_BaseDbContext/TestDbContexts.cs
@@ -16,9 +16,7 @@ public class TestDbContext(DbContextOptions<TestDbContext> options) : BaseDbCont
     public DbSet<Store> Stores { get; set; }
 }
 
-public class EmptyDbContext(DbContextOptions<EmptyDbContext> options) : BaseDbContext(options)
-{
-}
+public class EmptyDbContext(DbContextOptions<EmptyDbContext> options) : BaseDbContext(options);
 
 public class DbContextWithOwnedEntities(DbContextOptions<DbContextWithOwnedEntities> options) : BaseDbContext(options)
 {

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/QueryExecutionFailed.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_Queries/QueryExecutionFailed.cs
@@ -10,6 +10,4 @@ namespace Cratis.Arc.ProxyGenerator.Scenarios.for_Queries;
 /// Initializes a new instance of the <see cref="QueryExecutionFailed"/> class.
 /// </remarks>
 /// <param name="message">The error message.</param>
-public class QueryExecutionFailed(string message) : Exception(message)
-{
-}
+public class QueryExecutionFailed(string message) : Exception(message);


### PR DESCRIPTION
## Fixed
- Resolved 9 `MA0206` (unnecessary braces in type declaration) errors that were blocking Release-configuration builds after `Meziantou.Analyzer` was bumped to `3.0.117`.

## Summary
These exception types never went through Release-configuration CI to catch the new analyzer rule, since the `.NET Build` and `Publish` workflows both only trigger on `Source/**` paths and the analyzer bump only touched the root `Directory.Packages.props` manifest. Switched to semicolon-bodied primary constructor syntax per the project's own convention for types with no implementation body.