### PR TITLE
Restore build after Chronicle 15.38.4 update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,12 +54,12 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="snappier" Version="1.3.1" />
     <!-- Roslyn-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!-- Override vulnerable/incompatible transitive dependencies from analyzer testing packages -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
     <!-- Analysis -->

--- a/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
+++ b/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle;
+using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
@@ -48,6 +49,10 @@ internal sealed class EventStoreForScenario(EventScenario eventScenario, IReadMo
     /// <inheritdoc/>
     public IConstraints Constraints =>
         throw new NotSupportedException("Constraints are not exposed through command scenarios.");
+
+    /// <inheritdoc/>
+    public IPIIManager PII =>
+        throw new NotSupportedException("PII management is not supported for command scenarios.");
 
     /// <inheritdoc/>
     public IEventLog EventLog => eventScenario.EventLog;


### PR DESCRIPTION
## Fixed
- Restored a broken build caused by the Chronicle 15.38.4 package sweep: the in-memory command-scenario event store now implements the newly added `IEventStore.PII` member, and the Roslyn analyzer packages are pinned back to a version compatible with the shipped SDK compiler.

# Summary

The Chronicle 15.38.4 update landed on `main` with two build breaks that only surface with the pinned SDK (CI installs a newer SDK and did not catch them):

- **`CS9057`** — the sweep bumped `Microsoft.CodeAnalysis.CSharp`/`.Workspaces`/`.Workspaces.Common` to `5.6.0`; analyzers built against `5.6.0` cannot be loaded by the Roslyn `5.3.0` compiler in the pinned SDK. Reverted to `5.3.0`.
- **`CS0535`** — Chronicle `15.38.4` added `PII` to `IEventStore`; `EventStoreForScenario` did not implement it. Added it following the existing unsupported-operation pattern.

Verified locally: `dotnet clean` + `dotnet build -c Release` is clean (0 warnings, 0 errors) and all 13 `*.Specs` projects pass.