### PR TITLE
Add Arc analyzers for command Handle, [Roles], and exception hygiene

### DIFF
--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_command_handle_throws_built_in_exception.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_command_handle_throws_built_in_exception.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ArcArtifactBuiltInExceptionAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ArcArtifactBuiltInExceptionAnalyzer.for_ARC0012;
+
+public class when_command_handle_throws_built_in_exception
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public void Handle()
+        {
+            throw {|#0:new InvalidOperationException(""already registered"")|};
+        }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0012")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("InvalidOperationException"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_command_handle_throws_domain_exception.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_command_handle_throws_domain_exception.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ArcArtifactBuiltInExceptionAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ArcArtifactBuiltInExceptionAnalyzer.for_ARC0012;
+
+public class when_command_handle_throws_domain_exception
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public class AuthorAlreadyRegistered : Exception
+    {
+    }
+
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public void Handle()
+        {
+            throw new AuthorAlreadyRegistered();
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_unrelated_class_throws_built_in_exception.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_unrelated_class_throws_built_in_exception.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ArcArtifactBuiltInExceptionAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ArcArtifactBuiltInExceptionAnalyzer.for_ARC0012;
+
+public class when_unrelated_class_throws_built_in_exception
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+namespace TestNamespace
+{
+    public class SomeService
+    {
+        public void DoWork()
+        {
+            throw new InvalidOperationException(""not an arc artifact"");
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_validator_throws_built_in_exception.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ArcArtifactBuiltInExceptionAnalyzer/for_ARC0012/when_validator_throws_built_in_exception.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ArcArtifactBuiltInExceptionAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ArcArtifactBuiltInExceptionAnalyzer.for_ARC0012;
+
+public class when_validator_throws_built_in_exception
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using Cratis.Arc.Commands;
+
+namespace TestNamespace
+{
+    public class RegisterAuthor
+    {
+    }
+
+    public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+    {
+        public void Check()
+        {
+            throw {|#0:new ArgumentException(""bad"")|};
+        }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0012")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("ArgumentException"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_forwards_a_task.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_forwards_a_task.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandHandleTaskWrappingAnalyzer.for_ARC0010;
+
+public class when_handle_forwards_a_task
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public Task<string> Handle() => Resolve();
+
+        static Task<string> Resolve() => Task.FromResult(""value"");
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_is_async_with_await.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_is_async_with_await.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandHandleTaskWrappingAnalyzer.for_ARC0010;
+
+public class when_handle_is_async_with_await
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public async Task<string> Handle()
+        {
+            await Task.Delay(1);
+            return Name;
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_is_async_without_await.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_is_async_without_await.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandHandleTaskWrappingAnalyzer.for_ARC0010;
+
+public class when_handle_is_async_without_await
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public async Task<string> {|#0:Handle|}()
+        {
+            return Name;
+        }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0010")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("RegisterAuthor"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_returns_synchronous_shape.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_returns_synchronous_shape.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandHandleTaskWrappingAnalyzer.for_ARC0010;
+
+public class when_handle_returns_synchronous_shape
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public string Handle() => Name;
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_wraps_result_in_task.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_CommandHandleTaskWrappingAnalyzer/for_ARC0010/when_handle_wraps_result_in_task.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_CommandHandleTaskWrappingAnalyzer.for_ARC0010;
+
+public class when_handle_wraps_result_in_task
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public Task<string> {|#0:Handle|}() => Task.FromResult(Name);
+    }
+}",
+        VerifyCS.Diagnostic("ARC0010")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("RegisterAuthor"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_RolesLiteralAnalyzer/for_ARC0011/when_roles_uses_nameof.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_RolesLiteralAnalyzer/for_ARC0011/when_roles_uses_nameof.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.RolesLiteralAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_RolesLiteralAnalyzer.for_ARC0011;
+
+public class when_roles_uses_nameof
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Authorization;
+
+namespace TestNamespace
+{
+    public enum Role { Admin }
+
+    [Roles(nameof(Role.Admin))]
+    public class SomeController
+    {
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_RolesLiteralAnalyzer/for_ARC0011/when_roles_uses_string_literal.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_RolesLiteralAnalyzer/for_ARC0011/when_roles_uses_string_literal.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.RolesLiteralAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_RolesLiteralAnalyzer.for_ARC0011;
+
+public class when_roles_uses_string_literal
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Authorization;
+
+namespace TestNamespace
+{
+    [Roles({|#0:""Admin""|})]
+    public class SomeController
+    {
+    }
+}",
+        VerifyCS.Diagnostic("ARC0011")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Admin"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UnwrapCommandHandleTaskCodeFixProvider/when_unwrapping_async_without_await.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UnwrapCommandHandleTaskCodeFixProvider/when_unwrapping_async_without_await.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.CodeFixVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer, Cratis.Arc.CodeAnalysis.CodeFixes.UnwrapCommandHandleTaskCodeFixProvider>;
+
+namespace Cratis.Arc.CodeAnalysis.for_UnwrapCommandHandleTaskCodeFixProvider;
+
+public class when_unwrapping_async_without_await
+{
+    const string Source = @"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public async Task<string> {|#0:Handle|}()
+        {
+            return Name;
+        }
+    }
+}";
+
+    const string FixedSource = @"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public string Handle()
+        {
+            return Name;
+        }
+    }
+}";
+
+    [Fact] async Task should_unwrap_to_synchronous_signature() => await VerifyCS.VerifyCodeFixAsync(
+        Source,
+        FixedSource,
+        new ExpectedDiagnostic("ARC0010", DiagnosticSeverity.Warning, "RegisterAuthor"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UnwrapCommandHandleTaskCodeFixProvider/when_unwrapping_task_from_result.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UnwrapCommandHandleTaskCodeFixProvider/when_unwrapping_task_from_result.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.CodeFixVerifier<Cratis.Arc.CodeAnalysis.CommandHandleTaskWrappingAnalyzer, Cratis.Arc.CodeAnalysis.CodeFixes.UnwrapCommandHandleTaskCodeFixProvider>;
+
+namespace Cratis.Arc.CodeAnalysis.for_UnwrapCommandHandleTaskCodeFixProvider;
+
+public class when_unwrapping_task_from_result
+{
+    const string Source = @"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public Task<string> {|#0:Handle|}() => Task.FromResult(Name);
+    }
+}";
+
+    const string FixedSource = @"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    [Command]
+    public record RegisterAuthor(string Name)
+    {
+        public string Handle() => Name;
+    }
+}";
+
+    [Fact] async Task should_unwrap_to_synchronous_signature() => await VerifyCS.VerifyCodeFixAsync(
+        Source,
+        FixedSource,
+        new ExpectedDiagnostic("ARC0010", DiagnosticSeverity.Warning, "RegisterAuthor"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UseNameofForRolesCodeFixProvider/when_rewriting_literal_to_nameof.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_UseNameofForRolesCodeFixProvider/when_rewriting_literal_to_nameof.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.CodeFixVerifier<Cratis.Arc.CodeAnalysis.RolesLiteralAnalyzer, Cratis.Arc.CodeAnalysis.CodeFixes.UseNameofForRolesCodeFixProvider>;
+
+namespace Cratis.Arc.CodeAnalysis.for_UseNameofForRolesCodeFixProvider;
+
+public class when_rewriting_literal_to_nameof
+{
+    const string Source = @"
+using Cratis.Arc.Authorization;
+
+namespace TestNamespace
+{
+    public enum Role { Admin }
+
+    [Roles({|#0:""Admin""|})]
+    public class SomeController
+    {
+    }
+}";
+
+    const string FixedSource = @"
+using Cratis.Arc.Authorization;
+
+namespace TestNamespace
+{
+    public enum Role { Admin }
+
+    [Roles(nameof(Role.Admin))]
+    public class SomeController
+    {
+    }
+}";
+
+    [Fact] async Task should_rewrite_to_nameof() => await VerifyCS.VerifyCodeFixAsync(
+        Source,
+        FixedSource,
+        new ExpectedDiagnostic("ARC0011", DiagnosticSeverity.Warning, "Admin"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/.editorconfig
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/.editorconfig
@@ -1,0 +1,6 @@
+root = false
+
+[*.cs]
+# Analyzers and their code fixes share this assembly, so it references Microsoft.CodeAnalysis.Workspaces.
+# RS1038 warns against that combination; it is the accepted trade-off for co-locating fixes with analyzers.
+dotnet_diagnostic.RS1038.severity = none

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,6 @@ ARC0006|Arc|Warning|Command-scoped read model can be missing
 ARC0007|Arc|Warning|Command should be declared as a record
 ARC0008|Arc|Warning|ReadModel should be declared as a record
 ARC0009|Arc|Warning|Concept should be declared as a record
+ARC0010|Arc|Warning|Command Handle() wraps a synchronous result in a Task
+ARC0011|Arc|Warning|[Roles] argument should use nameof instead of a string literal
+ARC0012|Arc|Warning|Arc artifact throws a built-in exception type

--- a/Source/DotNET/Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/Arc.Core.CodeAnalysis.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ArcArtifactBuiltInExceptionAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ArcArtifactBuiltInExceptionAnalyzer.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that flags built-in exception types thrown from Arc artifacts.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ArcArtifactBuiltInExceptionAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string HandleMethodName = "Handle";
+    const string ReactorInterfaceName = "IReactor";
+    const string ReactorsNamespace = "Cratis.Chronicle.Reactors";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.ARC0012_ArcArtifactThrowsBuiltInException];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeThrow, SyntaxKind.ThrowStatement, SyntaxKind.ThrowExpression);
+    }
+
+    static void AnalyzeThrow(SyntaxNodeAnalysisContext context)
+    {
+        var thrownExpression = context.Node switch
+        {
+            ThrowStatementSyntax throwStatement => throwStatement.Expression,
+            ThrowExpressionSyntax throwExpression => throwExpression.Expression,
+            _ => null
+        };
+
+        if (thrownExpression is not ObjectCreationExpressionSyntax objectCreation)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol is not INamedTypeSymbol exceptionType ||
+            !IsBuiltInException(exceptionType, context.Compilation))
+        {
+            return;
+        }
+
+        if (!IsInArcArtifactScope(context.Node, context.SemanticModel))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARC0012_ArcArtifactThrowsBuiltInException,
+            objectCreation.GetLocation(),
+            exceptionType.Name));
+    }
+
+    static bool IsBuiltInException(INamedTypeSymbol type, Compilation compilation)
+    {
+        var exceptionType = compilation.GetTypeByMetadataName("System.Exception");
+
+        if (exceptionType is null || !InheritsFromOrEquals(type, exceptionType))
+        {
+            return false;
+        }
+
+        var @namespace = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+        return @namespace == "System" || @namespace.StartsWith("System.", StringComparison.Ordinal);
+    }
+
+    static bool InheritsFromOrEquals(INamedTypeSymbol type, INamedTypeSymbol candidateBase)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, candidateBase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsInArcArtifactScope(SyntaxNode node, SemanticModel semanticModel)
+    {
+        if (node.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } typeDeclaration ||
+            semanticModel.GetDeclaredSymbol(typeDeclaration) is not INamedTypeSymbol typeSymbol)
+        {
+            return false;
+        }
+
+        if (IsValidator(typeSymbol) || IsReactor(typeSymbol))
+        {
+            return true;
+        }
+
+        if (!HasCommandAttribute(typeSymbol))
+        {
+            return false;
+        }
+
+        return node.FirstAncestorOrSelf<MethodDeclarationSyntax>() is { } method &&
+            method.Identifier.ValueText == HandleMethodName;
+    }
+
+    static bool HasCommandAttribute(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == CommandAttributeName);
+
+    static bool IsValidator(INamedTypeSymbol typeSymbol)
+    {
+        for (var baseType = typeSymbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            var @namespace = baseType.ContainingNamespace?.ToDisplayString();
+
+            if ((baseType.Name == "CommandValidator" && @namespace == "Cratis.Arc.Commands") ||
+                (baseType.Name == "ConceptValidator" && @namespace == "Cratis.Arc.Validation"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsReactor(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.AllInterfaces.Any(@interface =>
+            @interface.Name == ReactorInterfaceName &&
+            @interface.ContainingNamespace?.ToDisplayString() == ReactorsNamespace);
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/CodeFixes/UnwrapCommandHandleTaskCodeFixProvider.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/CodeFixes/UnwrapCommandHandleTaskCodeFixProvider.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Cratis.Arc.CodeAnalysis.CodeFixes;
+
+/// <summary>
+/// Code fix that unwraps a command Handle() method from its Task wrapper to a synchronous signature.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UnwrapCommandHandleTaskCodeFixProvider)), Shared]
+public class UnwrapCommandHandleTaskCodeFixProvider : CodeFixProvider
+{
+    const string Title = "Unwrap to synchronous Handle()";
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [DiagnosticDescriptors.ARC0010_CommandHandleWrapsSynchronousResultInTask.Id];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics[0];
+
+        if (root?.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<MethodDeclarationSyntax>() is not { } method)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Title,
+                createChangedDocument: cancellationToken => UnwrapAsync(context.Document, method, cancellationToken),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    static async Task<Document> UnwrapAsync(Document document, MethodDeclarationSyntax method, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root is null || semanticModel is null)
+        {
+            return document;
+        }
+
+        var newReturnType = UnwrapReturnType(method.ReturnType).WithTriviaFrom(method.ReturnType);
+        var newModifiers = TokenList(method.Modifiers.Where(modifier => !modifier.IsKind(SyntaxKind.AsyncKeyword)));
+
+        // Unwrap the body using the original in-tree nodes so semantic queries stay valid, then apply the
+        // synchronous signature (dropping 'async' and the Task wrapper) on top of the transformed method.
+        var newMethod = (method.ExpressionBody is not null
+                ? UnwrapExpressionBody(method, method.ExpressionBody, semanticModel)
+                : UnwrapBlockBody(method, semanticModel))
+            .WithModifiers(newModifiers)
+            .WithReturnType(newReturnType);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(method, newMethod));
+    }
+
+    static TypeSyntax UnwrapReturnType(TypeSyntax returnType) =>
+        GetTaskTypeArgument(returnType) is { } typeArgument
+            ? typeArgument
+            : PredefinedType(Token(SyntaxKind.VoidKeyword));
+
+    static TypeSyntax? GetTaskTypeArgument(TypeSyntax returnType)
+    {
+        var genericName = returnType switch
+        {
+            GenericNameSyntax generic => generic,
+            QualifiedNameSyntax { Right: GenericNameSyntax generic } => generic,
+            _ => null
+        };
+
+        return genericName?.Identifier.ValueText == "Task" && genericName.TypeArgumentList.Arguments.Count == 1
+            ? genericName.TypeArgumentList.Arguments[0]
+            : null;
+    }
+
+    static MethodDeclarationSyntax UnwrapExpressionBody(MethodDeclarationSyntax method, ArrowExpressionClauseSyntax expressionBody, SemanticModel semanticModel)
+    {
+        var (isWrapper, inner) = Unwrap(expressionBody.Expression, semanticModel);
+
+        if (isWrapper && inner is null)
+        {
+            return method
+                .WithExpressionBody(null)
+                .WithSemicolonToken(Token(SyntaxKind.None))
+                .WithBody(Block());
+        }
+
+        var newExpression = (isWrapper ? inner! : expressionBody.Expression).WithTriviaFrom(expressionBody.Expression);
+        return method.WithExpressionBody(expressionBody.WithExpression(newExpression));
+    }
+
+    static MethodDeclarationSyntax UnwrapBlockBody(MethodDeclarationSyntax method, SemanticModel semanticModel)
+    {
+        if (method.Body is null)
+        {
+            return method;
+        }
+
+        var returnStatements = method.Body
+            .DescendantNodes(node => node == method.Body || !IsNestedFunction(node))
+            .OfType<ReturnStatementSyntax>()
+            .Where(statement => statement.Expression is not null)
+            .ToArray();
+
+        var newBody = method.Body.ReplaceNodes(returnStatements, (original, _) =>
+        {
+            var (isWrapper, inner) = Unwrap(original.Expression!, semanticModel);
+
+            if (!isWrapper)
+            {
+                return original;
+            }
+
+            return inner is null
+                ? ReturnStatement().WithTriviaFrom(original)
+                : original.WithExpression(inner.WithTriviaFrom(original.Expression!));
+        });
+
+        return method.WithBody(newBody);
+    }
+
+    static (bool IsWrapper, ExpressionSyntax? Inner) Unwrap(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        if (expression is InvocationExpressionSyntax invocation &&
+            semanticModel.GetSymbolInfo(invocation.Expression).Symbol is IMethodSymbol method &&
+            method.Name == "FromResult" &&
+            IsTaskType(method.ContainingType) &&
+            invocation.ArgumentList.Arguments.Count == 1)
+        {
+            return (true, invocation.ArgumentList.Arguments[0].Expression);
+        }
+
+        if (semanticModel.GetSymbolInfo(expression).Symbol is IPropertySymbol property &&
+            property.Name == "CompletedTask" &&
+            IsTaskType(property.ContainingType))
+        {
+            return (true, null);
+        }
+
+        return (false, expression);
+    }
+
+    static bool IsTaskType(INamedTypeSymbol type) =>
+        type.Name == "Task" && type.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks";
+
+    static bool IsNestedFunction(SyntaxNode node) =>
+        node is SimpleLambdaExpressionSyntax or
+            ParenthesizedLambdaExpressionSyntax or
+            AnonymousMethodExpressionSyntax or
+            LocalFunctionStatementSyntax;
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/CodeFixes/UseNameofForRolesCodeFixProvider.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/CodeFixes/UseNameofForRolesCodeFixProvider.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Cratis.Arc.CodeAnalysis.CodeFixes;
+
+/// <summary>
+/// Code fix that rewrites a [Roles] string literal into a nameof expression against a resolvable enum member.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseNameofForRolesCodeFixProvider)), Shared]
+public class UseNameofForRolesCodeFixProvider : CodeFixProvider
+{
+    const string Title = "Use nameof for role";
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        [DiagnosticDescriptors.ARC0011_RolesArgumentShouldUseNameof.Id];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics[0];
+
+        if (root?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not LiteralExpressionSyntax literal || semanticModel is null)
+        {
+            return;
+        }
+
+        var roleName = literal.Token.ValueText;
+
+        if (FindEnumMember(semanticModel.Compilation.GlobalNamespace, roleName) is not { } enumType)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Title,
+                createChangedDocument: cancellationToken => RewriteToNameofAsync(context.Document, literal, enumType.Name, roleName, cancellationToken),
+                equivalenceKey: Title),
+            diagnostic);
+    }
+
+    static async Task<Document> RewriteToNameofAsync(Document document, LiteralExpressionSyntax literal, string enumTypeName, string memberName, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root is null)
+        {
+            return document;
+        }
+
+        var nameofExpression = ParseExpression($"nameof({enumTypeName}.{memberName})").WithTriviaFrom(literal);
+        return document.WithSyntaxRoot(root.ReplaceNode(literal, nameofExpression));
+    }
+
+    static INamedTypeSymbol? FindEnumMember(INamespaceSymbol @namespace, string memberName)
+    {
+        foreach (var type in @namespace.GetTypeMembers())
+        {
+            if (type.TypeKind == TypeKind.Enum && type.GetMembers(memberName).Any(member => member.Kind == SymbolKind.Field))
+            {
+                return type;
+            }
+        }
+
+        foreach (var nested in @namespace.GetNamespaceMembers())
+        {
+            if (FindEnumMember(nested, memberName) is { } found)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/CommandHandleTaskWrappingAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/CommandHandleTaskWrappingAnalyzer.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that flags a command Handle() method returning a Task without awaiting anything.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandHandleTaskWrappingAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string HandleMethodName = "Handle";
+    const string TaskTypeName = "System.Threading.Tasks.Task";
+    const string TaskOfTTypeName = "System.Threading.Tasks.Task`1";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.ARC0010_CommandHandleWrapsSynchronousResultInTask];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+    {
+        var method = (MethodDeclarationSyntax)context.Node;
+
+        if (method.Identifier.ValueText != HandleMethodName)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(method) is not IMethodSymbol methodSymbol ||
+            methodSymbol.IsStatic ||
+            methodSymbol.DeclaredAccessibility != Accessibility.Public)
+        {
+            return;
+        }
+
+        if (!HasCommandAttribute(methodSymbol.ContainingType) || !ReturnsTask(methodSymbol.ReturnType, context.Compilation))
+        {
+            return;
+        }
+
+        var isAsync = methodSymbol.IsAsync;
+
+        // An async Handle() with no await is noise. A non-async Handle() that only produces a synchronous
+        // Task wrapper (Task.FromResult / Task.CompletedTask) is the same noise CS1998 cannot see.
+        var shouldReport = isAsync
+            ? !ContainsOwnAwait(method)
+            : ProducesOnlySynchronousTaskWrapper(method, context.SemanticModel);
+
+        if (!shouldReport)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARC0010_CommandHandleWrapsSynchronousResultInTask,
+            method.Identifier.GetLocation(),
+            methodSymbol.ContainingType.Name));
+    }
+
+    static bool HasCommandAttribute(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == CommandAttributeName);
+
+    static bool ReturnsTask(ITypeSymbol returnType, Compilation compilation)
+    {
+        if (returnType is not INamedTypeSymbol namedReturnType)
+        {
+            return false;
+        }
+
+        var taskType = compilation.GetTypeByMetadataName(TaskTypeName);
+        var taskOfTType = compilation.GetTypeByMetadataName(TaskOfTTypeName);
+
+        return SymbolEqualityComparer.Default.Equals(namedReturnType, taskType) ||
+               SymbolEqualityComparer.Default.Equals(namedReturnType.OriginalDefinition, taskOfTType);
+    }
+
+    static bool ContainsOwnAwait(MethodDeclarationSyntax method)
+    {
+        var body = (SyntaxNode?)method.Body ?? method.ExpressionBody?.Expression;
+
+        if (body is null)
+        {
+            return false;
+        }
+
+        return body.DescendantNodesAndSelf(node => node == body || !IsNestedFunction(node))
+            .OfType<AwaitExpressionSyntax>()
+            .Any();
+    }
+
+    static bool ProducesOnlySynchronousTaskWrapper(MethodDeclarationSyntax method, SemanticModel semanticModel)
+    {
+        var producedExpressions = GetProducedTaskExpressions(method).ToArray();
+
+        return producedExpressions.Length > 0 &&
+            producedExpressions.All(expression => IsSynchronousTaskWrapper(expression, semanticModel));
+    }
+
+    static IEnumerable<ExpressionSyntax> GetProducedTaskExpressions(MethodDeclarationSyntax method)
+    {
+        if (method.ExpressionBody is not null)
+        {
+            yield return method.ExpressionBody.Expression;
+            yield break;
+        }
+
+        if (method.Body is null)
+        {
+            yield break;
+        }
+
+        var returnExpressions = method.Body
+            .DescendantNodes(node => node == method.Body || !IsNestedFunction(node))
+            .OfType<ReturnStatementSyntax>()
+            .Select(statement => statement.Expression)
+            .Where(expression => expression is not null);
+
+        foreach (var expression in returnExpressions)
+        {
+            yield return expression!;
+        }
+    }
+
+    static bool IsSynchronousTaskWrapper(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        var symbol = semanticModel.GetSymbolInfo(expression is InvocationExpressionSyntax invocation ? invocation.Expression : expression).Symbol;
+
+        return symbol switch
+        {
+            IMethodSymbol method => method.Name == "FromResult" && IsTaskType(method.ContainingType),
+            IPropertySymbol property => property.Name == "CompletedTask" && IsTaskType(property.ContainingType),
+            _ => false
+        };
+    }
+
+    static bool IsTaskType(INamedTypeSymbol type) =>
+        type.Name == "Task" && type.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks";
+
+    static bool IsNestedFunction(SyntaxNode node) =>
+        node is SimpleLambdaExpressionSyntax or
+            ParenthesizedLambdaExpressionSyntax or
+            AnonymousMethodExpressionSyntax or
+            LocalFunctionStatementSyntax;
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -118,5 +118,41 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Concepts inherit ConceptAs<T> to wrap a primitive in a strongly-typed domain value. They must be declared as positional records so that value equality, immutability, and the implicit conversions behave correctly. Change the 'class' declaration to 'record'.");
 
+    /// <summary>
+    /// ARC0010: Command Handle() wraps a synchronous result in a Task.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0010_CommandHandleWrapsSynchronousResultInTask = new(
+        id: "ARC0010",
+        title: "Command Handle() wraps a synchronous result in a Task",
+        messageFormat: "Handle() on command '{0}' returns a Task but never awaits anything. Return the synchronous shape directly instead of wrapping it in a Task.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The command pipeline accepts the synchronous return shape directly. A Handle() that returns Task<T>/Task without awaiting — whether declared 'async' with no await, or wrapping the value in Task.FromResult/Task.CompletedTask — is pure noise. Unwrap it to return the event or result shape directly.");
+
+    /// <summary>
+    /// ARC0011: [Roles] argument should use nameof instead of a string literal.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0011_RolesArgumentShouldUseNameof = new(
+        id: "ARC0011",
+        title: "[Roles] argument should use nameof instead of a string literal",
+        messageFormat: "[Roles] argument \"{0}\" is a string literal. Use nameof(...) so it stays in sync with the role definition.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A string literal role silently desynchronizes from the role enum on rename — the authorization check then never matches and the endpoint is effectively locked, or worse, matches a stale role. Use nameof(<EnumType>.<Member>) so a rename is a compile error rather than a silent authorization failure.");
+
+    /// <summary>
+    /// ARC0012: Arc artifact throws a built-in exception type.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0012_ArcArtifactThrowsBuiltInException = new(
+        id: "ARC0012",
+        title: "Arc artifact throws a built-in exception type",
+        messageFormat: "'{0}' is a built-in exception type thrown from an Arc artifact. Throw a domain-named exception type instead so the failure carries domain meaning.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Domain failures raised from Arc artifacts — command Handle() methods, CommandValidator<T>/ConceptValidator<T> validators, and reactor handlers — should be expressed as domain-named exception types (or validator rejections). Built-in exceptions like InvalidOperationException, ArgumentException, or Exception carry no domain meaning to the caller or the log.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis/RolesLiteralAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/RolesLiteralAnalyzer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that flags a [Roles] argument declared as a string literal instead of a nameof expression.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RolesLiteralAnalyzer : DiagnosticAnalyzer
+{
+    const string RolesAttributeName = "Cratis.Arc.Authorization.RolesAttribute";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.ARC0011_RolesArgumentShouldUseNameof];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeAttribute, SyntaxKind.Attribute);
+    }
+
+    static void AnalyzeAttribute(SyntaxNodeAnalysisContext context)
+    {
+        var attribute = (AttributeSyntax)context.Node;
+
+        if (attribute.ArgumentList is not { } argumentList || argumentList.Arguments.Count == 0)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetSymbolInfo(attribute).Symbol is not IMethodSymbol constructor ||
+            constructor.ContainingType?.ToDisplayString() != RolesAttributeName)
+        {
+            return;
+        }
+
+        foreach (var argument in argumentList.Arguments)
+        {
+            if (argument.Expression is LiteralExpressionSyntax literal &&
+                literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ARC0011_RolesArgumentShouldUseNameof,
+                    literal.GetLocation(),
+                    literal.Token.ValueText));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Added

- Analyzer (ARC0010) that flags a `[Command]` `Handle()` returning `Task`/`Task<T>` without awaiting anything — including the `Task.FromResult`/`Task.CompletedTask` wrapper shape the compiler's own CS1998 does not catch — with a code fix that unwraps it to the synchronous return shape the command pipeline already accepts.
- Analyzer (ARC0011) that flags a `[Roles(...)]` string-literal argument, with a code fix that rewrites it to `nameof(<EnumType>.<Member>)` so a role rename becomes a compile error instead of a silent authorization failure.
- Analyzer (ARC0012) that flags built-in exception types (`Exception`, `InvalidOperationException`, `ArgumentException`, and the like) thrown from Arc artifacts — command `Handle()` methods, `CommandValidator<T>`/`ConceptValidator<T>` validators, and reactor handlers — steering domain failures toward domain-named exception types.