### PR TITLE
Hand off JavaScript dist to spec jobs via artifact instead of cache

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -9,7 +9,6 @@ env:
   DOTNET9_VERSION: "9.0.x"
   DOTNET10_VERSION: "10.0.x"
   DOTNET_OBJ_CACHE: "dotnet-obj-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}"
-  JS_DIST_CACHE: "js-dist-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}"
 
 on:
   workflow_dispatch:
@@ -117,25 +116,24 @@ jobs:
       - name: Yarn install
         run: yarn
 
-      - name: Cache JavaScript dist output
-        uses: actions/cache@v6
-        with:
-          path: Source/JavaScript/**/dist
-          key: ${{ env.JS_DIST_CACHE }}
-
       - name: Build
         run: dotnet build --configuration Release
 
-      # Hand off the compiled binaries to the spec jobs via an artifact rather than
-      # actions/cache. The bin output is an intra-run handoff, not cross-run reuse:
-      # actions/cache keys on the immutable commit SHA, so a single flaky save
-      # (reservation collision on the large ./**/bin cache) permanently poisons the
-      # key and every --no-build spec job fails with "cache not found". Artifacts are
-      # the correct primitive for passing build output between jobs in the same run.
+      # Hand off the compiled binaries AND the JavaScript dist output to the spec jobs
+      # via an artifact rather than actions/cache. This is an intra-run handoff, not
+      # cross-run reuse: actions/cache keys on the immutable commit SHA, so a single
+      # flaky save (reservation collision) permanently poisons the key and every
+      # --no-build spec job fails with "cache not found" — and a re-run cannot recover
+      # because the key is fixed to the SHA. The proxy-specs jobs execute generated
+      # proxies against Source/JavaScript/**/dist (e.g. Arc/dist/cjs/index.js), so that
+      # output must ride along in the same artifact. Artifacts are the correct primitive
+      # for passing build output between jobs in the same run.
       - name: Archive build output
         run: |
-          find . -type d -name bin -not -path '*/node_modules/*' -not -path './.git/*' -print0 \
-            | tar --null -czf build-output.tar.gz -T -
+          {
+            find . -type d -name bin -not -path '*/node_modules/*' -not -path './.git/*' -print0
+            find Source/JavaScript -type d -name dist -not -path '*/node_modules/*' -print0
+          } | tar --null -czf build-output.tar.gz -T -
 
       - name: Upload build output
         uses: actions/upload-artifact@v4
@@ -210,12 +208,6 @@ jobs:
             **/.eslintcache
             **/yarn.lock
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-
-      - name: Restore JavaScript dist output
-        uses: actions/cache@v6
-        with:
-          path: Source/JavaScript/**/dist
-          key: ${{ env.JS_DIST_CACHE }}
 
       - name: Download build output
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# Summary

CI reliability fix (no user-facing or runtime changes).

The `proxy-specs` jobs in the `.NET Build` workflow execute generated proxies against the built `Source/JavaScript/**/dist` output (e.g. `Arc/dist/cjs/index.js`). That output was handed off from `dotnet-build` to the spec jobs via `actions/cache` keyed on the commit SHA. Under `pull_request_target`, the `GITHUB_TOKEN` only has **read-only cache scope**, so the cache save is always denied (`cache write denied: token has no writable scopes`). The `js-dist` cache is therefore never written on PR runs, and every `proxy-specs` shard fails its restore with `JavaScript file not found: Arc/dist/cjs/index.js` — deterministically, with re-runs unable to recover.

Artifacts are not subject to that restriction, which is why the `bin` output already uses them (its `specs` jobs pass). This includes the JavaScript `dist` directories in the existing `build-output` artifact and removes the `js-dist` cache save/restore, so the dist output rides along with the `bin` output through the reliable artifact handoff.

> Note: this PR's own `proxy-specs` still fail, because `pull_request_target` runs the workflow as defined on the base branch (`main`), i.e. the old cache-based handoff. The fix only takes effect once merged to `main`; a re-run of dependent PRs will then go green.
