### PR TITLE
Add analyzer flagging reactor ICommandPipeline.Execute without [OnceOnly]

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.39.1" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.39.1" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.39.1" />
+    <PackageVersion Include="Cratis.Chronicle" Version="15.40.0" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.40.0" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.40.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.2" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.2" />
     <!-- MAUI -->
@@ -43,7 +43,7 @@
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
     <PackageVersion Include="SharpCompress" Version="1.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
@@ -54,18 +54,18 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="snappier" Version="1.3.1" />
     <!-- Roslyn-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!-- Override vulnerable/incompatible transitive dependencies from analyzer testing packages -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.119" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.122" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="15.38.4" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.38.4" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.38.4" />
+    <PackageVersion Include="Cratis.Chronicle" Version="15.39.1" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="15.39.1" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="15.39.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.2" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.2" />
     <!-- MAUI -->

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_method_invokes_execute_with_once_only.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_method_invokes_execute_with_once_only.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorCommandPipelineExecuteOnceOnlyAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer.when_analyzing_reactor_methods;
+
+public class and_method_invokes_execute_with_once_only : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Chronicle.Reactors;
+using Cratis.Arc.Commands;
+
+namespace TestNamespace
+{
+    public record BookReserved(string Isbn);
+    public record DecreaseStock(string Isbn);
+
+    public class StockKeeping(ICommandPipeline commandPipeline) : IReactor
+    {
+        [OnceOnly]
+        public Task BookReserved(BookReserved @event) =>
+            commandPipeline.Execute(new DecreaseStock(@event.Isbn));
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_method_invokes_execute_without_once_only.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_method_invokes_execute_without_once_only.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorCommandPipelineExecuteOnceOnlyAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer.when_analyzing_reactor_methods;
+
+public class and_method_invokes_execute_without_once_only : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Chronicle.Reactors;
+using Cratis.Arc.Commands;
+
+namespace TestNamespace
+{
+    public record BookReserved(string Isbn);
+    public record DecreaseStock(string Isbn);
+
+    public class StockKeeping(ICommandPipeline commandPipeline) : IReactor
+    {
+        public Task BookReserved(BookReserved @event) =>
+            {|#0:commandPipeline.Execute(new DecreaseStock(@event.Isbn))|};
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0006")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("BookReserved")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_non_reactor_invokes_execute.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer/when_analyzing_reactor_methods/and_non_reactor_invokes_execute.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.ReactorCommandPipelineExecuteOnceOnlyAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_ReactorCommandPipelineExecuteOnceOnlyAnalyzer.when_analyzing_reactor_methods;
+
+public class and_non_reactor_invokes_execute : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Threading.Tasks;
+using Cratis.Arc.Commands;
+
+namespace TestNamespace
+{
+    public record DecreaseStock(string Isbn);
+
+    public class StockKeeping(ICommandPipeline commandPipeline)
+    {
+        public Task Decrease(string isbn) =>
+            commandPipeline.Execute(new DecreaseStock(isbn));
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@ ARCCHR0002|Arc.Chronicle|Warning|Command has ambiguous event source id and shoul
 ARCCHR0003|Arc.Chronicle|Warning|Reactor must not inject IEventLog
 ARCCHR0004|Arc.Chronicle|Warning|[EventType] should not specify an explicit id
 ARCCHR0005|Arc.Chronicle|Warning|Chronicle artifacts are present but Chronicle is not wired up
+ARCCHR0006|Arc.Chronicle|Warning|Reactor handler invoking ICommandPipeline.Execute must be marked with [OnceOnly]

--- a/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
@@ -71,5 +71,17 @@ static class DiagnosticDescriptors
         description: "AddCratisArc on its own wires Arc with no event store, and running Arc without Chronicle is a supported, valid setup (backed by MongoDB or EF Core). This rule only fires when the project actually uses Chronicle — an aggregate root, reactor, reducer, fluent or model-bound projection (IProjectionFor or [FromEvent]/[SetFrom]/[SetValue]/... attributes), [EventType] event, or a type that injects a Chronicle service such as IEventLog or IEventStore. In that case the event store must be added with WithChronicle() on the Arc builder, or by using the all-in-one AddCratis(); without it, any command, query, reactor, or reducer that touches Chronicle fails to resolve at runtime. This analyzer only reports when the setup call and the Chronicle usage live in the same project, so it never fires when setup is wired up in a separate host project.",
         customTags: WellKnownDiagnosticTags.CompilationEnd);
 
+    /// <summary>
+    /// ARCCHR0006: Reactor handler invoking ICommandPipeline.Execute must be marked with [OnceOnly].
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0006_ReactorCommandPipelineExecuteMustBeOnceOnly = new(
+        id: "ARCCHR0006",
+        title: "Reactor handler invoking ICommandPipeline.Execute must be marked with [OnceOnly]",
+        messageFormat: "Reactor handler '{0}' invokes ICommandPipeline.Execute but is not marked [OnceOnly]; replay will re-execute the command. Mark the method [OnceOnly].",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A reactor handler that calls ICommandPipeline.Execute produces a side effect. During replay operations (redaction, revision, observer rewind), the handler runs again and re-executes the command, duplicating the side effect. Mark the method with [OnceOnly] so it is skipped during replays.");
+
     const string Category = "Arc.Chronicle";
 }

--- a/Source/DotNET/Chronicle.CodeAnalysis/ReactorCommandPipelineExecuteOnceOnlyAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/ReactorCommandPipelineExecuteOnceOnlyAnalyzer.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that warns when a reactor handler invoking <c>ICommandPipeline.Execute</c> is not marked with <c>[OnceOnly]</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReactorCommandPipelineExecuteOnceOnlyAnalyzer : DiagnosticAnalyzer
+{
+    const string ExecuteMethodName = "Execute";
+    const string ReactorInterfaceName = "IReactor";
+    const string ReactorsNamespace = "Cratis.Chronicle.Reactors";
+    const string OnceOnlyAttributeName = "OnceOnlyAttribute";
+    const string CommandPipelineInterfaceName = "ICommandPipeline";
+    const string CommandsNamespace = "Cratis.Arc.Commands";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0006_ReactorCommandPipelineExecuteMustBeOnceOnly];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (methodSymbol.Name != ExecuteMethodName || !IsCommandPipeline(methodSymbol.ContainingType))
+        {
+            return;
+        }
+
+        var methodDeclaration = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (methodDeclaration is null)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetDeclaredSymbol(methodDeclaration) is not IMethodSymbol enclosingMethod)
+        {
+            return;
+        }
+
+        if (!IsReactor(enclosingMethod.ContainingType))
+        {
+            return;
+        }
+
+        if (HasOnceOnlyAttribute(enclosingMethod) || HasOnceOnlyAttribute(enclosingMethod.ContainingType))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ARCCHR0006_ReactorCommandPipelineExecuteMustBeOnceOnly,
+            invocation.GetLocation(),
+            enclosingMethod.Name));
+    }
+
+    static bool IsReactor(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.AllInterfaces.Any(@interface =>
+            @interface.Name == ReactorInterfaceName &&
+            @interface.ContainingNamespace?.ToDisplayString() == ReactorsNamespace);
+
+    static bool IsCommandPipeline(ITypeSymbol? typeSymbol)
+    {
+        if (typeSymbol is null)
+        {
+            return false;
+        }
+
+        if (IsCommandPipelineInterface(typeSymbol))
+        {
+            return true;
+        }
+
+        return typeSymbol.AllInterfaces.Any(IsCommandPipelineInterface);
+    }
+
+    static bool IsCommandPipelineInterface(ITypeSymbol typeSymbol) =>
+        typeSymbol.Name == CommandPipelineInterfaceName &&
+        typeSymbol.ContainingNamespace?.ToDisplayString() == CommandsNamespace;
+
+    static bool HasOnceOnlyAttribute(ISymbol symbol) =>
+        symbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.Name == OnceOnlyAttributeName &&
+            attribute.AttributeClass?.ContainingNamespace?.ToDisplayString() == ReactorsNamespace);
+}


### PR DESCRIPTION
## Added

- New analyzer `ARCCHR0006` warns when a reactor handler invokes `ICommandPipeline.Execute` but is not marked `[OnceOnly]`. Without it, replay operations (redaction, revision, observer rewind) re-run the handler and re-execute the command, duplicating the side effect — the analyzer catches this at build time and points you to mark the handler `[OnceOnly]`.

## Fixed

- Update dependencies