### PR TITLE
Fix build break after Chronicle 15.39.1 and align SDK to analyzers

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Release
         id: release
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup .Net
         uses: actions/setup-dotnet@v4
@@ -104,6 +108,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node v16
         uses: actions/setup-node@v4

--- a/Source/DotNET/Chronicle/Reactors/CommandSideEffectExecutor.cs
+++ b/Source/DotNET/Chronicle/Reactors/CommandSideEffectExecutor.cs
@@ -36,7 +36,7 @@ public class CommandSideEffectExecutor(IServiceScopeFactory serviceScopeFactory)
     }
 
     static ReactorSideEffectFailure CreateFailure(object command, CommandResult result) =>
-        new([new AppendFailure([], false, DescribeFailure(command.GetType(), result))]);
+        new([new AppendFailure([], false, DescribeFailure(command.GetType(), result), [])]);
 
     static IEnumerable<string> DescribeFailure(Type commandType, CommandResult result)
     {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.100",
+        "version": "10.0.301",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
## Fixed
- Reactor command side-effect failures now build against latest Chronicle, which added a required `TargetEventSourceIds` parameter to `AppendFailure`