### PR TITLE
Add analyzer warning against IEventLog injection in command handlers

### DIFF
--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_does_not_inject_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_does_not_inject_event_log.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventLogInjectionAnalyzer.when_validating_command_handler;
+
+public class and_command_does_not_inject_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+
+namespace TestNamespace
+{
+    public record AuthorCreated(string Name);
+
+    [Command]
+    public record CreateAuthor(string Name)
+    {
+        public AuthorCreated Handle() => new(Name);
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_handle_injects_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_handle_injects_event_log.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventLogInjectionAnalyzer.when_validating_command_handler;
+
+public class and_command_handle_injects_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    [Command]
+    public record CreateAuthor(string Name)
+    {
+        public void Handle(IEventLog {|#0:eventLog|})
+        {
+        }
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0007")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("CreateAuthor", "Handle", "eventLog")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_provide_injects_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_command_provide_injects_event_log.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventLogInjectionAnalyzer.when_validating_command_handler;
+
+public class and_command_provide_injects_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    [Command]
+    public record CreateAuthor(string Name)
+    {
+        public void Provide(IEventLog {|#0:eventLog|})
+        {
+        }
+    }
+}",
+                VerifyCS.Diagnostic("ARCCHR0007")
+                    .WithSeverity(DiagnosticSeverity.Warning)
+                    .WithLocation(0)
+                    .WithArguments("CreateAuthor", "Provide", "eventLog")));
+
+    [Fact] void should_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_non_command_injects_event_log.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis.Specs/for_CommandEventLogInjectionAnalyzer/when_validating_command_handler/and_non_command_injects_event_log.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.Chronicle.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.Chronicle.CodeAnalysis.CommandEventLogInjectionAnalyzer>;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis.for_CommandEventLogInjectionAnalyzer.when_validating_command_handler;
+
+public class and_non_command_injects_event_log : Specification
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(async () => await VerifyCS.VerifyAnalyzerAsync(@"
+using Cratis.Chronicle.EventSequences;
+
+namespace TestNamespace
+{
+    public class SomeService
+    {
+        public void Handle(IEventLog eventLog)
+        {
+        }
+    }
+}"));
+
+    [Fact] void should_not_report_diagnostic() => _result.ShouldBeNull();
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Chronicle.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ ARCCHR0003|Arc.Chronicle|Warning|Reactor must not inject IEventLog
 ARCCHR0004|Arc.Chronicle|Warning|[EventType] should not specify an explicit id
 ARCCHR0005|Arc.Chronicle|Warning|Chronicle artifacts are present but Chronicle is not wired up
 ARCCHR0006|Arc.Chronicle|Warning|Reactor handler invoking ICommandPipeline.Execute must be marked with [OnceOnly]
+ARCCHR0007|Arc.Chronicle|Warning|Command handler must not inject IEventLog

--- a/Source/DotNET/Chronicle.CodeAnalysis/CommandEventLogInjectionAnalyzer.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/CommandEventLogInjectionAnalyzer.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.Chronicle.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that warns when a command injects <c>IEventLog</c> into its handler method instead of expressing appends through the return type.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandEventLogInjectionAnalyzer : DiagnosticAnalyzer
+{
+    const string CommandAttributeName = "Cratis.Arc.Commands.ModelBound.CommandAttribute";
+    const string EventLogInterfaceName = "IEventLog";
+    const string EventSequencesNamespace = "Cratis.Chronicle.EventSequences";
+    static readonly string[] _handlerMethodNames = ["Handle", "Provide"];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARCCHR0007_CommandHandleMustNotInjectEventLog];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (namedTypeSymbol.TypeKind != TypeKind.Class || !IsCommand(namedTypeSymbol))
+        {
+            return;
+        }
+
+        var handlerMethods = namedTypeSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(method =>
+                method.MethodKind == MethodKind.Ordinary &&
+                _handlerMethodNames.Contains(method.Name));
+
+        foreach (var method in handlerMethods)
+        {
+            foreach (var parameter in method.Parameters.Where(parameter => IsEventLog(parameter.Type)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.ARCCHR0007_CommandHandleMustNotInjectEventLog,
+                    parameter.Locations[0],
+                    namedTypeSymbol.Name,
+                    method.Name,
+                    parameter.Name));
+            }
+        }
+    }
+
+    static bool IsCommand(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.ToDisplayString() == CommandAttributeName);
+
+    static bool IsEventLog(ITypeSymbol type)
+    {
+        if (type.Name == EventLogInterfaceName &&
+            type.ContainingNamespace?.ToDisplayString() == EventSequencesNamespace)
+        {
+            return true;
+        }
+
+        return type.AllInterfaces.Any(@interface =>
+            @interface.Name == EventLogInterfaceName &&
+            @interface.ContainingNamespace?.ToDisplayString() == EventSequencesNamespace);
+    }
+}

--- a/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Chronicle.CodeAnalysis/DiagnosticDescriptors.cs
@@ -83,5 +83,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A reactor handler that calls ICommandPipeline.Execute produces a side effect. During replay operations (redaction, revision, observer rewind), the handler runs again and re-executes the command, duplicating the side effect. Mark the method with [OnceOnly] so it is skipped during replays.");
 
+    /// <summary>
+    /// ARCCHR0007: Command Handle method must not inject IEventLog.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARCCHR0007_CommandHandleMustNotInjectEventLog = new(
+        id: "ARCCHR0007",
+        title: "Command handler must not inject IEventLog",
+        messageFormat: "Command '{0}' injects IEventLog into '{1}' through parameter '{2}'. Express every append through the handler return type, not IEventLog.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A command expresses appends by returning events from its Handle method (a single event, a tuple of event and result, a Result, or a collection). Injecting IEventLog into the handler bypasses Arc's append pipeline and its correlation and ordering guarantees. Return the events instead of appending through IEventLog directly.");
+
     const string Category = "Arc.Chronicle";
 }


### PR DESCRIPTION
## Added
- New analyzer `ARCCHR0007` warns when a `[Command]` injects `IEventLog` into its `Handle`/`Provide` method. Express appends through the handler return type instead — injecting `IEventLog` bypasses Arc's append pipeline and its correlation and ordering guarantees.