### PR TITLE
Document the .NET SDK floor imposed by Arc's Roslyn analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,15 @@
     <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="snappier" Version="1.3.1" />
-    <!-- Roslyn-->
+    <!-- Roslyn.
+         The version referenced here becomes a HARD load-floor for consumers: the Arc analyzers and
+         source generators (Cratis.Arc.Core.CodeAnalysis, Cratis.Arc.Chronicle.CodeAnalysis,
+         Cratis.Arc.Core.Generators) are shipped as Roslyn components, so a consumer whose .NET SDK ships
+         an older compiler than this cannot load them and gets CS9057 — silently losing proxy generation
+         and all ARC*/ARCCHR* analyzer coverage.
+         5.6.0 requires .NET SDK 10.0.301+ (SDK 10.0.2xx ships Roslyn 5.3.0, 10.0.1xx ships 5.0.0).
+         Raising this floor is a MINOR change and must be stated in the release notes — never slip it in
+         on a patch. See the SDK requirement in README.md. -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ If you want to jump into building this repository and possibly contributing, ple
 
 The following are prerequisites to work with this repository.
 
-* [.NET 8+](https://dotnet.microsoft.com/en-us/).
+* [.NET SDK 10.0.301+](https://dotnet.microsoft.com/en-us/). Arc's analyzers and source generators are built
+  against Roslyn 5.6.0, which ships with .NET SDK 10.0.301 and newer. On an older SDK band the compiler
+  refuses to load them (CS9057), silently disabling proxy generation and the ARC*/ARCCHR* analyzers.
+  Consuming the `Cratis.Arc` packages carries the same floor. Raising this floor is a minor version bump.
 * [Node 16+](https://nodejs.org/en)
 * [Yarn](https://yarnpkg.com)
 


### PR DESCRIPTION
## Changed
- Documented that the `Cratis.Arc` analyzers and source generators require **.NET SDK 10.0.301+** (they are built against Roslyn 5.6.0). On an older SDK band the compiler emits CS9057 and silently disables proxy generation and all ARC*/ARCCHR* analyzers. Stated in the README prerequisites, with a guard-rail note that raising this floor is a minor version bump.