### PR TITLE
Introducing client side validation only for commands and leveraging this as default behavior in CommandForm

### DIFF
--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -11,6 +11,7 @@ import { ValidationResult } from '@cratis/arc/validation';
 import React, { useMemo, useState, useCallback } from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
+import { runCommandValidation } from './runCommandValidation';
 import { useIdentity } from '../../identity';
 
 // Re-export for backwards compatibility
@@ -33,6 +34,12 @@ export interface CommandFormProps<TCommand extends object, TResponse = object> {
     validateOn?: 'blur' | 'change' | 'both';
     validateAllFieldsOnChange?: boolean;
     validateOnInit?: boolean;
+    /**
+     * Whether silent/eager validation (on init, on change, on blur) should be performed against the
+     * server. Defaults to false — silent validation only runs client-side rules and never contacts the
+     * server. Executing the command still performs full server-side validation regardless of this flag;
+     * enable this only to surface server-only rules (e.g. uniqueness checks) before submission.
+     */
     autoServerValidate?: boolean;
     autoServerValidateThrottle?: number;
     fieldContainerComponent?: React.ComponentType<FieldContainerProps>;
@@ -167,16 +174,14 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
     const serverValidateThrottleTimer = React.useRef<NodeJS.Timeout | null>(null);
 
     const validateSilently = useCallback(async (showErrors: boolean) => {
-        if (commandInstance && typeof (commandInstance as Record<string, unknown>).validate === 'function') {
-            const validationResult = await ((commandInstance as Record<string, unknown>).validate as () => Promise<ICommandResult<unknown>>)();
-            if (validationResult) {
-                setSilentValidationResult(validationResult);
-                if (showErrors) {
-                    setCommandResult(validationResult);
-                }
+        const validationResult = await runCommandValidation(commandInstance, props.autoServerValidate ?? false);
+        if (validationResult) {
+            setSilentValidationResult(validationResult);
+            if (showErrors) {
+                setCommandResult(validationResult);
             }
         }
-    }, [commandInstance]);
+    }, [commandInstance, props.autoServerValidate]);
 
     // Update command values when mergedInitialValues changes (e.g., when data loads asynchronously)
     // When using currentValues, always update when they change (reactive mode for editing)

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormFields.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormFields.tsx
@@ -5,6 +5,7 @@ import { useCommandFormContext, type FieldValidationInfo } from './CommandFormCo
 import React from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import type { ICommandResult } from '@cratis/arc/commands';
+import { runCommandValidation } from './runCommandValidation';
 
 export interface ColumnInfo {
     fields: React.ReactElement<CommandFormFieldProps>[];
@@ -76,13 +77,11 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
 
                 // Always run silent validation after every value change.
                 // This is the sole driver of context.isValid — it runs regardless of
-                // validateOn so isValid is always accurate.
-                let validationResult: ICommandResult<unknown> | undefined = undefined;
-                if (context.commandInstance && typeof (context.commandInstance as Record<string, unknown>).validate === 'function') {
-                    validationResult = await ((context.commandInstance as Record<string, unknown>).validate as () => Promise<ICommandResult<unknown>>)();
-                    if (validationResult) {
-                        context.setSilentValidationResult(validationResult);
-                    }
+                // validateOn so isValid is always accurate. It only hits the server when
+                // autoServerValidate is enabled; otherwise it stays client-side only.
+                const validationResult = await runCommandValidation(context.commandInstance, context.autoServerValidate);
+                if (validationResult) {
+                    context.setSilentValidationResult(validationResult);
                 }
 
                 // Show validation error messages based on the validateOn setting.
@@ -116,8 +115,8 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
                 const shouldValidateOnBlur = context.validateOn === 'blur' || context.validateOn === 'both';
 
                 let validationResult: ICommandResult<unknown> | undefined = undefined;
-                if (shouldValidateOnBlur && context.commandInstance && typeof (context.commandInstance as Record<string, unknown>).validate === 'function') {
-                    validationResult = await ((context.commandInstance as Record<string, unknown>).validate as () => Promise<ICommandResult<unknown>>)();
+                if (shouldValidateOnBlur) {
+                    validationResult = await runCommandValidation(context.commandInstance, context.autoServerValidate);
 
                     if (validationResult) {
                         // Keep silent result current (covers edge cases where blur fires

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_autoServerValidate_is_not_specified/and_a_field_changes_to_a_valid_value.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_autoServerValidate_is_not_specified/and_a_field_changes_to_a_valid_value.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { CommandForm } from '../../CommandForm';
+import { asCommandFormField } from '../../asCommandFormField';
+import { Command, CommandValidator } from '@cratis/arc/commands';
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { a_command_form_context } from '../given/a_command_form_context';
+import { given } from '../../../../given';
+import { vi } from 'vitest';
+
+let serverValidateCallCount = 0;
+
+class ValidatedCommandValidator extends CommandValidator<ValidatedCommand> {
+    constructor() {
+        super();
+        this.ruleFor(c => c.name).notEmpty().minLength(3);
+    }
+}
+
+class ValidatedCommand extends Command {
+    readonly route = '/api/test';
+    readonly validation = new ValidatedCommandValidator();
+    readonly propertyDescriptors: PropertyDescriptor[] = [
+        new PropertyDescriptor('name', String, false)
+    ];
+
+    name = '';
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+const SimpleTextField = asCommandFormField<{ value: string; onChange: (value: unknown) => void; onBlur?: () => void; invalid: boolean; required: boolean; errors: string[] }>(
+    (props) => {
+        return React.createElement('input', {
+            type: 'text',
+            value: props.value,
+            onChange: props.onChange,
+            onBlur: props.onBlur,
+            'data-testid': 'text-input'
+        });
+    },
+    {
+        defaultValue: '',
+        extractValue: (e: unknown) => (e as React.ChangeEvent<HTMLInputElement>).target.value
+    }
+);
+
+describe("when autoServerValidate is not specified and a field changes to a valid value", given(a_command_form_context, context => {
+    let result: ReturnType<typeof render>;
+
+    beforeEach(() => {
+        serverValidateCallCount = 0;
+
+        vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+            if (url.toString().includes('/validate')) {
+                serverValidateCallCount++;
+            }
+            return new Response(JSON.stringify({}), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        });
+
+        result = render(
+            React.createElement(
+                CommandForm,
+                { command: ValidatedCommand },
+                React.createElement(SimpleTextField, {
+                    value: (c: ValidatedCommand) => c.name,
+                    title: 'Name'
+                })
+            ),
+            { wrapper: context.createWrapper() }
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should not contact the server on change or blur", async () => {
+        const input = result.getByTestId('text-input') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'John Doe' } });
+        fireEvent.blur(input);
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+        serverValidateCallCount.should.equal(0);
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_autoServerValidate_is_not_specified/with_valid_initial_values.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_CommandForm/when_autoServerValidate_is_not_specified/with_valid_initial_values.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { CommandForm, useCommandFormContext } from '../../CommandForm';
+import { Command, CommandValidator } from '@cratis/arc/commands';
+import { PropertyDescriptor } from '@cratis/arc/reflection';
+import { a_command_form_context } from '../given/a_command_form_context';
+import { given } from '../../../../given';
+import { vi } from 'vitest';
+
+let serverValidateCallCount = 0;
+
+class ValidatedCommandValidator extends CommandValidator<ValidatedCommand> {
+    constructor() {
+        super();
+        this.ruleFor(c => c.name).notEmpty().minLength(3);
+    }
+}
+
+class ValidatedCommand extends Command {
+    readonly route = '/api/test';
+    readonly validation = new ValidatedCommandValidator();
+    readonly propertyDescriptors: PropertyDescriptor[] = [
+        new PropertyDescriptor('name', String, false)
+    ];
+
+    name = '';
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    constructor() {
+        super(Object, false);
+    }
+}
+
+describe("when autoServerValidate is not specified with valid initial values", given(a_command_form_context, context => {
+    let capturedIsValid: boolean | undefined;
+
+    const ContextCapture = () => {
+        const ctx = useCommandFormContext();
+        capturedIsValid = ctx.isValid;
+        return React.createElement('div');
+    };
+
+    beforeEach(() => {
+        capturedIsValid = undefined;
+        serverValidateCallCount = 0;
+
+        vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+            if (url.toString().includes('/validate')) {
+                serverValidateCallCount++;
+            }
+            return new Response(JSON.stringify({}), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        });
+
+        render(
+            React.createElement(
+                CommandForm,
+                {
+                    command: ValidatedCommand,
+                    initialValues: { name: 'John Doe' }
+                },
+                React.createElement(ContextCapture)
+            ),
+            { wrapper: context.createWrapper() }
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should report isValid as true without contacting the server", async () => {
+        await waitFor(() => {
+            return capturedIsValid === true;
+        }, { timeout: 2000 });
+        serverValidateCallCount.should.equal(0);
+    });
+}));

--- a/Source/JavaScript/Arc.React/commands/CommandForm/runCommandValidation.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/runCommandValidation.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import type { ICommandResult } from '@cratis/arc/commands';
+
+export async function runCommandValidation(commandInstance: unknown, useServerValidation: boolean): Promise<ICommandResult<unknown> | undefined> {
+    if (!commandInstance) {
+        return undefined;
+    }
+
+    const instance = commandInstance as Record<string, unknown>;
+
+    if (useServerValidation && typeof instance.validate === 'function') {
+        return (instance.validate as () => Promise<ICommandResult<unknown>>)();
+    }
+
+    if (typeof instance.validateClientSide === 'function') {
+        return (instance.validateClientSide as () => ICommandResult<unknown>)();
+    }
+
+    return undefined;
+}

--- a/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/FakeCommand.ts
+++ b/Source/JavaScript/Arc.React/commands/for_CommandScopeImplementation/FakeCommand.ts
@@ -15,6 +15,7 @@ export class FakeCommand implements ICommand {
 
     execute: sinon.SinonSpy;
     validate: sinon.SinonSpy;
+    validateClientSide: sinon.SinonSpy;
     clear: sinon.SinonStub;
     setApiBasePath: sinon.SinonStub;
     setOrigin: sinon.SinonStub;
@@ -39,6 +40,7 @@ export class FakeCommand implements ICommand {
                 resolve(CommandResult.empty);
             });
         });
+        this.validateClientSide = sinon.fake(() => CommandResult.empty);
         this.clear = sinon.stub();
         this.setApiBasePath = sinon.stub();
         this.setOrigin = sinon.stub();

--- a/Source/JavaScript/Arc/commands/Command.ts
+++ b/Source/JavaScript/Arc/commands/Command.ts
@@ -121,6 +121,21 @@ export abstract class Command<TCommandContent = object, TCommandResponse = objec
         return this.performRequest(actualRoute, 'Command validation endpoint not found at route', 'Error during validation call');
     }
 
+    /** @inheritdoc */
+    validateClientSide(): CommandResult<TCommandResponse> {
+        const clientValidationErrors = this.validation?.validate(this) || [];
+        if (clientValidationErrors.length > 0) {
+            return CommandResult.validationFailed(clientValidationErrors) as CommandResult<TCommandResponse>;
+        }
+
+        const validationErrors = this.validateRequiredProperties();
+        if (validationErrors.length > 0) {
+            return CommandResult.validationFailed(validationErrors) as CommandResult<TCommandResponse>;
+        }
+
+        return CommandResult.empty as unknown as CommandResult<TCommandResponse>;
+    }
+
     private buildPayload(): object {
         const payload = {};
         this.propertyDescriptors.forEach(propertyDescriptor => {

--- a/Source/JavaScript/Arc/commands/ICommand.ts
+++ b/Source/JavaScript/Arc/commands/ICommand.ts
@@ -48,6 +48,16 @@ export interface ICommand<TCommandContent = object, TCommandResponse = object> e
     validate(): Promise<CommandResult<TCommandResponse>>;
 
     /**
+     * Validate the {@link ICommand} using only client-side rules, without contacting the server.
+     * @returns {CommandResult} for the validation containing the client-side validation status.
+     * @remarks
+     * This method checks the registered validator rules and required properties locally.
+     * It never performs a network call. Use this for cheap, immediate feedback while the user is typing;
+     * use {@link validate} when server-side rules (e.g. uniqueness checks) also need to be verified.
+     */
+    validateClientSide(): CommandResult<TCommandResponse>;
+
+    /**
      * Clear the command properties and reset them to their default values. This will also clear the initial values.
      * This is used when the command is not needed anymore and should be cleared.
      */

--- a/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_client_validation_failure.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_client_validation_failure.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { a_command_with_validator } from '../given/a_command_with_validator';
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+
+describe("when validating client side with client validation failure", given(a_command_with_validator, context => {
+    let result: CommandResult<object>;
+
+    beforeEach(() => {
+        context.command.email = '';
+        context.command.age = 25;
+
+        result = context.command.validateClientSide();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should not call server", () => context.fetchStub.called.should.be.false);
+    it("should return invalid result", () => result.isValid.should.be.false);
+    it("should have validation error", () => result.validationResults.length.should.equal(1));
+    it("should have error for email property", () => result.validationResults[0].members[0].should.equal('email'));
+}));

--- a/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_client_validation_passing.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_client_validation_passing.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Command } from '../../Command';
+import { CommandValidator } from '../../CommandValidator';
+import { PropertyDescriptor } from '../../../reflection/PropertyDescriptor';
+import '../../../validation/RuleBuilderExtensions';
+import sinon from 'sinon';
+import { CommandResult } from '../../CommandResult';
+import { createFetchHelper } from '../../../helpers/fetchHelper';
+
+interface ITestCommand {
+    email: string;
+    age: number;
+}
+
+class TestCommandValidator extends CommandValidator<ITestCommand> {
+    constructor() {
+        super();
+        this.ruleFor(c => c.email).notEmpty().emailAddress();
+        this.ruleFor(c => c.age).greaterThanOrEqual(18);
+    }
+}
+
+class TestCommand extends Command<ITestCommand> {
+    readonly route = '/api/test';
+    readonly validation = new TestCommandValidator();
+    readonly propertyDescriptors: PropertyDescriptor[] = [];
+    email = '';
+    age = 0;
+
+    constructor() {
+        super(Object, false);
+    }
+
+    get requestParameters(): string[] {
+        return [];
+    }
+
+    get properties(): string[] {
+        return ['email', 'age'];
+    }
+}
+
+describe("when validating client side with client validation passing", () => {
+    let command: TestCommand;
+    let fetchStub: sinon.SinonStub;
+    let fetchHelper: { stubFetch: () => sinon.SinonStub; restore: () => void };
+    let result: CommandResult<object>;
+
+    beforeEach(() => {
+        command = new TestCommand();
+        command.setOrigin('http://localhost');
+        command.email = 'test@example.com';
+        command.age = 25;
+
+        fetchHelper = createFetchHelper();
+        fetchStub = fetchHelper.stubFetch();
+
+        result = command.validateClientSide();
+    });
+
+    afterEach(() => {
+        fetchHelper.restore();
+    });
+
+    it("should not call server", () => fetchStub.called.should.be.false);
+    it("should return valid result", () => result.isValid.should.be.true);
+});

--- a/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_required_property_missing.ts
+++ b/Source/JavaScript/Arc/commands/for_Command/when_validating_client_side/with_required_property_missing.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { CommandResult } from '../../CommandResult';
+import { a_command } from '../given/a_command';
+
+describe("when validating client side with required property missing", given(class extends a_command {
+    constructor() {
+        super();
+        this.command.someProperty = undefined as unknown as string;
+    }
+}, context => {
+    let result: CommandResult<object>;
+
+    beforeEach(() => {
+        result = context.command.validateClientSide();
+    });
+
+    afterEach(() => {
+        context.fetchStub.restore();
+    });
+
+    it("should not call server", () => context.fetchStub.called.should.be.false);
+    it("should return invalid result", () => result.isValid.should.be.false);
+    it("should have validation error", () => result.validationResults.length.should.equal(1));
+    it("should have error for missing property", () => result.validationResults[0].members[0].should.equal('someProperty'));
+}));


### PR DESCRIPTION
## Fixed

- `CommandForm` now calls the `validateClientSide` for validating things when the automatic serverside validation is turned off.
