### PR TITLE
Bump Cratis.Metrics.Roslyn to 7.16.6 to satisfy Chronicle 16.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.1.0" />
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.1.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.2" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.6" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />


### PR DESCRIPTION
## Fixed

- Restore/build failure from a Cratis.Metrics.Roslyn package downgrade after updating to Cratis.Chronicle 16.1.0