### PR TITLE
Add landing page for the Reactors docs folder

### DIFF
--- a/Documentation/backend/chronicle/reactors/index.md
+++ b/Documentation/backend/chronicle/reactors/index.md
@@ -1,0 +1,12 @@
+---
+title: Reactors
+description: Topics for building reactors that react to Chronicle events and trigger side effects.
+---
+
+[React to an event](../react-to-an-event.md) covers the fundamentals of reactors — when to reach for one and how they observe events. The topics here go deeper on specific reactor patterns.
+
+## Topics
+
+| Topic | Description |
+| ------- | ----------- |
+| [Returning commands as side effects](./command-side-effects.md) | Let a reactor trigger follow-up commands by returning them — Arc executes them through the command pipeline automatically. |


### PR DESCRIPTION
## Fixed
- Added a missing `index.md` landing page for the Reactors docs folder — it had a `toc.yml` and one topic page but no landing, so its bare URL 404'd and broke the Documentation site's internal link check.