### PR TITLE
Fix observable concept-arg coercion, boxed/mixed event returns, and MVVM render reactions

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_a_concept_argument_as_string.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_a_concept_argument_as_string.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.Queries.for_QueryPipeline.when_performing;
+
+public class with_a_concept_argument_as_string : given.a_query_pipeline
+{
+    FullyQualifiedQueryName _queryName;
+    QueryArguments _parameters;
+    Guid _idValue;
+    QueryContext _capturedContext;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _queryName = "TestQuery";
+        _idValue = Guid.NewGuid();
+        _parameters = new() { { "id", _idValue.ToString() } };
+
+        _queryPerformer.Dependencies.Returns(new List<Type>());
+        _queryPerformer.Parameters.Returns(new QueryParameters([new QueryParameter("id", typeof(TestId))]));
+        _queryPerformerProviders.TryGetPerformersFor(_queryName, out var _).Returns(callInfo =>
+        {
+            callInfo[1] = _queryPerformer;
+            return true;
+        });
+
+        query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(QueryResult.Success(_correlationId));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(new { name = "Test" }));
+        _queryRenderers.Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>())
+            .Returns(new QueryRendererResult(1, new { name = "Test" }));
+    }
+
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, Paging.NotPaged, Sorting.None, _serviceProvider);
+
+    [Fact] void should_coerce_the_argument_to_the_concept_type() => _capturedContext.Arguments["id"].ShouldBeOfExactType<TestId>();
+    [Fact] void should_coerce_to_the_correct_concept_value() => ((TestId)_capturedContext.Arguments["id"]).Value.ShouldEqual(_idValue);
+
+    public record TestId(Guid Value) : ConceptAs<Guid>(Value);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_a_guid_argument_as_string.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_a_guid_argument_as_string.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_QueryPipeline.when_performing;
+
+public class with_a_guid_argument_as_string : given.a_query_pipeline
+{
+    FullyQualifiedQueryName _queryName;
+    QueryArguments _parameters;
+    Guid _idValue;
+    QueryContext _capturedContext;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _queryName = "TestQuery";
+        _idValue = Guid.NewGuid();
+        _parameters = new() { { "id", _idValue.ToString() } };
+
+        _queryPerformer.Dependencies.Returns(new List<Type>());
+        _queryPerformer.Parameters.Returns(new QueryParameters([new QueryParameter("id", typeof(Guid))]));
+        _queryPerformerProviders.TryGetPerformersFor(_queryName, out var _).Returns(callInfo =>
+        {
+            callInfo[1] = _queryPerformer;
+            return true;
+        });
+
+        query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(QueryResult.Success(_correlationId));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(new { name = "Test" }));
+        _queryRenderers.Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>())
+            .Returns(new QueryRendererResult(1, new { name = "Test" }));
+    }
+
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, Paging.NotPaged, Sorting.None, _serviceProvider);
+
+    [Fact] void should_coerce_the_argument_to_a_guid() => _capturedContext.Arguments["id"].ShouldBeOfExactType<Guid>();
+    [Fact] void should_coerce_to_the_correct_guid_value() => _capturedContext.Arguments["id"].ShouldEqual(_idValue);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_an_already_typed_concept_argument.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryPipeline/when_performing/with_an_already_typed_concept_argument.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.Queries.for_QueryPipeline.when_performing;
+
+public class with_an_already_typed_concept_argument : given.a_query_pipeline
+{
+    FullyQualifiedQueryName _queryName;
+    QueryArguments _parameters;
+    TestId _id;
+    QueryContext _capturedContext;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _queryName = "TestQuery";
+        _id = new TestId(Guid.NewGuid());
+        _parameters = new() { { "id", _id } };
+
+        _queryPerformer.Dependencies.Returns(new List<Type>());
+        _queryPerformer.Parameters.Returns(new QueryParameters([new QueryParameter("id", typeof(TestId))]));
+        _queryPerformerProviders.TryGetPerformersFor(_queryName, out var _).Returns(callInfo =>
+        {
+            callInfo[1] = _queryPerformer;
+            return true;
+        });
+
+        query_filters.OnPerform(Arg.Do<QueryContext>(ctx => _capturedContext = ctx)).Returns(QueryResult.Success(_correlationId));
+        _queryPerformer.Perform(Arg.Any<QueryContext>()).Returns(ValueTask.FromResult<object?>(new { name = "Test" }));
+        _queryRenderers.Render(Arg.Any<FullyQualifiedQueryName>(), Arg.Any<object>(), Arg.Any<IServiceProvider>())
+            .Returns(new QueryRendererResult(1, new { name = "Test" }));
+    }
+
+    async Task Because() => _result = await _pipeline.Perform(_queryName, _parameters, Paging.NotPaged, Sorting.None, _serviceProvider);
+
+    [Fact] void should_pass_the_same_instance_through_untouched() => ReferenceEquals(_capturedContext.Arguments["id"], _id).ShouldBeTrue();
+
+    public record TestId(Guid Value) : ConceptAs<Guid>(Value);
+}

--- a/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryPipeline.cs
@@ -57,7 +57,8 @@ public class QueryPipeline(
             }
 
             var dependencies = queryPerformer.Dependencies.Select(dependencyType => ResolveDependency(serviceProvider, dependencyType)).ToArray();
-            var context = new QueryContext(queryName, correlationId, paging, sorting, arguments, dependencies);
+            var coercedArguments = CoerceArguments(arguments, queryPerformer);
+            var context = new QueryContext(queryName, correlationId, paging, sorting, coercedArguments, dependencies);
             queryContextManager.Set(context);
 
             result = await queryFilters.OnPerform(context);
@@ -93,6 +94,49 @@ public class QueryPipeline(
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Coerces each raw query argument to its declared parameter type before it reaches the filters and performer.
+    /// </summary>
+    /// <param name="arguments">The <see cref="QueryArguments"/> to coerce.</param>
+    /// <param name="performer">The <see cref="IQueryPerformer"/> whose parameters describe the target types.</param>
+    /// <returns>The coerced <see cref="QueryArguments"/>, or the original instance when nothing needed coercion.</returns>
+    /// <remarks>
+    /// One-shot transports coerce arguments at the HTTP boundary, but streaming transports (WebSocket / SSE observable
+    /// queries) carry raw string arguments through verbatim. Coercing here — the single convergence point for every
+    /// transport — guarantees the <see cref="QueryContext"/> always exposes arguments in their declared parameter types,
+    /// so validation and invocation never see an unconverted string for a concept-typed parameter.
+    /// The conversion is idempotent, so already-typed arguments pass through untouched.
+    /// </remarks>
+    static QueryArguments CoerceArguments(QueryArguments arguments, IQueryPerformer performer)
+    {
+        var parameters = performer.Parameters;
+        if (arguments.Count == 0 || parameters is null)
+        {
+            return arguments;
+        }
+
+        var coerced = new QueryArguments();
+        var changed = false;
+        foreach (var kvp in arguments)
+        {
+            var value = kvp.Value;
+            var parameter = parameters.FirstOrDefault(_ => string.Equals(_.Name, kvp.Key, StringComparison.OrdinalIgnoreCase));
+            if (parameter is not null)
+            {
+                var convertedValue = value.ConvertTo(parameter.Type);
+                if (convertedValue is not null && !ReferenceEquals(convertedValue, value))
+                {
+                    value = convertedValue;
+                    changed = true;
+                }
+            }
+
+            coerced[kvp.Key] = value;
+        }
+
+        return changed ? coerced : arguments;
     }
 
     static object ResolveDependency(IServiceProvider serviceProvider, Type dependencyType)

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_boxed_wrapper_collection.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_boxed_wrapper_collection.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_checking_can_handle;
+
+public class with_boxed_wrapper_collection : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    bool _result;
+
+    void Establish()
+    {
+        _eventTypes.HasFor(typeof(TestEvent)).Returns(true);
+        _eventTypes.HasFor(typeof(AnotherTestEvent)).Returns(true);
+        _value =
+        [
+            new EventForEventSourceId(EventSourceId.New(), new TestEvent("First")),
+            new EventForEventSourceId(EventSourceId.New(), new AnotherTestEvent(42))
+        ];
+    }
+
+    void Because() => _result = _handler.CanHandle(_commandContext, _value);
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_mixed_plain_and_wrapped_events.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_mixed_plain_and_wrapped_events.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_checking_can_handle;
+
+public class with_mixed_plain_and_wrapped_events : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    bool _result;
+
+    void Establish()
+    {
+        _eventTypes.HasFor(typeof(TestEvent)).Returns(true);
+        _eventTypes.HasFor(typeof(AnotherTestEvent)).Returns(true);
+        _value =
+        [
+            new TestEvent("Plain"),
+            new EventForEventSourceId(EventSourceId.New(), new AnotherTestEvent(42))
+        ];
+    }
+
+    void Because() => _result = _handler.CanHandle(_commandContext, _value);
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_plain_events_only.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_checking_can_handle/with_plain_events_only.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_checking_can_handle;
+
+public class with_plain_events_only : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    bool _result;
+
+    void Establish()
+    {
+        _eventTypes.HasFor(typeof(TestEvent)).Returns(true);
+        _eventTypes.HasFor(typeof(AnotherTestEvent)).Returns(true);
+        _value = [new TestEvent("First"), new AnotherTestEvent(42)];
+    }
+
+    void Because() => _result = _handler.CanHandle(_commandContext, _value);
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/and_boxed_collection_append_is_constraint_rejected.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/and_boxed_collection_append_is_constraint_rejected.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_handling;
+
+public class and_boxed_collection_append_is_constraint_rejected : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    CommandResult _result;
+
+    void Establish()
+    {
+        var violation = new ConstraintViolation(
+            EventTypeId.Unknown,
+            EventSequenceNumber.Unavailable,
+            ConstraintType.Unknown,
+            new ConstraintName("TestConstraint"),
+            new ConstraintViolationMessage("Test violation"),
+            new ConstraintViolationDetails());
+
+        var failedResult = AppendResult.Failed(_correlationId, [violation]);
+        _eventLog.Append(Arg.Any<EventSourceId>(), Arg.Any<object>()).Returns(failedResult);
+        _eventTypes.HasFor(Arg.Any<Type>()).Returns(true);
+
+        _value = [new EventForEventSourceId(EventSourceId.New(), new TestEvent("Test"))];
+    }
+
+    async Task Because() => _result = await _handler.Handle(_commandContext, _value);
+
+    [Fact] void should_return_failed_command_result() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_include_constraint_violation_message() => _result.ValidationResults.First().Message.ShouldEqual("Test violation");
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/boxed_wrapper_collection.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/boxed_wrapper_collection.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_handling;
+
+public class boxed_wrapper_collection : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    CommandResult _result;
+    EventSourceId _firstEventSourceId;
+    EventSourceId _secondEventSourceId;
+    TestEvent _firstEvent;
+    AnotherTestEvent _secondEvent;
+
+    void Establish()
+    {
+        _eventTypes.HasFor(Arg.Any<Type>()).Returns(true);
+        _firstEventSourceId = EventSourceId.New();
+        _secondEventSourceId = EventSourceId.New();
+        _firstEvent = new TestEvent("First");
+        _secondEvent = new AnotherTestEvent(42);
+        _value =
+        [
+            new EventForEventSourceId(_firstEventSourceId, _firstEvent),
+            new EventForEventSourceId(_secondEventSourceId, _secondEvent)
+        ];
+    }
+
+    async Task Because() => _result = await _handler.Handle(_commandContext, _value);
+
+    [Fact] void should_return_success() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_append_first_event_with_its_event_source_id() => _eventLog.Received(1).Append(_firstEventSourceId, _firstEvent, Arg.Any<EventStreamType?>(), Arg.Any<EventStreamId?>(), Arg.Any<EventSourceType?>());
+    [Fact] void should_append_second_event_with_its_event_source_id() => _eventLog.Received(1).Append(_secondEventSourceId, _secondEvent, Arg.Any<EventStreamType?>(), Arg.Any<EventStreamId?>(), Arg.Any<EventSourceType?>());
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/mixed_plain_and_wrapped_events.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsForEventSourceIdCommandResponseValueHandler/when_handling/mixed_plain_and_wrapped_events.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsForEventSourceIdCommandResponseValueHandler.when_handling;
+
+public class mixed_plain_and_wrapped_events : given.an_events_for_event_source_id_command_response_value_handler
+{
+    object[] _value;
+    CommandResult _result;
+    EventSourceId _commandEventSourceId;
+    EventSourceId _wrapperEventSourceId;
+    TestEvent _plainEvent;
+    AnotherTestEvent _wrappedEvent;
+
+    void Establish()
+    {
+        _eventTypes.HasFor(Arg.Any<Type>()).Returns(true);
+        _commandEventSourceId = EventSourceId.New();
+        _wrapperEventSourceId = EventSourceId.New();
+        _commandContext.Values[WellKnownCommandContextKeys.EventSourceId] = _commandEventSourceId;
+
+        _plainEvent = new TestEvent("Plain");
+        _wrappedEvent = new AnotherTestEvent(42);
+        _value = [_plainEvent, new EventForEventSourceId(_wrapperEventSourceId, _wrappedEvent)];
+    }
+
+    async Task Because() => _result = await _handler.Handle(_commandContext, _value);
+
+    [Fact] void should_return_success() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_append_the_plain_event_to_the_command_event_source_id() => _eventLog.Received(1).Append(_commandEventSourceId, _plainEvent, Arg.Any<EventStreamType?>(), Arg.Any<EventStreamId?>(), Arg.Any<EventSourceType?>());
+    [Fact] void should_append_the_wrapped_event_to_its_own_event_source_id() => _eventLog.Received(1).Append(_wrapperEventSourceId, _wrappedEvent, Arg.Any<EventStreamType?>(), Arg.Any<EventStreamId?>(), Arg.Any<EventSourceType?>());
+}

--- a/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using Cratis.Arc.Commands;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences;
@@ -8,28 +9,62 @@ using Cratis.Chronicle.EventSequences;
 namespace Cratis.Arc.Chronicle.Commands;
 
 /// <summary>
-/// Represents a command response value handler that can handle an <see cref="IEnumerable{T}"/> of <see cref="EventForEventSourceId"/> as the response value.
+/// Represents a command response value handler that can handle a collection containing one or more
+/// <see cref="EventForEventSourceId"/> wrappers as the response value — including a mixed collection of
+/// plain events and wrappers.
 /// </summary>
 /// <param name="eventLog">The event log to append events to.</param>
 /// <param name="eventTypes">The event types.</param>
+/// <remarks>
+/// The match is based on the runtime type of each element rather than the static type of the collection, so a
+/// collection boxed as <see cref="IEnumerable{T}"/> of <see cref="object"/> — or a mixed collection of plain events
+/// and <see cref="EventForEventSourceId"/> wrappers — is appended instead of falling through the handlers and being
+/// silently serialized as the response payload. Each wrapper is appended to its own event source id; each plain event
+/// is appended to the command's event source id.
+/// </remarks>
 public class EventsForEventSourceIdCommandResponseValueHandler(IEventLog eventLog, IEventTypes eventTypes) : ICommandResponseValueHandler
 {
     /// <inheritdoc/>
-    public bool CanHandle(CommandContext commandContext, object value) =>
-        value is IEnumerable<EventForEventSourceId> events &&
-        events.All(e => eventTypes.HasFor(e.Event.GetType()));
+    public bool CanHandle(CommandContext commandContext, object value)
+    {
+        if (value is not IEnumerable enumerable || value is string)
+        {
+            return false;
+        }
+
+        var items = enumerable.Cast<object>().ToArray();
+
+        // An empty collection statically typed as wrappers is still ours — it is recognized (and appends
+        // nothing) rather than being serialized as the response payload.
+        if (items.Length == 0)
+        {
+            return value is IEnumerable<EventForEventSourceId>;
+        }
+
+        // A non-empty collection must contain at least one wrapper (distinguishing it from a pure plain-event
+        // collection handled by the sibling handler), and every element must be a wrapper carrying a registered
+        // event, or a registered plain event.
+        return items.Any(item => item is EventForEventSourceId) &&
+            items.All(item => item is EventForEventSourceId wrapper
+                ? eventTypes.HasFor(wrapper.Event.GetType())
+                : eventTypes.HasFor(item.GetType()));
+    }
 
     /// <inheritdoc/>
     public async Task<CommandResult> Handle(CommandContext commandContext, object value)
     {
-        var events = (IEnumerable<EventForEventSourceId>)value;
+        var items = ((IEnumerable)value).Cast<object>();
         var concurrencyScope = ConcurrencyScopeBuilder.BuildFromCommandContext(commandContext);
 
-        foreach (var eventForEventSourceId in events)
+        foreach (var item in items)
         {
+            var (eventSourceId, @event) = item is EventForEventSourceId wrapped
+                ? (wrapped.EventSourceId, wrapped.Event)
+                : (commandContext.GetEventSourceId(), item);
+
             var result = await eventLog.Append(
-                eventForEventSourceId.EventSourceId,
-                eventForEventSourceId.Event,
+                eventSourceId,
+                @event,
                 commandContext.GetEventStreamType(),
                 commandContext.GetEventStreamId(),
                 commandContext.GetEventSourceType(),

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ProxyGenerator.Specs.csproj
@@ -32,8 +32,18 @@
         <EmbeddedResource Include="Scenarios\Infrastructure\arc-bootstrap.js" Condition="Exists('Scenarios\Infrastructure\arc-bootstrap.js')" />
     </ItemGroup>
     <ItemGroup>
+        <!-- The scenario specs compile generated TypeScript in-process through ClearScript's V8 engine, which
+             requires the classic JavaScript-based TypeScript compiler (lib/typescript.js). TypeScript 7 ships a
+             native compiler that no longer exposes lib/typescript.js, so prefer the classic 'typescript-for-eslint'
+             alias (npm:typescript@6.0.3) when present, and fall back to the root 'typescript' package for
+             environments that still resolve a classic TypeScript. Either source lands at the same TargetPath the
+             runtime fixture reads. -->
+        <ProxyJavaScriptDependency Include="$(MSBuildThisFileDirectory)../../../../node_modules/typescript-for-eslint/lib/typescript.js"
+                                   Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/typescript-for-eslint/lib/typescript.js')">
+            <TargetPath>node_modules/typescript/lib/typescript.js</TargetPath>
+        </ProxyJavaScriptDependency>
         <ProxyJavaScriptDependency Include="$(MSBuildThisFileDirectory)../../../../node_modules/typescript/lib/typescript.js"
-                                   Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/typescript/lib/typescript.js')">
+                                   Condition="Exists('$(MSBuildThisFileDirectory)../../../../node_modules/typescript/lib/typescript.js') AND !Exists('$(MSBuildThisFileDirectory)../../../../node_modules/typescript-for-eslint/lib/typescript.js')">
             <TargetPath>node_modules/typescript/lib/typescript.js</TargetPath>
         </ProxyJavaScriptDependency>
         <ProxyJavaScriptDependency Include="$(MSBuildThisFileDirectory)../../../../node_modules/@cratis/fundamentals/dist/cjs/**/*"

--- a/Source/JavaScript/Arc.React.MVVM/MVVMContext.tsx
+++ b/Source/JavaScript/Arc.React.MVVM/MVVMContext.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Bindings } from './Bindings';
 import { configure as configureMobx } from 'mobx';
 import { MobxOptions } from './MobxOptions';
+import { deferredReactionScheduler } from './deferredReactionScheduler';
 
 export interface MVVMProps {
     children?: JSX.Element | JSX.Element[];
@@ -15,7 +16,8 @@ export const MVVMContext = React.createContext({});
 
 export const MVVM = (props: MVVMProps) => {
     const options: MobxOptions = {
-        ...{ enforceActions: 'never' },
+        enforceActions: 'never',
+        reactionScheduler: deferredReactionScheduler,
         ...(props.mobx || {}),
     };
 

--- a/Source/JavaScript/Arc.React.MVVM/deferredReactionScheduler.ts
+++ b/Source/JavaScript/Arc.React.MVVM/deferredReactionScheduler.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+let pendingReactions = false;
+
+/**
+ * A MobX reaction scheduler that defers pending reactions to a microtask so they never run synchronously
+ * inside React's render phase.
+ *
+ * MobX's default scheduler runs reactions synchronously the moment an observable changes. When an observable
+ * that a mounted `<Observer>` depends on mutates while React is rendering a *different* component — common
+ * when a page mounts many observable queries and one resolves mid-render — the reaction drives `forceUpdate`
+ * on that component during render, which React reports as "Cannot update a component while rendering a
+ * different component" and can escalate to an error boundary under live streaming timing.
+ *
+ * Deferring the reaction run to a microtask lets the in-progress render finish first; React then re-renders
+ * on the next tick. A single microtask is scheduled per batch — MobX's flush drains every pending reaction,
+ * so redundant scheduling is avoided while cascading reactions are still handled.
+ * @param runReactions The function provided by MobX that flushes all pending reactions.
+ */
+export function deferredReactionScheduler(runReactions: () => void): void {
+    if (pendingReactions) {
+        return;
+    }
+
+    pendingReactions = true;
+    queueMicrotask(() => {
+        pendingReactions = false;
+        runReactions();
+    });
+}

--- a/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_a_reaction_schedules_another_reaction.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_a_reaction_schedules_another_reaction.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { deferredReactionScheduler } from '../deferredReactionScheduler';
+
+describe('when a reaction schedules another reaction during flush', () => {
+    let outerRan: boolean;
+    let followUpRan: boolean;
+
+    beforeEach(async () => {
+        outerRan = false;
+        followUpRan = false;
+        deferredReactionScheduler(() => {
+            outerRan = true;
+            deferredReactionScheduler(() => { followUpRan = true; });
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+
+    it('should run the outer reaction', () => outerRan.should.be.true);
+    it('should run the follow-up reaction scheduled during the flush', () => followUpRan.should.be.true);
+});

--- a/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_scheduling_a_reaction.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_scheduling_a_reaction.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { deferredReactionScheduler } from '../deferredReactionScheduler';
+
+describe('when scheduling a reaction', () => {
+    let ranBeforeMicrotask: boolean;
+    let ran: boolean;
+
+    beforeEach(async () => {
+        ran = false;
+        deferredReactionScheduler(() => { ran = true; });
+        ranBeforeMicrotask = ran;
+        await Promise.resolve();
+    });
+
+    it('should not run the reaction synchronously', () => ranBeforeMicrotask.should.be.false);
+    it('should run the reaction on the next microtask', () => ran.should.be.true);
+});

--- a/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_scheduling_multiple_reactions_before_flush.ts
+++ b/Source/JavaScript/Arc.React.MVVM/for_deferredReactionScheduler/when_scheduling_multiple_reactions_before_flush.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { deferredReactionScheduler } from '../deferredReactionScheduler';
+
+describe('when scheduling multiple reactions before flush', () => {
+    let runCount: number;
+
+    beforeEach(async () => {
+        runCount = 0;
+        const run = () => { runCount++; };
+        deferredReactionScheduler(run);
+        deferredReactionScheduler(run);
+        deferredReactionScheduler(run);
+        await Promise.resolve();
+    });
+
+    it('should coalesce into a single microtask flush', () => runCount.should.equal(1));
+});


### PR DESCRIPTION
## Changed
- MVVM now defers MobX reactions to a microtask by default, so an observable that resolves mid-render no longer triggers React's "Cannot update a component while rendering a different component" error. The default is overridable through the `mobx` `reactionScheduler` option.

## Fixed
- Observable (SSE/WebSocket) queries with a `ConceptAs<T>` parameter no longer fail — query arguments are now coerced to their declared parameter types on the streaming path, matching one-shot queries.
- A command whose `Handle()` returns a boxed `IEnumerable<object>` of `EventForEventSourceId` wrappers, or a mixed collection of plain events and wrappers, now appends the events instead of silently reporting success with nothing appended.
