### PR TITLE
Validate command event returns in a single pass without materializing

### DIFF
--- a/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsForEventSourceIdCommandResponseValueHandler.cs
@@ -32,22 +32,38 @@ public class EventsForEventSourceIdCommandResponseValueHandler(IEventLog eventLo
             return false;
         }
 
-        var items = enumerable.Cast<object>().ToArray();
+        // Validate every element in a single pass, without materializing the collection: each element must be an
+        // EventForEventSourceId wrapper carrying a registered event, or a registered plain event. Short-circuit on
+        // the first invalid element.
+        var hasItems = false;
+        var hasWrapper = false;
+        foreach (var item in enumerable)
+        {
+            hasItems = true;
+            if (item is EventForEventSourceId wrapper)
+            {
+                hasWrapper = true;
+                if (!eventTypes.HasFor(wrapper.Event.GetType()))
+                {
+                    return false;
+                }
+            }
+            else if (item is null || !eventTypes.HasFor(item.GetType()))
+            {
+                return false;
+            }
+        }
 
-        // An empty collection statically typed as wrappers is still ours — it is recognized (and appends
-        // nothing) rather than being serialized as the response payload.
-        if (items.Length == 0)
+        // An empty collection statically typed as wrappers is still ours — it is recognized (and appends nothing)
+        // rather than being serialized as the response payload.
+        if (!hasItems)
         {
             return value is IEnumerable<EventForEventSourceId>;
         }
 
-        // A non-empty collection must contain at least one wrapper (distinguishing it from a pure plain-event
-        // collection handled by the sibling handler), and every element must be a wrapper carrying a registered
-        // event, or a registered plain event.
-        return items.Any(item => item is EventForEventSourceId) &&
-            items.All(item => item is EventForEventSourceId wrapper
-                ? eventTypes.HasFor(wrapper.Event.GetType())
-                : eventTypes.HasFor(item.GetType()));
+        // A non-empty collection must contain at least one wrapper, distinguishing it from a pure plain-event
+        // collection handled by the sibling handler.
+        return hasWrapper;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
# Summary

Internal efficiency cleanup — **no user-facing behavior change**, so no release-note entry.

`EventsForEventSourceIdCommandResponseValueHandler.CanHandle` previously materialized the returned event collection to an array and ran separate `Any`/`All` passes on every invocation, and the command pipeline calls `CanHandle` several times per command. It now validates every element in a single pass with early exit, allocating nothing. Behavior is identical; a `null` element now declines the handler rather than throwing.

Follow-up to #2352. Left open for human review.
