### PR TITLE
Harden command and query endpoints against hostile and malformed input

### DIFF
--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -49,6 +49,7 @@ public static class TestProject
         [
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Expressions.Expression).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_dereferences_a_null_concept.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_dereferences_a_null_concept.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_rule_dereferences_a_null_concept
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+    public record PlaceOrder(OrderId Id);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => {|#0:c.Id.Value|}).NotEqual(System.Guid.Empty);
+        }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0013")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Id"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_selects_the_concept_itself.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_selects_the_concept_itself.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_rule_selects_the_concept_itself
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+    public record PlaceOrder(OrderId Id);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => c.Id).NotNull();
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_dereferences_a_non_concept_member.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_dereferences_a_non_concept_member.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_selector_dereferences_a_non_concept_member
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+
+namespace TestNamespace
+{
+    public record PlaceOrder(string Name);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => c.Name.Length).GreaterThan(0);
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_is_the_concept_root_value.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_is_the_concept_root_value.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_selector_is_the_concept_root_value
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+
+    public class OrderIdValidator : AbstractValidator<OrderId>
+    {
+        public OrderIdValidator()
+        {
+            RuleFor(x => x.Value).NotEqual(System.Guid.Empty);
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ ARC0009|Arc|Warning|Concept should be declared as a record
 ARC0010|Arc|Warning|Command Handle() wraps a synchronous result in a Task
 ARC0011|Arc|Warning|[Roles] argument should use nameof instead of a string literal
 ARC0012|Arc|Warning|Arc artifact throws a built-in exception type
+ARC0013|Arc|Warning|Validator rule dereferences a possibly-null concept member

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -154,5 +154,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Domain failures raised from Arc artifacts — command Handle() methods, CommandValidator<T>/ConceptValidator<T> validators, and reactor handlers — should be expressed as domain-named exception types (or validator rejections). Built-in exceptions like InvalidOperationException, ArgumentException, or Exception carry no domain meaning to the caller or the log.");
 
+    /// <summary>
+    /// ARC0013: Validator rule dereferences a possibly-null concept member.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0013_ValidatorDereferencesNullConcept = new(
+        id: "ARC0013",
+        title: "Validator rule dereferences a possibly-null concept member",
+        messageFormat: "Concept '{0}' may be null at validation time; dereferencing its member in a validator rule throws instead of producing a validation error. Validate '{0}' first, or guard the rule with '.When(...)'.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A FluentValidation rule selector that dereferences a member of a ConceptAs<T> property assumes the concept is non-null. Because model-bound input can be deserialized with a null concept, the rule throws a NullReferenceException at validation time instead of producing a validation error. Validate the concept itself first (when it is required) or guard the rule with a null check (when it is optional), so invalid input is reported as a validation failure rather than crashing.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ValidatorConceptDereferenceAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ValidatorConceptDereferenceAnalyzer.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that flags a FluentValidation rule selector that dereferences a member of a possibly-null concept,
+/// which throws at validation time instead of producing a validation error.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ValidatorConceptDereferenceAnalyzer : DiagnosticAnalyzer
+{
+    const string ConceptAsTypeName = "ConceptAs";
+    const string ConceptsNamespace = "Cratis.Concepts";
+    const string AbstractValidatorTypeName = "AbstractValidator";
+    const string FluentValidationNamespace = "FluentValidation";
+    const string RuleForMethodName = "RuleFor";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARC0013_ValidatorDereferencesNullConcept];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Must be a FluentValidation RuleFor(...) call (RuleFor is declared on AbstractValidator<T>).
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method ||
+            method.Name != RuleForMethodName ||
+            !IsFluentValidator(method.ContainingType))
+        {
+            return;
+        }
+
+        // RuleFor takes a single property-selector lambda, e.g. RuleFor(c => c.Concept.Value).
+        if (invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        var body = invocation.ArgumentList.Arguments[0].Expression switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.Body as ExpressionSyntax,
+            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.Body as ExpressionSyntax,
+            _ => null
+        };
+        if (body is null)
+        {
+            return;
+        }
+
+        foreach (var memberAccess in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            // Only a nested member can be null here; the lambda's own parameter is the value being validated.
+            if (memberAccess.Expression is not MemberAccessExpressionSyntax conceptMember)
+            {
+                continue;
+            }
+
+            var conceptType = context.SemanticModel.GetTypeInfo(conceptMember, context.CancellationToken).Type;
+            if (conceptType is null || !InheritsFromConceptAs(conceptType))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARC0013_ValidatorDereferencesNullConcept,
+                memberAccess.GetLocation(),
+                conceptMember.Name.Identifier.Text));
+            return;
+        }
+    }
+
+    static bool IsFluentValidator(INamedTypeSymbol? typeSymbol)
+    {
+        var current = typeSymbol;
+        while (current is not null)
+        {
+            if (current.Name == AbstractValidatorTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == FluentValidationNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    static bool InheritsFromConceptAs(ITypeSymbol typeSymbol)
+    {
+        var current = typeSymbol.BaseType;
+        while (current is not null)
+        {
+            if (current.Name == ConceptAsTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == ConceptsNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_filter_resolving_validators_from_a_real_container.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_filter_resolving_validators_from_a_real_container.cs
@@ -5,6 +5,7 @@ using Cratis.Arc.Validation;
 using Cratis.Arc.Validation.for_DiscoverableValidators;
 using Cratis.Execution;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.given;
 
@@ -23,7 +24,7 @@ public class a_filter_resolving_validators_from_a_real_container : Specification
     void Establish()
     {
         _correlationId = CorrelationId.New();
-        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance));
+        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance), NullLogger<FluentValidationFilter>.Instance);
         _root = new ServiceCollection()
             .AddScoped(_ => new CommandDependency { IsAllowed = false })
             .AddTransient<CommandWithDependencyValidator>()

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_fluent_validation_filter.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/given/a_fluent_validation_filter.cs
@@ -4,6 +4,7 @@
 using Cratis.Arc.Validation;
 using Cratis.Execution;
 using FluentValidation.Results;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.given;
 
@@ -18,7 +19,7 @@ public class a_fluent_validation_filter : Specification
     {
         _correlationId = CorrelationId.New();
         _discoverableValidators = Substitute.For<IDiscoverableValidators>();
-        _filter = new FluentValidationFilter(_discoverableValidators);
+        _filter = new FluentValidationFilter(_discoverableValidators, NullLogger<FluentValidationFilter>.Instance);
         _context = new CommandContext(_correlationId, typeof(object), new object(), [], new());
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/without_a_registered_validator.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/without_a_registered_validator.cs
@@ -5,6 +5,7 @@ using Cratis.Arc.Validation;
 using Cratis.Arc.Validation.for_DiscoverableValidators;
 using Cratis.Execution;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_executing_command;
 
@@ -25,7 +26,7 @@ public class without_a_registered_validator : Specification
     void Establish()
     {
         _correlationId = CorrelationId.New();
-        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance));
+        _filter = new FluentValidationFilter(new DiscoverableValidators(Cratis.Types.Types.Instance), NullLogger<FluentValidationFilter>.Instance);
 
         // The scoped dependency is registered; the validator itself is intentionally NOT registered.
         _root = new ServiceCollection()

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/and_the_validator_is_cancelled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/and_the_validator_is_cancelled.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class and_the_validator_is_cancelled : given.a_fluent_validation_filter
+{
+    Exception _exception;
+
+    void Establish()
+    {
+        var command = new SomeCommand("value");
+        _context = new CommandContext(_correlationId, typeof(SomeCommand), command, [], new());
+
+        var validator = new CancellingValidator();
+        _discoverableValidators.TryGet(typeof(SomeCommand), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = validator;
+                return true;
+            });
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => await _filter.OnExecution(_context));
+
+    [Fact] void should_propagate_the_cancellation_instead_of_treating_it_as_invalid() => (_exception is OperationCanceledException).ShouldBeTrue();
+
+    record SomeCommand(string Value);
+
+    class CancellingValidator : AbstractValidator<SomeCommand>
+    {
+        public CancellingValidator() => RuleFor(c => c.Value).Must(_ => throw new OperationCanceledException());
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_a_validator_dereferencing_a_null_concept_member.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_a_validator_dereferencing_a_null_concept_member.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Http;
+using Cratis.Concepts;
+using FluentValidation;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_a_validator_dereferencing_a_null_concept_member : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+
+    void Establish()
+    {
+        var command = new CommandWithRequiredConcept(null!);
+        _context = new CommandContext(_correlationId, typeof(CommandWithRequiredConcept), command, [], new());
+
+        var validator = new CommandWithRequiredConceptValidator();
+        _discoverableValidators.TryGet(typeof(CommandWithRequiredConcept), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = validator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_succeed() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception_detail() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_surface_a_single_validation_error() => _result.ValidationResults.Count().ShouldEqual(1);
+    [Fact] void should_surface_the_generic_validation_message() => _result.ValidationResults.Single().Message.ShouldEqual("The command could not be validated.");
+    [Fact] void should_map_to_bad_request() => EndpointRouteHelper.GetStatusCode(_result.IsSuccess, _result.IsAuthorized, _result.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+
+    record RequiredConcept(string Value) : ConceptAs<string>(Value);
+    record CommandWithRequiredConcept(RequiredConcept Concept);
+
+    class CommandWithRequiredConceptValidator : AbstractValidator<CommandWithRequiredConcept>
+    {
+        public CommandWithRequiredConceptValidator() => RuleFor(c => c.Concept.Value).NotEmpty();
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/SomeCommand.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/SomeCommand.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper;
+
+public record SomeCommand(int Amount, string Name);

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/given/a_command_endpoint_mapper.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/given/a_command_endpoint_mapper.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper.given;
+
+public class a_command_endpoint_mapper : Specification
+{
+    protected IHttpRequestContext _context;
+    protected ILogger _logger;
+    protected CorrelationId _correlationId;
+    protected Type _commandType;
+
+    void Establish()
+    {
+        _context = Substitute.For<IHttpRequestContext>();
+        _logger = Substitute.For<ILogger>();
+        _correlationId = CorrelationId.New();
+        _commandType = typeof(SomeCommand);
+    }
+
+    protected static JsonException CaptureJsonException(string json)
+    {
+        try
+        {
+            JsonSerializer.Deserialize<SomeCommand>(json);
+        }
+        catch (JsonException ex)
+        {
+            return ex;
+        }
+
+        throw new InvalidOperationException("Expected the JSON to fail to deserialize, but it succeeded.");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_a_field_has_the_wrong_type.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_a_field_has_the_wrong_type.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper.when_reading_the_command_body;
+
+public class and_a_field_has_the_wrong_type : given.a_command_endpoint_mapper
+{
+    JsonException _parserException;
+    CommandResult? _failure;
+    object? _command;
+
+    void Establish()
+    {
+        // A string where a number is expected — System.Text.Json throws and its message names the field path and target type.
+        _parserException = CaptureJsonException("{ \"Amount\": \"not-a-number\", \"Name\": \"x\" }");
+        _context.ReadBodyAsJson(_commandType, Arg.Any<CancellationToken>()).Returns<Task<object?>>(_ => throw _parserException);
+    }
+
+    async Task Because() => (_command, _failure) = await CommandEndpointMapper.ReadCommandBody(_context, _commandType, _correlationId, _logger);
+
+    [Fact] void should_not_produce_a_command() => _command.ShouldBeNull();
+    [Fact] void should_be_a_validation_failure() => _failure!.IsValid.ShouldBeFalse();
+    [Fact] void should_stay_authorized() => _failure!.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_not_carry_an_exception() => _failure!.HasExceptions.ShouldBeFalse();
+    [Fact] void should_map_to_bad_request() => EndpointRouteHelper.GetStatusCode(_failure!.IsSuccess, _failure.IsAuthorized, _failure.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+    [Fact] void should_not_leak_the_target_type_or_field_path() => _failure!.ValidationResults.Any(validationResult => validationResult.Message.Contains(_parserException.Message)).ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_malformed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_malformed.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper.when_reading_the_command_body;
+
+public class and_the_body_is_malformed : given.a_command_endpoint_mapper
+{
+    JsonException _parserException;
+    CommandResult? _failure;
+    object? _command;
+
+    void Establish()
+    {
+        _parserException = CaptureJsonException("{ this is not valid json ");
+        _context.ReadBodyAsJson(_commandType, Arg.Any<CancellationToken>()).Returns<Task<object?>>(_ => throw _parserException);
+    }
+
+    async Task Because() => (_command, _failure) = await CommandEndpointMapper.ReadCommandBody(_context, _commandType, _correlationId, _logger);
+
+    [Fact] void should_not_produce_a_command() => _command.ShouldBeNull();
+    [Fact] void should_produce_a_failure_result() => _failure.ShouldNotBeNull();
+    [Fact] void should_be_a_validation_failure() => _failure!.IsValid.ShouldBeFalse();
+    [Fact] void should_stay_authorized() => _failure!.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_not_carry_an_exception() => _failure!.HasExceptions.ShouldBeFalse();
+    [Fact] void should_map_to_bad_request() => EndpointRouteHelper.GetStatusCode(_failure!.IsSuccess, _failure.IsAuthorized, _failure.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+    [Fact] void should_not_leak_the_parser_message() => _failure!.ValidationResults.Any(validationResult => validationResult.Message.Contains(_parserException.Message)).ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_null.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_null.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper.when_reading_the_command_body;
+
+public class and_the_body_is_null : given.a_command_endpoint_mapper
+{
+    CommandResult? _failure;
+    object? _command;
+
+    void Establish() => _context.ReadBodyAsJson(_commandType, Arg.Any<CancellationToken>()).Returns(Task.FromResult<object?>(null));
+
+    async Task Because() => (_command, _failure) = await CommandEndpointMapper.ReadCommandBody(_context, _commandType, _correlationId, _logger);
+
+    [Fact] void should_not_produce_a_command() => _command.ShouldBeNull();
+    [Fact] void should_be_a_validation_failure() => _failure!.IsValid.ShouldBeFalse();
+    [Fact] void should_stay_authorized() => _failure!.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_map_to_bad_request() => EndpointRouteHelper.GetStatusCode(_failure!.IsSuccess, _failure.IsAuthorized, _failure.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_valid.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandEndpointMapper/when_reading_the_command_body/and_the_body_is_valid.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandEndpointMapper.when_reading_the_command_body;
+
+public class and_the_body_is_valid : given.a_command_endpoint_mapper
+{
+    SomeCommand _deserializedCommand;
+    CommandResult? _failure;
+    object? _command;
+
+    void Establish()
+    {
+        _deserializedCommand = new SomeCommand(42, "ok");
+        _context.ReadBodyAsJson(_commandType, Arg.Any<CancellationToken>()).Returns(Task.FromResult<object?>(_deserializedCommand));
+    }
+
+    async Task Because() => (_command, _failure) = await CommandEndpointMapper.ReadCommandBody(_context, _commandType, _correlationId, _logger);
+
+    [Fact] void should_return_the_deserialized_command() => _command.ShouldEqual(_deserializedCommand);
+    [Fact] void should_not_produce_a_failure() => _failure.ShouldBeNull();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_denies_before_a_throwing_filter.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_denies_before_a_throwing_filter.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+public class and_a_filter_denies_before_a_throwing_filter : Specification
+{
+    CommandFilters _commandFilters;
+    ICommandFilter _authorizationFilter;
+    ICommandFilter _validationFilter;
+    CommandContext _context;
+    CommandResult _result;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _authorizationFilter = Substitute.For<ICommandFilter>();
+        _validationFilter = Substitute.For<ICommandFilter>();
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
+
+        _authorizationFilter.OnExecution(_context).Returns(Task.FromResult(CommandResult.Unauthorized(_context.CorrelationId, "forbidden")));
+
+        // A later filter (e.g. a validator dereferencing a null concept) would throw if it ran — the chain
+        // must short-circuit on the authorization denial before reaching it, so the throw never happens.
+        _validationFilter.OnExecution(_context).Returns<Task<CommandResult>>(_ => throw new InvalidOperationException("validator dereferenced a null concept"));
+
+        var filters = new List<ICommandFilter> { _authorizationFilter, _validationFilter };
+        var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        commandFiltersActivitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new CommandFilters(new KnownInstancesOf<ICommandFilter>(filters), commandFiltersActivitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => _result = await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_call_the_authorization_filter() => _authorizationFilter.Received(1).OnExecution(_context);
+    [Fact] void should_not_call_the_throwing_filter() => _validationFilter.DidNotReceive().OnExecution(_context);
+    [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_map_to_forbidden_and_not_internal_server_error() => EndpointRouteHelper.GetStatusCode(_result.IsSuccess, _result.IsAuthorized, _result.IsValid).ShouldEqual(HttpStatusCode.Forbidden);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_throws.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+public class and_a_filter_throws : Specification
+{
+    const string ThrownMessage = "the filter blew up";
+
+    CommandFilters _commandFilters;
+    ICommandFilter _firstFilter;
+    ICommandFilter _throwingFilter;
+    ICommandFilter _laterFilter;
+    CommandContext _context;
+    CommandResult _result;
+    CommandResult _firstFilterResult;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _firstFilter = Substitute.For<ICommandFilter>();
+        _throwingFilter = Substitute.For<ICommandFilter>();
+        _laterFilter = Substitute.For<ICommandFilter>();
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
+
+        _firstFilterResult = CommandResult.Success(_context.CorrelationId);
+        _firstFilter.OnExecution(_context).Returns(Task.FromResult(_firstFilterResult));
+        _throwingFilter.OnExecution(_context).Returns<Task<CommandResult>>(_ => throw new InvalidOperationException(ThrownMessage));
+
+        var filters = new List<ICommandFilter> { _firstFilter, _throwingFilter, _laterFilter };
+        var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        commandFiltersActivitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new CommandFilters(new KnownInstancesOf<ICommandFilter>(filters), commandFiltersActivitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => _result = await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_call_the_first_filter() => _firstFilter.Received(1).OnExecution(_context);
+    [Fact] void should_call_the_throwing_filter() => _throwingFilter.Received(1).OnExecution(_context);
+    [Fact] void should_short_circuit_and_not_call_the_later_filter() => _laterFilter.DidNotReceive().OnExecution(_context);
+    [Fact] void should_carry_the_thrown_error() => _result.ExceptionMessages.ShouldContain(ThrownMessage);
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_preserve_the_prior_authorized_verdict() => _result.IsAuthorized.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_throws_a_validation_failure.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_filter_throws_a_validation_failure.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Http;
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+public class and_a_filter_throws_a_validation_failure : Specification
+{
+    CommandFilters _commandFilters;
+    ICommandFilter _filter;
+    CommandContext _context;
+    CommandResult _result;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _filter = Substitute.For<ICommandFilter>();
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
+
+        // A validator whose read-model dependency cannot be resolved (no event source id) throws an IValidationFailure
+        // during construction — which surfaces here as a throwing filter. It must become a 400, not a 500.
+        _filter.OnExecution(_context).Returns<Task<CommandResult>>(_ => throw new TheValidationFailure());
+
+        var filters = new List<ICommandFilter> { _filter };
+        var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        commandFiltersActivitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new CommandFilters(new KnownInstancesOf<ICommandFilter>(filters), commandFiltersActivitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => _result = await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception_detail() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_surface_the_validation_message() => _result.ValidationResults.ShouldContain(vr => vr.Message == "missing identifier");
+    [Fact] void should_map_to_bad_request_not_internal_server_error() => EndpointRouteHelper.GetStatusCode(_result.IsSuccess, _result.IsAuthorized, _result.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+
+    class TheValidationFailure : Exception, IValidationFailure
+    {
+        public ValidationResult ValidationResult { get; } = ValidationResult.Error("missing identifier");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_all_filters_succeed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_all_filters_succeed.cs
@@ -1,21 +1,18 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.Validation;
 using Cratis.Execution;
 using Cratis.Traces;
 
 namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
 
-public class and_both_filter_errors : Specification
+public class and_all_filters_succeed : Specification
 {
     CommandFilters _commandFilters;
     ICommandFilter _filter1;
     ICommandFilter _filter2;
     CommandContext _context;
     CommandResult _result;
-    CommandResult _firstFilterResult;
-    CommandResult _secondFilterResult;
     System.Diagnostics.ActivitySource _activitySource;
 
     void Establish()
@@ -24,17 +21,9 @@ public class and_both_filter_errors : Specification
         _filter2 = Substitute.For<ICommandFilter>();
         _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
 
-        _firstFilterResult = new()
-        {
-            IsAuthorized = false
-        };
+        _filter1.OnExecution(_context).Returns(Task.FromResult<CommandResult>(null!));
+        _filter2.OnExecution(_context).Returns(Task.FromResult(CommandResult.Success(_context.CorrelationId)));
 
-        _secondFilterResult = new()
-        {
-            ValidationResults = [new ValidationResult(ValidationResultSeverity.Error, "error", [], null!)]
-        };
-        _filter1.OnExecution(_context).Returns(Task.FromResult(_firstFilterResult));
-        _filter2.OnExecution(_context).Returns(Task.FromResult(_secondFilterResult));
         var filters = new List<ICommandFilter> { _filter1, _filter2 };
         var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
         _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
@@ -46,13 +35,10 @@ public class and_both_filter_errors : Specification
 
     async Task Because() => _result = await _commandFilters.OnExecution(_context);
 
-    [Fact] void should_call_first_filter() => _filter1.Received(1).OnExecution(_context);
-    [Fact] void should_call_second_filter() => _filter2.Received(1).OnExecution(_context);
-    [Fact]
-    void should_return_result_combining_both_filter_results()
-    {
-        _result.IsAuthorized.ShouldBeFalse();
-        _result.IsValid.ShouldBeFalse();
-        _result.ValidationResults.ShouldContain(_secondFilterResult.ValidationResults.First());
-    }
+    [Fact] void should_call_the_first_filter() => _filter1.Received(1).OnExecution(_context);
+    [Fact] void should_call_the_second_filter() => _filter2.Received(1).OnExecution(_context);
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_a_dependency_factory_throws_a_validation_failure.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandHandlerArgumentResolver/when_resolving/and_a_dependency_factory_throws_a_validation_failure.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Commands.for_CommandHandlerArgumentResolver.when_resolving;
+
+public class and_a_dependency_factory_throws_a_validation_failure : given.a_command_handler_argument_resolver
+{
+    class Dependency;
+
+    class Handler
+    {
+        public void Handle(Dependency dependency) { }
+    }
+
+    Exception _exception;
+    ServiceProvider _provider;
+
+    void Establish()
+    {
+        HandleHasParameters<Handler>();
+        ProvideReturns();
+
+        // A read model factory that throws because the command carried no usable event source id is the real shape of
+        // this: a registered service whose factory throws an IValidationFailure. Prove it propagates unwrapped through
+        // GetService and the resolver, so the pipeline can convert it into a 400 rather than a 500.
+        _provider = new ServiceCollection()
+            .AddScoped<Dependency>(_ => throw new TheValidationFailure())
+            .BuildServiceProvider();
+        _serviceProvider = _provider;
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => await Resolve());
+
+    void Destroy() => _provider.Dispose();
+
+    [Fact] void should_propagate_the_validation_failure_unwrapped() => (_exception is IValidationFailure).ShouldBeTrue();
+
+    class TheValidationFailure : Exception, IValidationFailure
+    {
+        public ValidationResult ValidationResult { get; } = ValidationResult.Error("missing identifier");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_argument_resolution_throws_a_validation_failure.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_argument_resolution_throws_a_validation_failure.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+public class and_argument_resolution_throws_a_validation_failure : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult _result;
+
+    void Establish() =>
+        _commandHandlerArgumentResolver
+            .Resolve(Arg.Any<ICommandHandler>(), Arg.Any<CommandContext>(), Arg.Any<IServiceProvider>(), Arg.Any<ValidationResultSeverity?>())
+            .Returns<ValueTask<CommandHandlerArgumentResolution>>(_ => throw new TheValidationFailure());
+
+    async Task Because() => _result = await _commandPipeline.Execute(_command);
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception_detail() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_surface_the_validation_message() => _result.ValidationResults.ShouldContain(vr => vr.Message == "missing identifier");
+    [Fact] void should_not_invoke_the_handler() => _commandHandler.DidNotReceive().Handle(Arg.Any<CommandContext>());
+
+    class TheValidationFailure : Exception, IValidationFailure
+    {
+        public ValidationResult ValidationResult { get; } = ValidationResult.Error("missing identifier");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_creating_from_an_exception/and_the_exception_is_a_plain_error.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_creating_from_an_exception/and_the_exception_is_a_plain_error.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResult.when_creating_from_an_exception;
+
+public class and_the_exception_is_a_plain_error : Specification
+{
+    CorrelationId _correlationId;
+    CommandResult _result;
+
+    void Establish() => _correlationId = CorrelationId.New();
+
+    void Because() => _result = CommandResult.FromException(_correlationId, new InvalidOperationException("boom"));
+
+    [Fact] void should_carry_the_exception() => _result.HasExceptions.ShouldBeTrue();
+    [Fact] void should_remain_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] void should_keep_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_creating_from_an_exception/and_the_exception_is_a_validation_failure.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_creating_from_an_exception/and_the_exception_is_a_validation_failure.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResult.when_creating_from_an_exception;
+
+public class and_the_exception_is_a_validation_failure : Specification
+{
+    CorrelationId _correlationId;
+    CommandResult _result;
+
+    void Establish() => _correlationId = CorrelationId.New();
+
+    void Because() => _result = CommandResult.FromException(_correlationId, new TheValidationFailure());
+
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception_detail() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_surface_the_validation_message() => _result.ValidationResults.Single().Message.ShouldEqual("invalid input");
+    [Fact] void should_keep_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+
+    class TheValidationFailure : Exception, IValidationFailure
+    {
+        public ValidationResult ValidationResult { get; } = ValidationResult.Error("invalid input");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryEndpointMapper/given/a_query_request.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryEndpointMapper/given/a_query_request.cs
@@ -38,6 +38,7 @@ public class a_query_request : a_query_endpoint_mapper
         correlationIdAccessor.Current.Returns(CorrelationId.New());
 
         var requestServices = new ServiceCollection()
+            .AddLogging()
             .AddSingleton(_queryPipeline)
             .AddSingleton(_observableQueryHandler)
             .AddSingleton(correlationIdAccessor)

--- a/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/RecordingLogger.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/RecordingLogger.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.for_ExceptionDetailRedactor;
+
+/// <summary>
+/// An <see cref="ILogger"/> that records the formatted messages logged to it, so specs can assert that
+/// redacted exception detail is still logged server-side.
+/// </summary>
+public class RecordingLogger : ILogger
+{
+    public List<string> Messages { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+        Messages.Add(formatter(state, exception));
+
+    sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_with_exposure_disabled.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_with_exposure_disabled.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Execution;
+
+namespace Cratis.Arc.for_ExceptionDetailRedactor.when_redacting;
+
+public class a_command_result_with_exposure_disabled : Specification
+{
+    const string SecretMessage = "Object reference not set to an instance of an object at SecretType.SecretMethod";
+    const string SecretStackTrace = "   at Core.Secret.Handler.Handle() in /src/Secret.cs:line 42";
+
+    CorrelationId _correlationId;
+    RecordingLogger _logger;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _logger = new RecordingLogger();
+        _result = new CommandResult
+        {
+            CorrelationId = _correlationId,
+            ExceptionMessages = [SecretMessage],
+            ExceptionStackTrace = SecretStackTrace
+        };
+    }
+
+    void Because() => ExceptionDetailRedactor.Redact(_result, exposeExceptionDetails: false, _logger);
+
+    [Fact] void should_still_report_having_exceptions() => _result.HasExceptions.ShouldBeTrue();
+    [Fact] void should_retain_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_replace_the_messages_with_a_generic_marker() => _result.ExceptionMessages.ShouldContainOnly(ExceptionDetailRedactor.RedactedMessage);
+    [Fact] void should_not_leak_the_original_message() => _result.ExceptionMessages.ShouldNotContain(SecretMessage);
+    [Fact] void should_clear_the_stack_trace() => _result.ExceptionStackTrace.ShouldBeEmpty();
+    [Fact] void should_log_the_full_message_server_side() => _logger.Messages.Exists(message => message.Contains(SecretMessage)).ShouldBeTrue();
+    [Fact] void should_log_the_full_stack_trace_server_side() => _logger.Messages.Exists(message => message.Contains(SecretStackTrace)).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_with_exposure_enabled.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_with_exposure_enabled.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Execution;
+
+namespace Cratis.Arc.for_ExceptionDetailRedactor.when_redacting;
+
+public class a_command_result_with_exposure_enabled : Specification
+{
+    const string OriginalMessage = "Something went wrong in a specific way";
+    const string OriginalStackTrace = "   at Core.Some.Handler.Handle()";
+
+    RecordingLogger _logger;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _logger = new RecordingLogger();
+        _result = new CommandResult
+        {
+            CorrelationId = CorrelationId.New(),
+            ExceptionMessages = [OriginalMessage],
+            ExceptionStackTrace = OriginalStackTrace
+        };
+    }
+
+    void Because() => ExceptionDetailRedactor.Redact(_result, exposeExceptionDetails: true, _logger);
+
+    [Fact] void should_keep_the_original_message() => _result.ExceptionMessages.ShouldContainOnly(OriginalMessage);
+    [Fact] void should_keep_the_original_stack_trace() => _result.ExceptionStackTrace.ShouldEqual(OriginalStackTrace);
+    [Fact] void should_not_log_anything() => _logger.Messages.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_without_exceptions.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_command_result_without_exceptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+
+namespace Cratis.Arc.for_ExceptionDetailRedactor.when_redacting;
+
+public class a_command_result_without_exceptions : Specification
+{
+    RecordingLogger _logger;
+    CommandResult _result;
+    ValidationResult _validationResult;
+
+    void Establish()
+    {
+        _logger = new RecordingLogger();
+        _validationResult = ValidationResult.Error("Name is required", ["Name"]);
+        _result = new CommandResult
+        {
+            CorrelationId = CorrelationId.New(),
+            ValidationResults = [_validationResult]
+        };
+    }
+
+    void Because() => ExceptionDetailRedactor.Redact(_result, exposeExceptionDetails: false, _logger);
+
+    [Fact] void should_leave_the_validation_results_untouched() => _result.ValidationResults.ShouldContainOnly(_validationResult);
+    [Fact] void should_not_introduce_any_exception_messages() => _result.ExceptionMessages.ShouldBeEmpty();
+    [Fact] void should_not_log_anything() => _logger.Messages.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_query_result_with_exposure_disabled.cs
+++ b/Source/DotNET/Arc.Core.Specs/for_ExceptionDetailRedactor/when_redacting/a_query_result_with_exposure_disabled.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+
+namespace Cratis.Arc.for_ExceptionDetailRedactor.when_redacting;
+
+public class a_query_result_with_exposure_disabled : Specification
+{
+    const string SecretMessage = "Sorting field could not be found on Core.Secret.ReadModel";
+    const string SecretStackTrace = "   at Cratis.Arc.MongoDB.QueryContextAwareSet.Initialize()";
+
+    CorrelationId _correlationId;
+    RecordingLogger _logger;
+    QueryResult _result;
+
+    void Establish()
+    {
+        _correlationId = CorrelationId.New();
+        _logger = new RecordingLogger();
+        _result = new QueryResult
+        {
+            CorrelationId = _correlationId,
+            ExceptionMessages = [SecretMessage],
+            ExceptionStackTrace = SecretStackTrace
+        };
+    }
+
+    void Because() => ExceptionDetailRedactor.Redact(_result, exposeExceptionDetails: false, _logger);
+
+    [Fact] void should_still_report_having_exceptions() => _result.HasExceptions.ShouldBeTrue();
+    [Fact] void should_retain_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_replace_the_messages_with_a_generic_marker() => _result.ExceptionMessages.ShouldContainOnly(ExceptionDetailRedactor.RedactedMessage);
+    [Fact] void should_not_leak_the_read_model_type_name() => _result.ExceptionMessages.ShouldNotContain(SecretMessage);
+    [Fact] void should_clear_the_stack_trace() => _result.ExceptionStackTrace.ShouldBeEmpty();
+    [Fact] void should_log_the_full_detail_server_side() => _logger.Messages.Exists(message => message.Contains(SecretMessage)).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core/Arc.Core.csproj
+++ b/Source/DotNET/Arc.Core/Arc.Core.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Cratis.Arc" />
+        <InternalsVisibleTo Include="Cratis.Arc.Core.Specs" />
         <InternalsVisibleTo Include="Cratis.Arc.MongoDB" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore" />
         <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore.Specs" />

--- a/Source/DotNET/Arc.Core/ArcOptions.cs
+++ b/Source/DotNET/Arc.Core/ArcOptions.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Cratis.Arc.Execution;
 using Cratis.Arc.Queries;
 using Cratis.Arc.Tenancy;
+using Cratis.Execution;
 
 namespace Cratis.Arc;
 
@@ -55,4 +56,15 @@ public class ArcOptions
     /// Gets or sets the hosting options for Arc, only used by Arc.Core.
     /// </summary>
     public HostingOptions Hosting { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether exception detail (messages and stack traces) is exposed
+    /// to clients in serialized <see cref="Commands.CommandResult"/> and <see cref="Queries.QueryResult"/> responses.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see langword="true"/> only in the Development environment and <see langword="false"/> otherwise.
+    /// When <see langword="false"/>, exception messages and stack traces are redacted from responses (the full detail
+    /// is still logged server-side and the correlation identifier is retained) to avoid leaking internal information.
+    /// </remarks>
+    public bool ExposeExceptionDetails { get; set; } = RuntimeEnvironment.IsDevelopment;
 }

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
@@ -5,6 +5,7 @@ using Cratis.Arc.Http;
 using Cratis.Arc.Validation;
 using Cratis.Execution;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Cratis.Arc.Commands;
@@ -90,6 +91,7 @@ public static class CommandEndpointMapper
                 var correlationIdAccessor = context.RequestServices.GetRequiredService<ICorrelationIdAccessor>();
                 var commandPipeline = context.RequestServices.GetRequiredService<ICommandPipeline>();
                 var arcOptions = context.RequestServices.GetRequiredService<IOptions<ArcOptions>>().Value;
+                var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(CommandEndpointMapper).FullName!);
 
                 context.HandleCorrelationId(correlationIdAccessor, arcOptions.CorrelationId);
 
@@ -118,8 +120,10 @@ public static class CommandEndpointMapper
                 }
                 catch (Exception ex)
                 {
-                    commandResult = CommandResult.Error(correlationIdAccessor.Current, $"Failed to read request body: {ex.Message}");
+                    commandResult = CommandResult.Error(correlationIdAccessor.Current, ex);
                 }
+
+                ExceptionDetailRedactor.Redact(commandResult, arcOptions.ExposeExceptionDetails, logger);
 
                 var statusCode = EndpointRouteHelper.GetStatusCode(commandResult.IsSuccess, commandResult.IsAuthorized, commandResult.IsValid);
                 context.SetStatusCode(statusCode);

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Cratis.Arc.Http;
 using Cratis.Arc.Validation;
 using Cratis.Execution;
@@ -61,6 +62,42 @@ public static class CommandEndpointMapper
         }
     }
 
+    /// <summary>
+    /// Reads and deserializes the request body into a command instance, mapping a deserialization failure
+    /// (malformed or wrong-typed body) to a validation failure (HTTP 400) instead of a server error (HTTP 500).
+    /// </summary>
+    /// <param name="context">The <see cref="IHttpRequestContext"/> to read the body from.</param>
+    /// <param name="commandType">The type of command to deserialize.</param>
+    /// <param name="correlationId">The <see cref="CorrelationId"/> associated with the request.</param>
+    /// <param name="logger">The <see cref="ILogger"/> used to log the underlying parser detail server-side.</param>
+    /// <returns>
+    /// A tuple with the deserialized command (when successful) or a <see cref="CommandResult"/> describing the
+    /// failure (when the body could not be read). Exactly one of the two is non-null.
+    /// </returns>
+    internal static async Task<(object? Command, CommandResult? Failure)> ReadCommandBody(
+        IHttpRequestContext context,
+        Type commandType,
+        CorrelationId correlationId,
+        ILogger logger)
+    {
+        try
+        {
+            var command = await context.ReadBodyAsJson(commandType, context.RequestAborted);
+            if (command is null)
+            {
+                logger.FailedToReadCommandBody(commandType.FullName ?? commandType.Name, null);
+                return (null, CommandResult.InvalidBody(correlationId));
+            }
+
+            return (command, null);
+        }
+        catch (JsonException ex)
+        {
+            logger.FailedToReadCommandBody(commandType.FullName ?? commandType.Name, ex);
+            return (null, CommandResult.InvalidBody(correlationId));
+        }
+    }
+
     static void MapCommandEndpoint(
         IEndpointMapper mapper,
         string url,
@@ -105,18 +142,10 @@ public static class CommandEndpointMapper
                 CommandResult commandResult;
                 try
                 {
-                    var command = await context.ReadBodyAsJson(commandType, context.RequestAborted);
-
-                    if (command is null)
-                    {
-                        commandResult = CommandResult.Error(correlationIdAccessor.Current, $"Could not deserialize command of type '{commandType}' from request body.");
-                    }
-                    else
-                    {
-                        commandResult = validateOnly
-                            ? await commandPipeline.Validate(command, context.RequestServices, allowedSeverity, context.RequestAborted)
-                            : await commandPipeline.Execute(command, context.RequestServices, allowedSeverity, context.RequestAborted);
-                    }
+                    var (command, bodyFailure) = await ReadCommandBody(context, commandType, correlationIdAccessor.Current, logger);
+                    commandResult = bodyFailure ?? (validateOnly
+                        ? await commandPipeline.Validate(command!, context.RequestServices, allowedSeverity, context.RequestAborted)
+                        : await commandPipeline.Execute(command!, context.RequestServices, allowedSeverity, context.RequestAborted));
                 }
                 catch (Exception ex)
                 {

--- a/Source/DotNET/Arc.Core/Commands/CommandEndpointMapperLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandEndpointMapperLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Log messages for <see cref="CommandEndpointMapper"/>.
+/// </summary>
+internal static partial class CommandEndpointMapperLogMessages
+{
+    [LoggerMessage(LogLevel.Debug, "The request body for command '{CommandType}' could not be read or deserialized")]
+    internal static partial void FailedToReadCommandBody(this ILogger logger, string commandType, Exception? exception);
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
@@ -35,8 +35,10 @@ public class CommandFilters(IInstancesOf<ICommandFilter> filters, IActivitySourc
             {
                 // A throwing filter must not abort the chain and discard the verdicts of the filters that already
                 // ran (e.g. a clean Unauthorized from an authorization filter). Merge the failure into the running
-                // result so prior verdicts are preserved; the short-circuit below then stops the chain.
-                result.MergeWith(CommandResult.Error(context.CorrelationId, ex));
+                // result so prior verdicts are preserved; the short-circuit below then stops the chain. FromException
+                // maps an IValidationFailure (invalid client input) to a validation failure (400) and anything else
+                // to an error (500).
+                result.MergeWith(CommandResult.FromException(context.CorrelationId, ex));
             }
 
             // Stop once a filter has produced a non-success (blocking) verdict — an authorization denial or a

--- a/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
@@ -23,10 +23,27 @@ public class CommandFilters(IInstancesOf<ICommandFilter> filters, IActivitySourc
 
         foreach (var filter in filters)
         {
-            var filterResult = await filter.OnExecution(context);
-            if (filterResult is not null)
+            try
             {
-                result.MergeWith(filterResult);
+                var filterResult = await filter.OnExecution(context);
+                if (filterResult is not null)
+                {
+                    result.MergeWith(filterResult);
+                }
+            }
+            catch (Exception ex)
+            {
+                // A throwing filter must not abort the chain and discard the verdicts of the filters that already
+                // ran (e.g. a clean Unauthorized from an authorization filter). Merge the failure into the running
+                // result so prior verdicts are preserved; the short-circuit below then stops the chain.
+                result.MergeWith(CommandResult.Error(context.CorrelationId, ex));
+            }
+
+            // Stop once a filter has produced a non-success (blocking) verdict — an authorization denial or a
+            // validation failure must not be overwritten (or a later filter allowed to throw) by continuing the chain.
+            if (!result.IsSuccess)
+            {
+                return result;
             }
         }
 

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -132,7 +132,7 @@ public class CommandPipeline(
         }
         catch (Exception ex)
         {
-            result.MergeWith(CommandResult.Error(correlationId, ex));
+            result.MergeWith(CommandResult.FromException(correlationId, ex));
         }
 
         return result;
@@ -202,7 +202,7 @@ public class CommandPipeline(
         }
         catch (Exception ex)
         {
-            result.MergeWith(CommandResult.Error(correlationId, ex));
+            result.MergeWith(CommandResult.FromException(correlationId, ex));
         }
 
         return result;

--- a/Source/DotNET/Arc.Core/Commands/CommandResult.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandResult.cs
@@ -113,6 +113,22 @@ public class CommandResult
     public static CommandResult Error(CorrelationId correlationId, Exception exception) => new() { CorrelationId = correlationId, ExceptionMessages = [exception.Message], ExceptionStackTrace = exception.StackTrace ?? string.Empty };
 
     /// <summary>
+    /// Creates a new <see cref="CommandResult"/> from an exception.
+    /// </summary>
+    /// <param name="correlationId">The <see cref="CorrelationId"/> associated with the command.</param>
+    /// <param name="exception">The exception to convert.</param>
+    /// <returns>A <see cref="CommandResult"/>.</returns>
+    /// <remarks>
+    /// An exception implementing <see cref="IValidationFailure"/> represents invalid client input and becomes a
+    /// validation failure (mapping to HTTP 400); any other exception becomes an error result (HTTP 500). This lets
+    /// code running inside the pipeline reject a command as invalid without knowing how the result is serialized.
+    /// </remarks>
+    public static CommandResult FromException(CorrelationId correlationId, Exception exception) =>
+        exception is IValidationFailure validationFailure
+            ? new() { CorrelationId = correlationId, ValidationResults = [validationFailure.ValidationResult] }
+            : Error(correlationId, exception);
+
+    /// <summary>
     /// Merges the results of one or more <see cref="CommandResult"/> instances into this.
     /// </summary>
     /// <param name="commandResults">Params of <see cref="CommandResult"/> to merge with.</param>

--- a/Source/DotNET/Arc.Core/Commands/CommandResult.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandResult.cs
@@ -90,6 +90,21 @@ public class CommandResult
     public static CommandResult Error(CorrelationId correlationId, string message) => new() { CorrelationId = correlationId, ExceptionMessages = [message] };
 
     /// <summary>
+    /// Creates a new <see cref="CommandResult"/> representing a request body that could not be read or deserialized.
+    /// </summary>
+    /// <param name="correlationId">The <see cref="CorrelationId"/> associated with the command.</param>
+    /// <returns>A <see cref="CommandResult"/> that is a validation failure (mapping to HTTP 400), carrying no internal detail.</returns>
+    /// <remarks>
+    /// A malformed or wrong-typed request body is a client error, not a server fault. This surfaces it as a
+    /// validation failure (so the endpoint returns 400) without echoing the underlying parser message.
+    /// </remarks>
+    public static CommandResult InvalidBody(CorrelationId correlationId) => new()
+    {
+        CorrelationId = correlationId,
+        ValidationResults = [ValidationResult.Error("The request body could not be read or is not valid for this command.")]
+    };
+
+    /// <summary>
     /// Creates a new <see cref="CommandResult"/> representing an error.
     /// </summary>
     /// <param name="correlationId">The <see cref="CorrelationId"/> associated with the command.</param>

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Cratis.Arc.Validation;
 using FluentValidation;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Commands.Filters;
 
@@ -12,7 +13,8 @@ namespace Cratis.Arc.Commands.Filters;
 /// Represents a command filter that validates commands before they are handled.
 /// </summary>
 /// <param name="discoverableValidators">The <see cref="IDiscoverableValidators"/> to use for finding validators.</param>
-public class FluentValidationFilter(IDiscoverableValidators discoverableValidators) : ICommandFilter
+/// <param name="logger">The <see cref="ILogger{TCategoryName}"/> used to log a validator that throws while validating.</param>
+public class FluentValidationFilter(IDiscoverableValidators discoverableValidators, ILogger<FluentValidationFilter> logger) : ICommandFilter
 {
     /// <inheritdoc/>
     public async Task<CommandResult> OnExecution(CommandContext context)
@@ -41,26 +43,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
 
         if (TryGetValidator(context, instanceType, out var validator))
         {
-            var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
-            var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
-            var validationResult = await validator.ValidateAsync(validationContext, context.CancellationToken);
-            if (!validationResult.IsValid)
-            {
-                commandResult.MergeWith(new CommandResult
-                {
-                    ValidationResults = validationResult.Errors.Select(_ =>
-                    {
-                        var severity = _.Severity switch
-                        {
-                            FluentValidation.Severity.Info => ValidationResultSeverity.Information,
-                            FluentValidation.Severity.Warning => ValidationResultSeverity.Warning,
-                            FluentValidation.Severity.Error => ValidationResultSeverity.Error,
-                            _ => ValidationResultSeverity.Error
-                        };
-                        return new ValidationResult(severity, _.ErrorMessage, [_.PropertyName], _.CustomState ?? null!);
-                    }).ToArray()
-                });
-            }
+            commandResult.MergeWith(await RunValidator(context, instance, validator));
         }
 
         if (!instanceType.IsPrimitive &&
@@ -97,6 +80,58 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                     }
                 }
             }
+        }
+
+        return commandResult;
+    }
+
+    /// <summary>
+    /// Runs a resolved validator against an instance, converting a validator that throws while validating
+    /// (for example a rule that dereferences a null concept member such as <c>RuleFor(c =&gt; c.X.Value)</c> on a
+    /// null <c>X</c>) into a validation failure (HTTP 400) instead of letting it propagate as a server error (HTTP 500).
+    /// </summary>
+    /// <param name="context">The <see cref="CommandContext"/> the validation runs within.</param>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validator">The <see cref="IValidator"/> to run.</param>
+    /// <returns>A <see cref="CommandResult"/> describing the validation outcome.</returns>
+    async Task<CommandResult> RunValidator(CommandContext context, object instance, IValidator validator)
+    {
+        var commandResult = CommandResult.Success(context.CorrelationId);
+
+        try
+        {
+            var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
+            var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
+            var validationResult = await validator.ValidateAsync(validationContext, context.CancellationToken);
+            if (!validationResult.IsValid)
+            {
+                commandResult.MergeWith(new CommandResult
+                {
+                    ValidationResults = validationResult.Errors.Select(_ =>
+                    {
+                        var severity = _.Severity switch
+                        {
+                            FluentValidation.Severity.Info => ValidationResultSeverity.Information,
+                            FluentValidation.Severity.Warning => ValidationResultSeverity.Warning,
+                            FluentValidation.Severity.Error => ValidationResultSeverity.Error,
+                            _ => ValidationResultSeverity.Error
+                        };
+                        return new ValidationResult(severity, _.ErrorMessage, [_.PropertyName], _.CustomState ?? null!);
+                    }).ToArray()
+                });
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A validator that dereferences a null concept member throws while validating hostile or partial
+            // input. Surface it as a validation failure (HTTP 400) rather than letting it propagate to a server
+            // error (HTTP 500). The detail is logged server-side and never returned to the client. Cancellation
+            // is deliberately excluded so a cancelled request is not mistaken for invalid input.
+            logger.CommandValidatorThrew(instance.GetType().FullName ?? instance.GetType().Name, ex);
+            commandResult.MergeWith(new CommandResult
+            {
+                ValidationResults = [ValidationResult.Error("The command could not be validated.")]
+            });
         }
 
         return commandResult;

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilterLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilterLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Commands.Filters;
+
+/// <summary>
+/// Log messages for <see cref="FluentValidationFilter"/>.
+/// </summary>
+internal static partial class FluentValidationFilterLogMessages
+{
+    [LoggerMessage(LogLevel.Warning, "The validator for '{ModelType}' threw while validating; surfacing the command as invalid")]
+    internal static partial void CommandValidatorThrew(this ILogger logger, string modelType, Exception exception);
+}

--- a/Source/DotNET/Arc.Core/ExceptionDetailRedactor.cs
+++ b/Source/DotNET/Arc.Core/ExceptionDetailRedactor.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc;
+
+/// <summary>
+/// Redacts exception detail (messages and stack traces) from command and query results before they are
+/// serialized to a client, so internal information is not leaked outside of the Development environment.
+/// </summary>
+/// <remarks>
+/// Redaction mutates the result that is about to be written to the wire; the full detail is logged
+/// server-side first so nothing is lost. The correlation identifier is retained and a generic marker
+/// replaces the real messages so that <c>HasExceptions</c> (and therefore the HTTP status code) is unchanged.
+/// </remarks>
+public static class ExceptionDetailRedactor
+{
+    /// <summary>
+    /// The generic message that replaces real exception detail when redaction is enabled.
+    /// </summary>
+    public const string RedactedMessage = "An internal error occurred while processing the request. See server logs for details.";
+
+    /// <summary>
+    /// Redacts exception detail from a <see cref="CommandResult"/> when exposing detail is disabled.
+    /// </summary>
+    /// <param name="result">The <see cref="CommandResult"/> to redact.</param>
+    /// <param name="exposeExceptionDetails">Whether exception detail may be exposed to the client.</param>
+    /// <param name="logger">The <see cref="ILogger"/> used to log the full detail server-side.</param>
+    public static void Redact(CommandResult result, bool exposeExceptionDetails, ILogger logger)
+    {
+        if (exposeExceptionDetails || !result.HasExceptions)
+        {
+            return;
+        }
+
+        LogFullDetail(logger, result.CorrelationId, result.ExceptionMessages, result.ExceptionStackTrace);
+        result.ExceptionMessages = [RedactedMessage];
+        result.ExceptionStackTrace = string.Empty;
+    }
+
+    /// <summary>
+    /// Redacts exception detail from a <see cref="QueryResult"/> when exposing detail is disabled.
+    /// </summary>
+    /// <param name="result">The <see cref="QueryResult"/> to redact.</param>
+    /// <param name="exposeExceptionDetails">Whether exception detail may be exposed to the client.</param>
+    /// <param name="logger">The <see cref="ILogger"/> used to log the full detail server-side.</param>
+    public static void Redact(QueryResult result, bool exposeExceptionDetails, ILogger logger)
+    {
+        if (exposeExceptionDetails || !result.HasExceptions)
+        {
+            return;
+        }
+
+        LogFullDetail(logger, result.CorrelationId, result.ExceptionMessages, result.ExceptionStackTrace);
+        result.ExceptionMessages = [RedactedMessage];
+        result.ExceptionStackTrace = string.Empty;
+    }
+
+    static void LogFullDetail(ILogger logger, CorrelationId correlationId, IEnumerable<string> messages, string stackTrace) =>
+        logger.RedactedExceptionDetail(correlationId.ToString(), string.Join("; ", messages), stackTrace);
+}

--- a/Source/DotNET/Arc.Core/ExceptionDetailRedactorLogMessages.cs
+++ b/Source/DotNET/Arc.Core/ExceptionDetailRedactorLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc;
+
+/// <summary>
+/// Log messages for <see cref="ExceptionDetailRedactor"/>.
+/// </summary>
+internal static partial class ExceptionDetailRedactorLogMessages
+{
+    [LoggerMessage(LogLevel.Error, "An unhandled exception occurred while processing a request (correlation id: {CorrelationId}). Messages: {ExceptionMessages}. Stack trace: {ExceptionStackTrace}")]
+    internal static partial void RedactedExceptionDetail(this ILogger logger, string correlationId, string exceptionMessages, string exceptionStackTrace);
+}

--- a/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryEndpointMapper.cs
@@ -6,6 +6,7 @@ using Cratis.Arc.Http;
 using Cratis.Execution;
 using Cratis.Types;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Cratis.Arc.Queries;
@@ -97,6 +98,7 @@ public static class QueryEndpointMapper
             {
                 var correlationIdAccessor = context.RequestServices.GetRequiredService<ICorrelationIdAccessor>();
                 var arcOptions = context.RequestServices.GetRequiredService<IOptions<ArcOptions>>().Value;
+                var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(QueryEndpointMapper).FullName!);
 
                 context.HandleCorrelationId(correlationIdAccessor, arcOptions.CorrelationId);
 
@@ -112,7 +114,8 @@ public static class QueryEndpointMapper
                 }
                 catch (Exception ex)
                 {
-                    var errorResult = QueryResult.Error(correlationIdAccessor.Current, $"Failed to read query request: {ex.Message}");
+                    var errorResult = QueryResult.Error(correlationIdAccessor.Current, ex);
+                    ExceptionDetailRedactor.Redact(errorResult, arcOptions.ExposeExceptionDetails, logger);
                     context.SetStatusCode((int)HttpStatusCode.BadRequest);
                     await context.WriteResponseAsJson(errorResult, typeof(QueryResult), context.RequestAborted);
                     return;
@@ -127,6 +130,8 @@ public static class QueryEndpointMapper
     {
         var queryPipeline = context.RequestServices.GetRequiredService<IQueryPipeline>();
         var observableQueryHandler = context.RequestServices.GetRequiredService<IObservableQueryHandler>();
+        var arcOptions = context.RequestServices.GetRequiredService<IOptions<ArcOptions>>().Value;
+        var logger = context.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(QueryEndpointMapper).FullName!);
 
         var queryResult = await queryPipeline.Perform(performer.FullyQualifiedName, request.Arguments, request.Paging, request.Sorting, context.RequestServices);
 
@@ -136,6 +141,8 @@ public static class QueryEndpointMapper
             await observableQueryHandler.HandleStreamingResult(context, performer.Name, queryResult.Data);
             return;
         }
+
+        ExceptionDetailRedactor.Redact(queryResult, arcOptions.ExposeExceptionDetails, logger);
 
         var statusCode = EndpointRouteHelper.GetStatusCode(queryResult.IsSuccess, queryResult.IsAuthorized, queryResult.IsValid);
         context.SetStatusCode(statusCode);

--- a/Source/DotNET/Arc.Core/Validation/IValidationFailure.cs
+++ b/Source/DotNET/Arc.Core/Validation/IValidationFailure.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Validation;
+
+/// <summary>
+/// Implemented by an exception that represents invalid command input rather than a server fault.
+/// </summary>
+/// <remarks>
+/// When an exception implementing this interface surfaces within the command pipeline, it is converted into a command
+/// validation failure (mapping to HTTP 400) instead of an error response (HTTP 500). Throw an exception implementing
+/// this to reject a command as invalid from code that runs inside the pipeline — for example resolving a dependency
+/// that requires client-provided input that was not supplied.
+/// </remarks>
+public interface IValidationFailure
+{
+    /// <summary>
+    /// Gets the <see cref="ValidationResult"/> describing why the command is invalid.
+    /// </summary>
+    ValidationResult ValidationResult { get; }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_a_key_that_converts_to_a_null_event_source_id.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_a_key_that_converts_to_a_null_event_source_id.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_getting_event_source_id;
+
+public class from_command_with_a_key_that_converts_to_a_null_event_source_id : Specification
+{
+    CommandWithNullConvertingKey _command;
+    EventSourceId _result;
+    Exception _exception;
+
+    void Establish() => _command = new(new NullConvertingKey());
+
+    void Because() => _exception = Catch.Exception(() => _result = _command.GetEventSourceId());
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_return_unspecified() => _result.ShouldEqual(EventSourceId.Unspecified);
+
+    public class NullConvertingKey
+    {
+        public override string ToString() => null!;
+    }
+
+    public class CommandWithNullConvertingKey(NullConvertingKey key)
+    {
+        [Key]
+        public NullConvertingKey Key { get; init; } = key;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_a_key_that_fails_conversion.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceExtensions/when_getting_event_source_id/from_command_with_a_key_that_fails_conversion.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceExtensions.when_getting_event_source_id;
+
+public class from_command_with_a_key_that_fails_conversion : Specification
+{
+    CommandWithFailingKey _command;
+    EventSourceId _result;
+    Exception _exception;
+
+    void Establish() => _command = new(new FailingKey());
+
+    void Because() => _exception = Catch.Exception(() => _result = _command.GetEventSourceId());
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_return_unspecified() => _result.ShouldEqual(EventSourceId.Unspecified);
+
+    public class FailingKey
+    {
+        public override string ToString() => throw new InvalidOperationException("the underlying key value is null");
+    }
+
+    public class CommandWithFailingKey(FailingKey key)
+    {
+        [Key]
+        public FailingKey Key { get; init; } = key;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_read_model/without_event_source_id.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_read_model/without_event_source_id.cs
@@ -7,8 +7,8 @@ public class without_event_source_id : given.a_read_model_resolution
 {
     void Establish() => GivenEventSourceIdIsUnspecified();
 
-    void Because() => CatchResolveReadModelException();
+    void Because() => ResolveReadModel();
 
-    [Fact] void should_throw_unable_to_resolve_read_model_from_command_context() => _exception.ShouldBeOfExactType<UnableToResolveReadModelFromCommandContext>();
+    [Fact] void should_return_null() => _result.ShouldBeNull();
     [Fact] void should_not_release_the_read_model() => ShouldNotHaveReleasedReadModel();
 }

--- a/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_read_model/without_event_source_id.cs
+++ b/Source/DotNET/Chronicle.Specs/ReadModels/for_ReadModelServiceCollectionExtensions/when_resolving_read_model/without_event_source_id.cs
@@ -1,14 +1,19 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Validation;
+
 namespace Cratis.Arc.Chronicle.ReadModels.for_ReadModelServiceCollectionExtensions.when_resolving_read_model;
 
 public class without_event_source_id : given.a_read_model_resolution
 {
     void Establish() => GivenEventSourceIdIsUnspecified();
 
-    void Because() => ResolveReadModel();
+    void Because() => CatchResolveReadModelException();
 
-    [Fact] void should_return_null() => _result.ShouldBeNull();
+    [Fact] void should_throw_unable_to_resolve_read_model_from_command_context() => _exception.ShouldBeOfExactType<UnableToResolveReadModelFromCommandContext>();
+    [Fact] void should_be_a_validation_failure() => (_exception is IValidationFailure).ShouldBeTrue();
+    [Fact] void should_carry_a_validation_error() => ((IValidationFailure)_exception).ValidationResult.Severity.ShouldEqual(ValidationResultSeverity.Error);
+    [Fact] void should_not_leak_the_read_model_type_in_the_client_message() => ((IValidationFailure)_exception).ValidationResult.Message.ShouldEqual("The command is missing the identifier required to load its current state.");
     [Fact] void should_not_release_the_read_model() => ShouldNotHaveReleasedReadModel();
 }

--- a/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceExtensions.cs
@@ -64,7 +64,7 @@ public static class EventSourceExtensions
             var id = values.Find(IsEventSourceIdValue);
             if (id is not null)
             {
-                eventSourceId = ToEventSourceId(id);
+                eventSourceId = ToEventSourceIdOrUnspecified(id);
             }
         }
         else
@@ -80,7 +80,7 @@ public static class EventSourceExtensions
                 var value = property.GetValue(command);
                 if (value is not null)
                 {
-                    eventSourceId = ToEventSourceId(value);
+                    eventSourceId = ToEventSourceIdOrUnspecified(value);
                 }
             }
         }
@@ -128,6 +128,31 @@ public static class EventSourceExtensions
         }
 
         return value.ToString()!;
+    }
+
+    /// <summary>
+    /// Converts a value to an <see cref="EventSourceId"/>, returning <see cref="EventSourceId.Unspecified"/> when the
+    /// conversion fails.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>The corresponding <see cref="EventSourceId"/>, or <see cref="EventSourceId.Unspecified"/> when conversion fails.</returns>
+    /// <remarks>
+    /// A key value whose underlying concept is null (for example a generic <see cref="EventSourceId{T}"/> or a concept
+    /// wrapping a null value) would throw inside the implicit conversion. Extracting the event source id runs before
+    /// any command filter, so a throw here would surface as an unhandled server error (HTTP 500) for hostile or partial
+    /// command input. Treat an unconvertible key as an unspecified id instead, letting the command flow reach the
+    /// validation and read-model resolution stages that turn it into a clean response.
+    /// </remarks>
+    static EventSourceId ToEventSourceIdOrUnspecified(object value)
+    {
+        try
+        {
+            return ToEventSourceId(value);
+        }
+        catch (Exception)
+        {
+            return EventSourceId.Unspecified;
+        }
     }
 
     static bool IsGenericEventSourceIdType(Type? type)

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
@@ -80,19 +80,20 @@ public static class ReadModelServiceCollectionExtensions
     /// <param name="readModelType">Type of read model to resolve.</param>
     /// <param name="commandContext">The <see cref="CommandContext"/> to resolve from.</param>
     /// <param name="readModels">The <see cref="IReadModels"/> service.</param>
-    /// <returns>The resolved read model instance, or null when it does not exist or the command carried no usable event source id.</returns>
+    /// <returns>The resolved read model instance, or null when it does not exist.</returns>
+    /// <exception cref="UnableToResolveReadModelFromCommandContext">Thrown when the command context carries no usable event source id to resolve the read model by; it surfaces as a validation failure (HTTP 400).</exception>
     internal static object? ResolveReadModel(Type readModelType, CommandContext commandContext, IReadModels readModels)
     {
         var eventSourceId = commandContext.GetEventSourceId();
         if (eventSourceId == EventSourceId.Unspecified)
         {
-            // An unspecified event source id means the command carried no usable key (absent or unconvertible), so
-            // there is no entity to load. Return null — the same as a never-created or removed read model — so that
-            // command-scoped code injecting a nullable read model receives null and treats it as "does not exist"
-            // (surfacing a clean validation response), while a non-nullable (must-exist) injection still fails through
-            // the standard parameter-resolution contract. Throwing here instead would pre-empt that contract and turn
-            // even the nullable, recoverable case into an unhandled server error.
-            return null;
+            // A read model is keyed by the command's event source id, so an unspecified id (the command carried no
+            // usable key) can never resolve one — for a nullable and a non-nullable dependency alike. That is invalid
+            // client input, not "the entity does not exist", so returning null would be misleading and letting the
+            // throw fall through as-is would be an unhandled server error. UnableToResolveReadModelFromCommandContext
+            // implements IValidationFailure, so the pipeline surfaces it as a validation failure (HTTP 400). A
+            // valid-but-not-found read model still resolves to null below.
+            throw new UnableToResolveReadModelFromCommandContext(readModelType);
         }
 
         var readModel = readModels.GetInstanceById(readModelType, eventSourceId).GetAwaiter().GetResult();

--- a/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
+++ b/Source/DotNET/Chronicle/ReadModels/ReadModelServiceCollectionExtensions.cs
@@ -80,14 +80,19 @@ public static class ReadModelServiceCollectionExtensions
     /// <param name="readModelType">Type of read model to resolve.</param>
     /// <param name="commandContext">The <see cref="CommandContext"/> to resolve from.</param>
     /// <param name="readModels">The <see cref="IReadModels"/> service.</param>
-    /// <returns>The resolved read model instance, or null when it does not exist.</returns>
-    /// <exception cref="UnableToResolveReadModelFromCommandContext">Thrown when the command context does not contain a usable event source id.</exception>
+    /// <returns>The resolved read model instance, or null when it does not exist or the command carried no usable event source id.</returns>
     internal static object? ResolveReadModel(Type readModelType, CommandContext commandContext, IReadModels readModels)
     {
         var eventSourceId = commandContext.GetEventSourceId();
         if (eventSourceId == EventSourceId.Unspecified)
         {
-            throw new UnableToResolveReadModelFromCommandContext(readModelType);
+            // An unspecified event source id means the command carried no usable key (absent or unconvertible), so
+            // there is no entity to load. Return null — the same as a never-created or removed read model — so that
+            // command-scoped code injecting a nullable read model receives null and treats it as "does not exist"
+            // (surfacing a clean validation response), while a non-nullable (must-exist) injection still fails through
+            // the standard parameter-resolution contract. Throwing here instead would pre-empt that contract and turn
+            // even the nullable, recoverable case into an unhandled server error.
+            return null;
         }
 
         var readModel = readModels.GetInstanceById(readModelType, eventSourceId).GetAwaiter().GetResult();

--- a/Source/DotNET/Chronicle/ReadModels/UnableToResolveReadModelFromCommandContext.cs
+++ b/Source/DotNET/Chronicle/ReadModels/UnableToResolveReadModelFromCommandContext.cs
@@ -1,17 +1,29 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Validation;
+
 namespace Cratis.Arc.Chronicle.ReadModels;
 
 /// <summary>
 /// Exception that gets thrown when not being able to resolve a read model from command context.
 /// </summary>
 /// <param name="readModelType">Type of read model that could not be resolved.</param>
+/// <remarks>
+/// A read model is keyed by the command's event source id, so a command that carries no usable identifier can never
+/// resolve one — that is invalid client input, not a server fault. This implements <see cref="IValidationFailure"/> so
+/// the command pipeline surfaces it as a validation failure (HTTP 400). The detailed message (naming the read model
+/// type) is for server logs only; the client sees the generic validation message.
+/// </remarks>
 public class UnableToResolveReadModelFromCommandContext(Type readModelType)
-    : Exception($"Unable to resolve read model of type '{readModelType.FullName}' from command context. Make sure the command has a property that is assignable to EventSourceId or marked with [Key] attribute")
+    : Exception($"Unable to resolve read model of type '{readModelType.FullName}' from command context. Make sure the command has a property that is assignable to EventSourceId or marked with [Key] attribute"),
+      IValidationFailure
 {
     /// <summary>
     /// Gets the read model type that could not be resolved.
     /// </summary>
     public Type ReadModelType { get; } = readModelType;
+
+    /// <inheritdoc/>
+    public ValidationResult ValidationResult { get; } = ValidationResult.Error("The command is missing the identifier required to load its current state.");
 }

--- a/Source/DotNET/EntityFrameworkCore.Specs/Observe/for_QueryContextAwareSet/when_adding/and_the_page_size_is_out_of_range.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Observe/for_QueryContextAwareSet/when_adding/and_the_page_size_is_out_of_range.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+
+namespace Cratis.Arc.EntityFrameworkCore.Observe.for_QueryContextAwareSet.when_adding;
+
+public class and_the_page_size_is_out_of_range : Specification
+{
+    QueryContextAwareSet<SomeEntity> _set;
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        var queryContext = new QueryContext("[Test]", CorrelationId.New(), new Paging(0, 0, true), Sorting.None);
+        _set = new QueryContextAwareSet<SomeEntity>(queryContext);
+        _set.Add(new(Guid.NewGuid(), 1));
+        _set.Add(new(Guid.NewGuid(), 2));
+    });
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_clamp_the_page_size_to_a_single_item() => _set.Count().ShouldEqual(1);
+
+    record SomeEntity(Guid Id, int Value);
+}

--- a/Source/DotNET/EntityFrameworkCore.Specs/Observe/for_QueryContextAwareSet/when_adding/and_the_sort_field_is_unknown.cs
+++ b/Source/DotNET/EntityFrameworkCore.Specs/Observe/for_QueryContextAwareSet/when_adding/and_the_sort_field_is_unknown.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Queries;
+using Cratis.Execution;
+
+namespace Cratis.Arc.EntityFrameworkCore.Observe.for_QueryContextAwareSet.when_adding;
+
+public class and_the_sort_field_is_unknown : Specification
+{
+    QueryContextAwareSet<SomeEntity> _set;
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        var queryContext = new QueryContext("[Test]", CorrelationId.New(), Paging.NotPaged, new Sorting("ThisFieldDoesNotExist", SortDirection.Ascending));
+        _set = new QueryContextAwareSet<SomeEntity>(queryContext);
+        _set.Add(new(Guid.NewGuid(), 1));
+        _set.Add(new(Guid.NewGuid(), 2));
+    });
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_keep_all_items() => _set.Count().ShouldEqual(2);
+
+    record SomeEntity(Guid Id, int Value);
+}

--- a/Source/DotNET/EntityFrameworkCore/EntityFrameworkCore.csproj
+++ b/Source/DotNET/EntityFrameworkCore/EntityFrameworkCore.csproj
@@ -5,6 +5,9 @@
         <NoWarn>$(NoWarn);NU5104</NoWarn>
     </PropertyGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Cratis.Arc.EntityFrameworkCore.Specs" />
+    </ItemGroup>
+    <ItemGroup>
         <PackageReference Include="Cratis.Fundamentals" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />

--- a/Source/DotNET/EntityFrameworkCore/Observe/QueryContextAwareSet.cs
+++ b/Source/DotNET/EntityFrameworkCore/Observe/QueryContextAwareSet.cs
@@ -130,11 +130,9 @@ internal sealed class QueryContextAwareSet<TEntity> : IEnumerable<TEntity>
         _maxSize = null;
         if (_queryContext.Paging.IsPaged)
         {
-            _maxSize = _queryContext.Paging.Size;
-            if (_maxSize < 1)
-            {
-                throw new ArgumentException("Page size must be greater than 0", nameof(newQueryContext));
-            }
+            // Clamp a non-positive (out-of-range) page size to a minimum of one item rather than throwing: a
+            // malformed or hostile page size must degrade to a valid page instead of surfacing a server error.
+            _maxSize = Math.Max(1, _queryContext.Paging.Size);
         }
 
         var createNewStorage = oldQueryContext?.Paging.IsPaged == true && _maxSize < oldQueryContext.Paging.Size;
@@ -148,24 +146,28 @@ internal sealed class QueryContextAwareSet<TEntity> : IEnumerable<TEntity>
 
         if (SortingIsEnabled())
         {
-            var sortingFieldProperty = typeof(TEntity).GetProperty(_queryContext.Sorting.Field.Value.ToPascalCase(), BindingFlags.Instance | BindingFlags.Public)
-                ?? throw new ArgumentException($"Sorting field could not be found on {typeof(TEntity)}", nameof(newQueryContext));
-            _sortingFieldComparer = (typeof(Comparer<>)
-                .MakeGenericType(sortingFieldProperty.PropertyType)
-                .GetProperty(nameof(Comparer<object>.Default), BindingFlags.Public | BindingFlags.Static)!
-                .GetValue(null)
-                as IComparer)!;
-            _getSortingField = entity =>
+            // An unknown sort field is ignored rather than throwing: throwing would surface as a server error and
+            // leak the read model type name for hostile or malformed input. The set keeps insertion order instead.
+            var sortingFieldProperty = typeof(TEntity).GetProperty(_queryContext.Sorting.Field.Value.ToPascalCase(), BindingFlags.Instance | BindingFlags.Public);
+            if (sortingFieldProperty is not null)
             {
-                try
+                _sortingFieldComparer = (typeof(Comparer<>)
+                    .MakeGenericType(sortingFieldProperty.PropertyType)
+                    .GetProperty(nameof(Comparer<object>.Default), BindingFlags.Public | BindingFlags.Static)!
+                    .GetValue(null)
+                    as IComparer)!;
+                _getSortingField = entity =>
                 {
-                    return sortingFieldProperty.GetValue(entity);
-                }
-                catch (Exception)
-                {
-                    return null;
-                }
-            };
+                    try
+                    {
+                        return sortingFieldProperty.GetValue(entity);
+                    }
+                    catch (Exception)
+                    {
+                        return null;
+                    }
+                };
+            }
         }
 
         if (_items is null || createNewStorage)

--- a/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_adding/and_the_page_size_is_out_of_range.cs
+++ b/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_adding/and_the_page_size_is_out_of_range.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+
+namespace Cratis.Arc.MongoDB.for_QueryContextAwareSet.when_adding;
+
+public class and_the_page_size_is_out_of_range : Specification
+{
+    QueryContextAwareSet<SomeClassWithSomeId> _set;
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        _set = new(QueryContextBuilder.New()
+            .WithPageSize(0)
+            .Build());
+        _set.Add(new(Guid.NewGuid(), 1));
+        _set.Add(new(Guid.NewGuid(), 2));
+    });
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_clamp_the_page_size_to_a_single_item() => _set.Count().ShouldEqual(1);
+}

--- a/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_adding/and_the_sort_field_is_unknown.cs
+++ b/Source/DotNET/MongoDB.Specs/for_QueryContextAwareSet/when_adding/and_the_sort_field_is_unknown.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+using SortDirection = Cratis.Arc.Queries.SortDirection;
+
+namespace Cratis.Arc.MongoDB.for_QueryContextAwareSet.when_adding;
+
+public class and_the_sort_field_is_unknown : Specification
+{
+    QueryContextAwareSet<SomeClassWithSomeId> _set;
+    SomeClassWithSomeId _first;
+    SomeClassWithSomeId _second;
+    Exception _exception;
+
+    void Establish()
+    {
+        _first = new(Guid.NewGuid(), 1);
+        _second = new(Guid.NewGuid(), 2);
+    }
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        _set = new(QueryContextBuilder.New()
+            .WithSorting(new("ThisFieldDoesNotExist", SortDirection.Ascending))
+            .Build());
+        _set.Add(_first);
+        _set.Add(_second);
+    });
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_keep_all_items() => _set.Count().ShouldEqual(2);
+}

--- a/Source/DotNET/MongoDB/QueryContextAwareSet.cs
+++ b/Source/DotNET/MongoDB/QueryContextAwareSet.cs
@@ -149,11 +149,9 @@ internal sealed class QueryContextAwareSet<TDocument> : IEnumerable<TDocument>
         _maxSize = null;
         if (_queryContext.Paging.IsPaged)
         {
-            _maxSize = _queryContext.Paging.Size;
-        }
-        if (_maxSize < 1)
-        {
-            throw new ArgumentException("Page size must be greater than 0", nameof(newQueryContext));
+            // Clamp a non-positive (out-of-range) page size to a minimum of one item rather than throwing: a
+            // malformed or hostile page size must degrade to a valid page instead of surfacing a server error.
+            _maxSize = Math.Max(1, _queryContext.Paging.Size);
         }
 
         var createNewStorage = oldQueryContext?.Paging.IsPaged == true && _maxSize < oldQueryContext.Paging.Size;
@@ -167,23 +165,28 @@ internal sealed class QueryContextAwareSet<TDocument> : IEnumerable<TDocument>
 
         if (SortingIsEnabled())
         {
-            var sortingFieldProperty = typeof(TDocument).GetProperty(_queryContext.Sorting.Field.Value.ToPascalCase(), BindingFlags.Instance | BindingFlags.Public) ?? throw new ArgumentException($"Sorting field could not be found on {typeof(TDocument)}", nameof(newQueryContext));
-            _sortingFieldComparer = (typeof(Comparer<>)
-                .MakeGenericType(sortingFieldProperty.PropertyType)
-                .GetProperty(nameof(Comparer<object>.Default), BindingFlags.Public | BindingFlags.Static)!
-                .GetValue(null)
-                as IComparer)!;
-            _getSortingField = document =>
+            // An unknown sort field is ignored rather than throwing: throwing would surface as a server error and
+            // leak the read model type name for hostile or malformed input. The set keeps insertion order instead.
+            var sortingFieldProperty = typeof(TDocument).GetProperty(_queryContext.Sorting.Field.Value.ToPascalCase(), BindingFlags.Instance | BindingFlags.Public);
+            if (sortingFieldProperty is not null)
             {
-                try
+                _sortingFieldComparer = (typeof(Comparer<>)
+                    .MakeGenericType(sortingFieldProperty.PropertyType)
+                    .GetProperty(nameof(Comparer<object>.Default), BindingFlags.Public | BindingFlags.Static)!
+                    .GetValue(null)
+                    as IComparer)!;
+                _getSortingField = document =>
                 {
-                    return sortingFieldProperty.GetValue(document);
-                }
-                catch (Exception)
-                {
-                    return null;
-                }
-            };
+                    try
+                    {
+                        return sortingFieldProperty.GetValue(document);
+                    }
+                    catch (Exception)
+                    {
+                        return null;
+                    }
+                };
+            }
         }
 
         if (_items is null || createNewStorage)


### PR DESCRIPTION
# Summary

Hardens Arc's command and query endpoints against hostile, null, and malformed input. Driving every command and query endpoint with adversarial input previously produced a large number of HTTP 500 responses that returned the exception message and full stack trace to the caller. Each of those cases now degrades to a clean, correct response — a 400 for bad input, a 403 for a forbidden request, a redacted error otherwise — and internal detail is no longer leaked to clients. A new analyzer catches the most common of these mistakes at authoring time.

## Added

- `ArcOptions.ExposeExceptionDetails` to control whether command and query error responses include exception messages and stack traces. It defaults to enabled only in the Development environment.
- `IValidationFailure` — an exception implementing it is surfaced as a command validation failure (HTTP 400) instead of a server error, so code that runs inside the command pipeline can reject a command as invalid by throwing.
- New analyzer **ARC0013** — warns when a validator rule dereferences a member of a possibly-null concept (for example `RuleFor(c => c.Order.Value)`), which throws at validation time instead of producing a validation error. Validate the concept first, or guard the rule with `.When(...)`.

## Security

- Exception messages and stack traces are no longer returned to clients in command and query responses outside the Development environment. The full detail is logged server-side and the correlation id is retained, so failures can still be traced without leaking internal information.

## Fixed

- Malformed or wrong-typed command request bodies now return HTTP 400 instead of HTTP 500.
- A command validator that throws while validating hostile or partial input now returns a validation error (HTTP 400) instead of HTTP 500.
- A command that targets an aggregate but provides no usable event source id now returns a validation error (HTTP 400) instead of crashing with HTTP 500, with a client-safe message that does not leak the read model type.
- A throwing command filter no longer aborts the filter chain or masks an earlier authorization result — a forbidden request now returns HTTP 403 instead of HTTP 500.
- Observable queries no longer fail with HTTP 500 (or leak the read model type name) on an unknown sort field, and now clamp a non-positive page size to a valid page — for both MongoDB and Entity Framework Core read models.
