### PR TITLE
Add ARC0013: flag a validator dereferencing a possibly-null concept

### DIFF
--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/Testing/TestProject.cs
@@ -49,6 +49,7 @@ public static class TestProject
         [
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Expressions.Expression).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Attribute).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_dereferences_a_null_concept.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_dereferences_a_null_concept.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_rule_dereferences_a_null_concept
+{
+    [Fact] async Task should_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+    public record PlaceOrder(OrderId Id);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => {|#0:c.Id.Value|}).NotEqual(System.Guid.Empty);
+        }
+    }
+}",
+        VerifyCS.Diagnostic("ARC0013")
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments("Id"));
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_selects_the_concept_itself.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_rule_selects_the_concept_itself.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_rule_selects_the_concept_itself
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+    public record PlaceOrder(OrderId Id);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => c.Id).NotNull();
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_dereferences_a_non_concept_member.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_dereferences_a_non_concept_member.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_selector_dereferences_a_non_concept_member
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+
+namespace TestNamespace
+{
+    public record PlaceOrder(string Name);
+
+    public class PlaceOrderValidator : AbstractValidator<PlaceOrder>
+    {
+        public PlaceOrderValidator()
+        {
+            RuleFor(c => c.Name.Length).GreaterThan(0);
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_is_the_concept_root_value.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ValidatorConceptDereferenceAnalyzer/for_ARC0013/when_selector_is_the_concept_root_value.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ValidatorConceptDereferenceAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ValidatorConceptDereferenceAnalyzer.for_ARC0013;
+
+public class when_selector_is_the_concept_root_value
+{
+    [Fact] async Task should_not_report_diagnostic() => await VerifyCS.VerifyAnalyzerAsync(@"
+using FluentValidation;
+using Cratis.Concepts;
+
+namespace TestNamespace
+{
+    public record OrderId(System.Guid Value) : ConceptAs<System.Guid>(Value);
+
+    public class OrderIdValidator : AbstractValidator<OrderId>
+    {
+        public OrderIdValidator()
+        {
+            RuleFor(x => x.Value).NotEqual(System.Guid.Empty);
+        }
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ ARC0009|Arc|Warning|Concept should be declared as a record
 ARC0010|Arc|Warning|Command Handle() wraps a synchronous result in a Task
 ARC0011|Arc|Warning|[Roles] argument should use nameof instead of a string literal
 ARC0012|Arc|Warning|Arc artifact throws a built-in exception type
+ARC0013|Arc|Warning|Validator rule dereferences a possibly-null concept member

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -154,5 +154,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Domain failures raised from Arc artifacts — command Handle() methods, CommandValidator<T>/ConceptValidator<T> validators, and reactor handlers — should be expressed as domain-named exception types (or validator rejections). Built-in exceptions like InvalidOperationException, ArgumentException, or Exception carry no domain meaning to the caller or the log.");
 
+    /// <summary>
+    /// ARC0013: Validator rule dereferences a possibly-null concept member.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0013_ValidatorDereferencesNullConcept = new(
+        id: "ARC0013",
+        title: "Validator rule dereferences a possibly-null concept member",
+        messageFormat: "Concept '{0}' may be null at validation time; dereferencing its member in a validator rule throws instead of producing a validation error. Validate '{0}' first, or guard the rule with '.When(...)'.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A FluentValidation rule selector that dereferences a member of a ConceptAs<T> property assumes the concept is non-null. Because model-bound input can be deserialized with a null concept, the rule throws a NullReferenceException at validation time instead of producing a validation error. Validate the concept itself first (when it is required) or guard the rule with a null check (when it is optional), so invalid input is reported as a validation failure rather than crashing.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ValidatorConceptDereferenceAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ValidatorConceptDereferenceAnalyzer.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Arc.CodeAnalysis;
+
+/// <summary>
+/// Analyzer that flags a FluentValidation rule selector that dereferences a member of a possibly-null concept,
+/// which throws at validation time instead of producing a validation error.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ValidatorConceptDereferenceAnalyzer : DiagnosticAnalyzer
+{
+    const string ConceptAsTypeName = "ConceptAs";
+    const string ConceptsNamespace = "Cratis.Concepts";
+    const string AbstractValidatorTypeName = "AbstractValidator";
+    const string FluentValidationNamespace = "FluentValidation";
+    const string RuleForMethodName = "RuleFor";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticDescriptors.ARC0013_ValidatorDereferencesNullConcept];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Must be a FluentValidation RuleFor(...) call (RuleFor is declared on AbstractValidator<T>).
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method ||
+            method.Name != RuleForMethodName ||
+            !IsFluentValidator(method.ContainingType))
+        {
+            return;
+        }
+
+        // RuleFor takes a single property-selector lambda, e.g. RuleFor(c => c.Concept.Value).
+        if (invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        var body = invocation.ArgumentList.Arguments[0].Expression switch
+        {
+            SimpleLambdaExpressionSyntax simple => simple.Body as ExpressionSyntax,
+            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.Body as ExpressionSyntax,
+            _ => null
+        };
+        if (body is null)
+        {
+            return;
+        }
+
+        foreach (var memberAccess in body.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            // Only a nested member can be null here; the lambda's own parameter is the value being validated.
+            if (memberAccess.Expression is not MemberAccessExpressionSyntax conceptMember)
+            {
+                continue;
+            }
+
+            var conceptType = context.SemanticModel.GetTypeInfo(conceptMember, context.CancellationToken).Type;
+            if (conceptType is null || !InheritsFromConceptAs(conceptType))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ARC0013_ValidatorDereferencesNullConcept,
+                memberAccess.GetLocation(),
+                conceptMember.Name.Identifier.Text));
+            return;
+        }
+    }
+
+    static bool IsFluentValidator(INamedTypeSymbol? typeSymbol)
+    {
+        var current = typeSymbol;
+        while (current is not null)
+        {
+            if (current.Name == AbstractValidatorTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == FluentValidationNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    static bool InheritsFromConceptAs(ITypeSymbol typeSymbol)
+    {
+        var current = typeSymbol.BaseType;
+        while (current is not null)
+        {
+            if (current.Name == ConceptAsTypeName &&
+                current.ContainingNamespace?.ToDisplayString() == ConceptsNamespace)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Added

- New analyzer **ARC0013** — warns when a validator rule dereferences a member of a possibly-null concept (for example `RuleFor(c => c.Order.Value)`). Because model-bound input can be deserialized with a null concept, the rule throws at validation time instead of producing a validation error; the analyzer flags it in the editor and points to the fixes (validate the concept when required, or guard the rule with `.When(...)`).
