### PR TITLE
Run command authorization filter before validation so a forbidden caller gets 403

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_caller_is_authorized_but_the_command_is_invalid.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_a_caller_is_authorized_but_the_command_is_invalid.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Commands.Filters;
+using Cratis.Arc.Http;
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+public class and_a_caller_is_authorized_but_the_command_is_invalid : Specification
+{
+    CommandFilters _commandFilters;
+    RecordingValidationFilter _validationFilter;
+    CommandContext _context;
+    CommandResult _result;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
+
+        var authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
+        authorizationEvaluator.IsAuthorized(Arg.Any<Type>()).Returns(true);
+        var authorizationFilter = new AuthorizationFilter(authorizationEvaluator);
+
+        _validationFilter = new RecordingValidationFilter();
+
+        // Authorization is decided first (by Order) and passes, so validation still runs and the invalid command
+        // is reported as a 400 — ordering must not suppress validation for an authorized caller.
+        var filters = new List<ICommandFilter> { _validationFilter, authorizationFilter };
+        var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        commandFiltersActivitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new CommandFilters(new KnownInstancesOf<ICommandFilter>(filters), commandFiltersActivitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => _result = await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_be_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_run_the_validation_filter() => _validationFilter.WasCalled.ShouldBeTrue();
+    [Fact] void should_map_to_bad_request() => EndpointRouteHelper.GetStatusCode(_result.IsSuccess, _result.IsAuthorized, _result.IsValid).ShouldEqual(HttpStatusCode.BadRequest);
+    [Fact] void should_surface_the_validation_message() => _result.ValidationResults.ShouldContain(vr => vr.Message == "name is required");
+
+    class RecordingValidationFilter : ICommandFilter
+    {
+        public bool WasCalled { get; private set; }
+
+        public Task<CommandResult> OnExecution(CommandContext context)
+        {
+            WasCalled = true;
+            return Task.FromResult(new CommandResult
+            {
+                CorrelationId = context.CorrelationId,
+                ValidationResults = [ValidationResult.Error("name is required")]
+            });
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_authorization_denies_a_caller_whose_command_is_also_invalid.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_authorization_denies_a_caller_whose_command_is_also_invalid.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Arc.Authorization;
+using Cratis.Arc.Commands.Filters;
+using Cratis.Arc.Http;
+using Cratis.Arc.Validation;
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+public class and_authorization_denies_a_caller_whose_command_is_also_invalid : Specification
+{
+    CommandFilters _commandFilters;
+    RecordingValidationFilter _validationFilter;
+    CommandContext _context;
+    CommandResult _result;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new());
+
+        var authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
+        authorizationEvaluator.IsAuthorized(Arg.Any<Type>()).Returns(false);
+        var authorizationFilter = new AuthorizationFilter(authorizationEvaluator);
+
+        _validationFilter = new RecordingValidationFilter();
+
+        // The validation filter is registered first on purpose: authorization must still be decided first (by Order),
+        // so a forbidden caller whose command is also invalid gets a clean 403 and the validation filter never runs.
+        var filters = new List<ICommandFilter> { _validationFilter, authorizationFilter };
+        var commandFiltersActivitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        commandFiltersActivitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new CommandFilters(new KnownInstancesOf<ICommandFilter>(filters), commandFiltersActivitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => _result = await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_map_to_forbidden_not_bad_request() => EndpointRouteHelper.GetStatusCode(_result.IsSuccess, _result.IsAuthorized, _result.IsValid).ShouldEqual(HttpStatusCode.Forbidden);
+    [Fact] void should_not_run_the_validation_filter() => _validationFilter.WasCalled.ShouldBeFalse();
+    [Fact] void should_not_leak_any_validation_detail() => _result.ValidationResults.ShouldBeEmpty();
+
+    class RecordingValidationFilter : ICommandFilter
+    {
+        public bool WasCalled { get; private set; }
+
+        public Task<CommandResult> OnExecution(CommandContext context)
+        {
+            WasCalled = true;
+            return Task.FromResult(new CommandResult
+            {
+                CorrelationId = context.CorrelationId,
+                ValidationResults = [ValidationResult.Error("name is required")]
+            });
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
@@ -21,7 +21,11 @@ public class CommandFilters(IInstancesOf<ICommandFilter> filters, IActivitySourc
         var result = CommandResult.Success(context.CorrelationId);
         using var span = activitySource.OnExecution(context.Type.FullName ?? context.Type.Name);
 
-        foreach (var filter in filters)
+        // Evaluate authorization filters before ordinary filters, independent of the order IInstancesOf yields them.
+        // Without this the short-circuit below could return on a validation failure before the authorization filter
+        // runs, leaving the authorization verdict at its default (authorized) and reporting a forbidden caller as
+        // authorized. OrderBy is a stable sort, so filters within the same group keep their discovery order.
+        foreach (var filter in filters.OrderBy(filter => filter is IAuthorizationCommandFilter ? 0 : 1))
         {
             try
             {

--- a/Source/DotNET/Arc.Core/Commands/Filters/AuthorizationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/AuthorizationFilter.cs
@@ -9,7 +9,7 @@ namespace Cratis.Arc.Commands.Filters;
 /// Represents a command filter that authorizes commands before they are handled.
 /// </summary>
 /// <param name="authorizationHelper">The <see cref="IAuthorizationEvaluator"/> to use for authorization checks.</param>
-public class AuthorizationFilter(IAuthorizationEvaluator authorizationHelper) : ICommandFilter
+public class AuthorizationFilter(IAuthorizationEvaluator authorizationHelper) : IAuthorizationCommandFilter
 {
     /// <inheritdoc/>
     public Task<CommandResult> OnExecution(CommandContext context)

--- a/Source/DotNET/Arc.Core/Commands/IAuthorizationCommandFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/IAuthorizationCommandFilter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands;
+
+/// <summary>
+/// Defines an <see cref="ICommandFilter"/> that authorizes command execution and must run before other filters.
+/// </summary>
+/// <remarks>
+/// Filters implementing this interface are evaluated before ordinary command filters, independent of the order in
+/// which they are discovered. This guarantees a forbidden caller is denied (403) before any validation runs — the
+/// filter chain short-circuits on the authorization verdict, so validation never executes and no validation detail
+/// is returned to a caller with no rights to the endpoint.
+/// </remarks>
+public interface IAuthorizationCommandFilter : ICommandFilter;


### PR DESCRIPTION
## Fixed
- A command that fails role authorization now returns `403 Forbidden` even when the command is also invalid, instead of a `400` validation error.

## Security
- Validation detail is no longer returned to a caller who is not authorized for a command endpoint — authorization is decided before validation runs.
