### PR TITLE
Fix command validation for secondary null keys and nested concept members

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_complex_object_and_nested_validation_fails.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_executing_command/with_complex_object_and_nested_validation_fails.cs
@@ -58,7 +58,7 @@ public class with_complex_object_and_nested_validation_fails : given.a_fluent_va
     [Fact] void should_have_one_validation_result() => _result.ValidationResults.Count().ShouldEqual(1);
     [Fact] void should_have_validation_result_with_error_severity() => _result.ValidationResults.First().Severity.ShouldEqual(ValidationResultSeverity.Error);
     [Fact] void should_have_validation_result_with_correct_message() => _result.ValidationResults.First().Message.ShouldEqual("Nested value is invalid");
-    [Fact] void should_have_validation_result_with_correct_member() => _result.ValidationResults.First().Members.ShouldContain("Value");
+    [Fact] void should_attribute_the_member_to_the_owning_property() => _result.ValidationResults.First().Members.ShouldContain("nested.Value");
     [Fact] void should_call_command_validator() => _commandValidator.Received(1).ValidateAsync(Arg.Any<IValidationContext>(), Arg.Any<CancellationToken>());
     [Fact] void should_call_nested_validator() => _nestedValidator.Received(1).ValidateAsync(Arg.Any<IValidationContext>(), Arg.Any<CancellationToken>());
 

--- a/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_a_deeply_nested_validator_reporting_an_inner_member.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/Filters/for_FluentValidationFilter/when_validating/with_a_deeply_nested_validator_reporting_an_inner_member.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentValidation;
+using FluentValidation.Results;
+using ValidationResult = FluentValidation.Results.ValidationResult;
+
+namespace Cratis.Arc.Commands.Filters.for_FluentValidationFilter.when_validating;
+
+public class with_a_deeply_nested_validator_reporting_an_inner_member : given.a_fluent_validation_filter
+{
+    CommandResult _result;
+    IValidator _innerValidator;
+    OuterCommand _command;
+
+    void Establish()
+    {
+        _command = new OuterCommand(new Middle(new Inner("value")));
+        _context = new CommandContext(_correlationId, typeof(OuterCommand), _command, [], new());
+
+        _innerValidator = Substitute.For<IValidator>();
+        _innerValidator.ValidateAsync(Arg.Any<IValidationContext>(), Arg.Any<CancellationToken>())
+            .Returns(new ValidationResult([new ValidationFailure("Value", "Inner value is invalid")]));
+
+        _discoverableValidators.TryGet(typeof(Inner), out Arg.Any<IValidator>())
+            .Returns(x =>
+            {
+                x[1] = _innerValidator;
+                return true;
+            });
+    }
+
+    async Task Because() => _result = await _filter.OnExecution(_context);
+
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_compose_the_full_camel_cased_path() => _result.ValidationResults.First().Members.ShouldContain("middle.inner.Value");
+
+    record OuterCommand(Middle Middle);
+    record Middle(Inner Inner);
+    record Inner(string Value);
+}

--- a/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
+++ b/Source/DotNET/Arc.Core/Commands/Filters/FluentValidationFilter.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Cratis.Arc.Validation;
+using Cratis.Strings;
 using FluentValidation;
 using Microsoft.Extensions.Logging;
 
@@ -20,11 +21,22 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
     public async Task<CommandResult> OnExecution(CommandContext context)
     {
         var commandResult = CommandResult.Success(context.CorrelationId);
-        commandResult.MergeWith(await Validate(context, context.Command, new HashSet<object>(ReferenceEqualityComparer.Instance)));
+        commandResult.MergeWith(await Validate(context, context.Command, new HashSet<object>(ReferenceEqualityComparer.Instance), string.Empty));
         return commandResult;
     }
 
-    async Task<CommandResult> Validate(CommandContext context, object instance, HashSet<object> visited)
+    /// <summary>
+    /// Prefixes a validation failure member with the owning property path, producing a dotted path whose leading
+    /// segment is the command field (for example <c>email.Value</c>). At the command root the path is empty, so the
+    /// member is returned unchanged.
+    /// </summary>
+    /// <param name="path">The camelCased property path from the command root, or empty at the root.</param>
+    /// <param name="member">The failure member reported by the validator.</param>
+    /// <returns>The member prefixed with <paramref name="path"/>, or the member unchanged when the path is empty.</returns>
+    static string Combine(string path, string member) =>
+        string.IsNullOrEmpty(path) ? member : $"{path}.{member}";
+
+    async Task<CommandResult> Validate(CommandContext context, object instance, HashSet<object> visited, string path)
     {
         var commandResult = CommandResult.Success(context.CorrelationId);
 
@@ -43,7 +55,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
 
         if (TryGetValidator(context, instanceType, out var validator))
         {
-            commandResult.MergeWith(await RunValidator(context, instance, validator));
+            commandResult.MergeWith(await RunValidator(context, instance, validator, path));
         }
 
         if (!instanceType.IsPrimitive &&
@@ -58,7 +70,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                 foreach (var element in (System.Collections.IEnumerable)instance)
                 {
                     if (element is null) continue;
-                    commandResult.MergeWith(await Validate(context, element, visited));
+                    commandResult.MergeWith(await Validate(context, element, visited, path));
                 }
             }
             else
@@ -76,7 +88,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                     var propertyValue = property.GetValue(instance);
                     if (propertyValue is not null)
                     {
-                        commandResult.MergeWith(await Validate(context, propertyValue, visited));
+                        commandResult.MergeWith(await Validate(context, propertyValue, visited, Combine(path, property.Name.ToCamelCase())));
                     }
                 }
             }
@@ -93,8 +105,12 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
     /// <param name="context">The <see cref="CommandContext"/> the validation runs within.</param>
     /// <param name="instance">The instance to validate.</param>
     /// <param name="validator">The <see cref="IValidator"/> to run.</param>
+    /// <param name="path">The camelCased property path from the command root to <paramref name="instance"/> (empty at
+    /// the root). Each failure's member is prefixed with it so a rule on a nested value — for example a
+    /// <c>ConceptValidator&lt;T&gt;</c>'s <c>RuleFor(x =&gt; x.Value)</c>, which reports the inner member <c>Value</c> —
+    /// is attributed to the owning command field (<c>email.Value</c>) rather than the unattributable <c>Value</c>.</param>
     /// <returns>A <see cref="CommandResult"/> describing the validation outcome.</returns>
-    async Task<CommandResult> RunValidator(CommandContext context, object instance, IValidator validator)
+    async Task<CommandResult> RunValidator(CommandContext context, object instance, IValidator validator, string path)
     {
         var commandResult = CommandResult.Success(context.CorrelationId);
 
@@ -116,7 +132,7 @@ public class FluentValidationFilter(IDiscoverableValidators discoverableValidato
                             FluentValidation.Severity.Error => ValidationResultSeverity.Error,
                             _ => ValidationResultSeverity.Error
                         };
-                        return new ValidationResult(severity, _.ErrorMessage, [_.PropertyName], _.CustomState ?? null!);
+                        return new ValidationResult(severity, _.ErrorMessage, [Combine(path, _.PropertyName)], _.CustomState ?? null!);
                     }).ToArray()
                 });
             }

--- a/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/given/a_required_concept_filter.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/given/a_required_concept_filter.cs
@@ -20,12 +20,16 @@ public class a_required_concept_filter : Specification
 
     protected record Name(string Value) : ConceptAs<string>(Value);
     protected record OrderId(Guid Value) : EventSourceId<Guid>(Value);
+    protected record CustomerId(Guid Value) : EventSourceId<Guid>(Value);
 
     protected record CommandWithRequiredConcept(Name Name);
     protected record CommandWithNullableConcept(Name? Name);
     protected record CommandWithEventSourceKey(OrderId Id);
     protected record CommandWithKeyAttributeConcept([property: Key] Name Id);
     protected record CommandWithNonConceptProperty(string Value);
+
+    protected record CommandWithPrimaryAndSecondaryEventSourceKeys(OrderId Id, CustomerId SecondaryId);
+    protected record CommandWithEventSourceKeyAndSecondaryKeyAttribute(OrderId Id, [property: Key] Name SecondaryKey);
 
     protected record CommandWithComputedConcept(Name First)
     {

--- a/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_a_secondary_event_source_key_concept_is_null.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_a_secondary_event_source_key_concept_is_null.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.Chronicle.Commands.for_RequiredConceptFilter.when_executing;
+
+public class and_a_secondary_event_source_key_concept_is_null : given.a_required_concept_filter
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await Execute(new CommandWithPrimaryAndSecondaryEventSourceKeys(new OrderId(Guid.NewGuid()), null!));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_point_at_the_secondary_key() => _result.ValidationResults.ShouldContain(validationResult => validationResult.Members.Contains(nameof(CommandWithPrimaryAndSecondaryEventSourceKeys.SecondaryId)));
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_a_secondary_key_attribute_concept_is_null.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_a_secondary_key_attribute_concept_is_null.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.Chronicle.Commands.for_RequiredConceptFilter.when_executing;
+
+public class and_a_secondary_key_attribute_concept_is_null : given.a_required_concept_filter
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await Execute(new CommandWithEventSourceKeyAndSecondaryKeyAttribute(new OrderId(Guid.NewGuid()), null!));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_not_carry_any_exception() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_point_at_the_secondary_key() => _result.ValidationResults.ShouldContain(validationResult => validationResult.Members.Contains(nameof(CommandWithEventSourceKeyAndSecondaryKeyAttribute.SecondaryKey)));
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_both_event_source_keys_are_null.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_both_event_source_keys_are_null.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.Chronicle.Commands.for_RequiredConceptFilter.when_executing;
+
+public class and_both_event_source_keys_are_null : given.a_required_concept_filter
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await Execute(new CommandWithPrimaryAndSecondaryEventSourceKeys(null!, null!));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_point_at_the_secondary_key() => _result.ValidationResults.ShouldContain(validationResult => validationResult.Members.Contains(nameof(CommandWithPrimaryAndSecondaryEventSourceKeys.SecondaryId)));
+    [Fact] void should_not_point_at_the_resolved_key() => _result.ValidationResults.ShouldNotContain(validationResult => validationResult.Members.Contains(nameof(CommandWithPrimaryAndSecondaryEventSourceKeys.Id)));
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_the_primary_event_source_key_is_null_with_a_secondary_present.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_RequiredConceptFilter/when_executing/and_the_primary_event_source_key_is_null_with_a_secondary_present.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Arc.Chronicle.Commands.for_RequiredConceptFilter.when_executing;
+
+public class and_the_primary_event_source_key_is_null_with_a_secondary_present : given.a_required_concept_filter
+{
+    CommandResult _result;
+
+    async Task Because() => _result = await Execute(new CommandWithPrimaryAndSecondaryEventSourceKeys(null!, new CustomerId(Guid.NewGuid())));
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Chronicle/Commands/RequiredConceptFilter.cs
+++ b/Source/DotNET/Chronicle/Commands/RequiredConceptFilter.cs
@@ -19,12 +19,15 @@ namespace Cratis.Arc.Chronicle.Commands;
 /// dereferenced later in <c>Provide()</c>, <c>Handle()</c>, or a validator rule and throws a <see cref="NullReferenceException"/>
 /// — which surfaces as a redacted server error (HTTP 500) rather than the 400 the input deserves. Surfacing it here as a
 /// validation failure turns it into a clean 400 pointing at the offending field. A concept declared nullable
-/// (<c>Concept?</c>) is intentionally optional and left alone; the event source key (an <see cref="Cratis.Chronicle.Events.EventSourceId"/>,
-/// a generic <c>EventSourceId&lt;T&gt;</c>, or a <c>[Key]</c> property) is excluded because a null key is deliberately
-/// resolved to an unspecified id rather than rejected. Only the command's own settable properties are inspected — a
-/// computed (get-only) property is never evaluated, so a derived concept that dereferences a missing value cannot turn
-/// this into a server error, and a concept nested inside another record is not checked here. To make a concept optional,
-/// declare it nullable.
+/// (<c>Concept?</c>) is intentionally optional and left alone; the <em>resolved</em> event source key (an
+/// <see cref="Cratis.Chronicle.Events.EventSourceId"/>, a generic <c>EventSourceId&lt;T&gt;</c>, or a <c>[Key]</c>
+/// property) is excluded because a null key is deliberately resolved to an unspecified id rather than rejected. When a
+/// command declares more than one key property, only the one that <see cref="EventSourceExtensions.GetEventSourceId"/>
+/// actually resolves — the first — is excluded; any <em>other</em> key-typed concept is a required value and a null one
+/// is rejected here (it would otherwise be dereferenced downstream and surface as a server error). Only the command's
+/// own settable properties are inspected — a computed (get-only) property is never evaluated, so a derived concept that
+/// dereferences a missing value cannot turn this into a server error, and a concept nested inside another record is not
+/// checked here. To make a concept optional, declare it nullable.
 /// </remarks>
 [Singleton]
 public class RequiredConceptFilter : ICommandFilter
@@ -59,15 +62,22 @@ public class RequiredConceptFilter : ICommandFilter
     static PropertyInfo[] RequiredConceptPropertiesFor(Type commandType)
     {
         var nullabilityContext = new NullabilityInfoContext();
+        var properties = commandType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // Only the resolved event source key — the first key property, matching EventSourceExtensions.GetEventSourceId —
+        // is excluded, because a null primary key is deliberately resolved to an unspecified id. Any other key-typed
+        // concept property is a required value; a null one would otherwise be dereferenced downstream and surface as an
+        // HTTP 500 instead of a clean 400.
+        var eventSourceKeyProperty = properties.FirstOrDefault(property => property.IsEventSourceKeyProperty());
+
         return
         [
-            .. commandType
-                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .. properties
                 .Where(property =>
                     property.CanWrite &&
                     property.GetIndexParameters().Length == 0 &&
                     property.PropertyType.IsConcept() &&
-                    !property.IsEventSourceKeyProperty() &&
+                    !ReferenceEquals(property, eventSourceKeyProperty) &&
                     nullabilityContext.Create(property).ReadState == NullabilityState.NotNull)
         ];
     }

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -11,6 +11,7 @@ import { ValidationResult } from '@cratis/arc/validation';
 import React, { useMemo, useState, useCallback } from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
+import { memberMatchesField } from './memberMatchesField';
 import { runCommandValidation } from './runCommandValidation';
 import { useIdentity } from '../../identity';
 
@@ -299,7 +300,7 @@ const CommandFormComponent = <TCommand extends object = object, TResponse = obje
         }
 
         for (const validationResult of commandResult.validationResults) {
-            if (validationResult.members && validationResult.members.includes(propertyName)) {
+            if (memberMatchesField(validationResult.members, propertyName)) {
                 return validationResult.message;
             }
         }

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormFields.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormFields.tsx
@@ -5,6 +5,7 @@ import { useCommandFormContext, type FieldValidationInfo } from './CommandFormCo
 import React from 'react';
 import type { CommandFormFieldProps } from './CommandFormField';
 import type { ICommandResult } from '@cratis/arc/commands';
+import { memberMatchesField } from './memberMatchesField';
 import { runCommandValidation } from './runCommandValidation';
 
 export interface ColumnInfo {
@@ -66,7 +67,7 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
                 // silent validation result updates asynchronously below.
                 if (context.onFieldChange) {
                     const prevErrors = context.commandResult?.validationResults?.filter(
-                        vr => vr.members.includes(propertyName)
+                        vr => memberMatchesField(vr.members, propertyName)
                     ).map(vr => vr.message) || [];
                     const validationInfo: FieldValidationInfo = {
                         isValid: prevErrors.length === 0,
@@ -94,10 +95,10 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
                         // Per-field merge: keep errors from untouched fields, update this field.
                         const currentErrors = context.commandResult?.validationResults || [];
                         const errorsFromOtherFields = currentErrors.filter(
-                            vr => !vr.members.includes(propertyName)
+                            vr => !memberMatchesField(vr.members, propertyName)
                         );
                         const errorsForThisField = validationResult.validationResults?.filter(
-                            vr => vr.members.includes(propertyName)
+                            vr => memberMatchesField(vr.members, propertyName)
                         ) || [];
                         const mergedValidationResults = [...errorsFromOtherFields, ...errorsForThisField];
                         context.setCommandResult({
@@ -129,10 +130,10 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
                             // Per-field merge: keep errors from untouched fields, update this field.
                             const currentErrors = context.commandResult?.validationResults || [];
                             const errorsFromOtherFields = currentErrors.filter(
-                                vr => !vr.members.includes(propertyName)
+                                vr => !memberMatchesField(vr.members, propertyName)
                             );
                             const errorsForThisField = validationResult.validationResults?.filter(
-                                vr => vr.members.includes(propertyName)
+                                vr => memberMatchesField(vr.members, propertyName)
                             ) || [];
                             const mergedValidationResults = [...errorsFromOtherFields, ...errorsForThisField];
                             context.setCommandResult({
@@ -148,7 +149,7 @@ const CommandFormFieldWrapper = ({ field }: { field: React.ReactElement<CommandF
                 if (context.onFieldChange && validationResult) {
                     const currentValue = (context.commandInstance as Record<string, unknown>)[propertyName];
                     const fieldErrors = validationResult?.validationResults?.filter(
-                        vr => vr.members.includes(propertyName)
+                        vr => memberMatchesField(vr.members, propertyName)
                     ).map(vr => vr.message) || [];
                     const validationInfo: FieldValidationInfo = {
                         isValid: fieldErrors.length === 0,

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_belongs_to_another_field.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_belongs_to_another_field.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { memberMatchesField } from '../memberMatchesField';
+
+describe('when a member belongs to another field', () => {
+    const result = memberMatchesField(['other.Value'], 'email');
+
+    it('should not match', () => result.should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_equals_the_field.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_equals_the_field.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { memberMatchesField } from '../memberMatchesField';
+
+describe('when a member equals the field', () => {
+    const result = memberMatchesField(['email'], 'email');
+
+    it('should match', () => result.should.be.true);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_is_a_path_under_the_field.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_is_a_path_under_the_field.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { memberMatchesField } from '../memberMatchesField';
+
+describe('when a member is a path under the field', () => {
+    const result = memberMatchesField(['email.Value'], 'email');
+
+    it('should match', () => result.should.be.true);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_only_shares_a_prefix_with_the_field.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_a_member_only_shares_a_prefix_with_the_field.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { memberMatchesField } from '../memberMatchesField';
+
+describe('when a member only shares a prefix with the field', () => {
+    const result = memberMatchesField(['emailAddress'], 'email');
+
+    it('should not match', () => result.should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_there_are_no_members.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_memberMatchesField/when_there_are_no_members.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { memberMatchesField } from '../memberMatchesField';
+
+describe('when there are no members', () => {
+    const result = memberMatchesField(undefined, 'email');
+
+    it('should not match', () => result.should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/memberMatchesField.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/memberMatchesField.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Determines whether a validation result member attributes to a given command form field.
+ *
+ * A member matches when it is exactly the field name, or a dotted path whose leading segment is the field
+ * name (e.g. `email.Value` attributes to the `email` field). The dotted-path case lets a failure that
+ * originates in a nested validator — such as a `ConceptValidator<T>`'s `RuleFor(x => x.Value)`, which the
+ * server reports as `email.Value` — surface on the field it belongs to.
+ * @param members - The members reported by a validation result, or undefined.
+ * @param fieldName - The command form field name to match against.
+ * @returns True when a member attributes to the field; otherwise false.
+ */
+export const memberMatchesField = (members: readonly string[] | undefined, fieldName: string): boolean =>
+    !!members?.some(member => member === fieldName || member.startsWith(`${fieldName}.`));


### PR DESCRIPTION
# Summary

Two correctness fixes in the command validation pipeline, both about a validation failure being reported against a member that could never be attributed to the command field it belonged to.

## Fixed
- A command declaring more than one event-source-key concept now returns HTTP 400 (not a 500) when a secondary key arrives null, with the failure pointing at the offending field.
- Validation failures raised by a nested `ConceptValidator<T>` rule (for example `RuleFor(x => x.Value)`) now surface on the owning command form field. Previously the failure was reported against the concept's inner `Value` member and was never displayed during write-time (blur/change) validation.
