### PR TITLE
Stop observable query connections from reconnecting while data is flowing

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_a_message_was_just_sent.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_a_message_was_just_sent.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_KeepAliveTracker.when_getting_time_until_next_keep_alive;
+
+public class and_a_message_was_just_sent : Specification
+{
+    static readonly TimeSpan _interval = TimeSpan.FromSeconds(30);
+    KeepAliveTracker _tracker;
+    TimeSpan _result;
+
+    void Establish() => _tracker = new KeepAliveTracker(DateTimeOffset.UtcNow);
+
+    void Because() => _result = _tracker.GetTimeUntilNextKeepAlive(_interval);
+
+    [Fact] void should_wait_close_to_a_full_interval() => (_result > _interval - TimeSpan.FromSeconds(1)).ShouldBeTrue();
+    [Fact] void should_never_wait_longer_than_the_interval() => (_result <= _interval).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_a_message_was_sent_midway_through_the_interval.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_a_message_was_sent_midway_through_the_interval.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_KeepAliveTracker.when_getting_time_until_next_keep_alive;
+
+/// <summary>
+/// Guards the regression that caused clients to drop healthy connections: a keep-alive loop waking on a
+/// fixed interval grid would skip the tick following a mid-interval data message and defer the keep-alive
+/// by a further full interval, letting the gap between messages approach twice the interval. The remaining
+/// time must always be measured from the last message sent, so the gap can never exceed one interval.
+/// </summary>
+public class and_a_message_was_sent_midway_through_the_interval : Specification
+{
+    static readonly TimeSpan _interval = TimeSpan.FromSeconds(30);
+    KeepAliveTracker _tracker;
+    TimeSpan _result;
+
+    void Establish() =>
+        _tracker = new KeepAliveTracker(DateTimeOffset.UtcNow - TimeSpan.FromSeconds(20));
+
+    void Because() => _result = _tracker.GetTimeUntilNextKeepAlive(_interval);
+
+    [Fact] void should_wait_only_the_remainder_of_the_interval() => (_result <= TimeSpan.FromSeconds(10)).ShouldBeTrue();
+    [Fact] void should_not_defer_to_the_next_full_interval() => (_result < _interval).ShouldBeTrue();
+    [Fact] void should_still_have_time_remaining() => (_result > TimeSpan.Zero).ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_interval_has_elapsed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_KeepAliveTracker/when_getting_time_until_next_keep_alive/and_interval_has_elapsed.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_KeepAliveTracker.when_getting_time_until_next_keep_alive;
+
+public class and_interval_has_elapsed : Specification
+{
+    KeepAliveTracker _tracker;
+    TimeSpan _result;
+
+    void Establish() =>
+        _tracker = new KeepAliveTracker(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(5));
+
+    void Because() => _result = _tracker.GetTimeUntilNextKeepAlive(TimeSpan.FromSeconds(30));
+
+    [Fact] void should_report_a_keep_alive_is_due_now() => _result.ShouldEqual(TimeSpan.Zero);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHubMessage/when_creating_connected_message.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHubMessage/when_creating_connected_message.cs
@@ -6,10 +6,12 @@ namespace Cratis.Arc.Queries.for_ObservableQueryHubMessage;
 public class when_creating_connected_message : Specification
 {
     const string ConnectionId = "test-connection-id";
+    static readonly TimeSpan _keepAliveInterval = TimeSpan.FromSeconds(30);
     ObservableQueryHubMessage _result;
 
-    void Because() => _result = ObservableQueryHubMessage.CreateConnected(ConnectionId);
+    void Because() => _result = ObservableQueryHubMessage.CreateConnected(ConnectionId, _keepAliveInterval);
 
     [Fact] void should_have_connected_type() => _result.Type.ShouldEqual(ObservableQueryHubMessageType.Connected);
     [Fact] void should_carry_connection_id_as_payload() => _result.Payload.ShouldEqual(ConnectionId);
+    [Fact] void should_advertise_keep_alive_interval_in_milliseconds() => _result.KeepAliveIntervalMs.ShouldEqual(30_000L);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHubMessage/when_creating_connected_message_with_keep_alive_disabled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHubMessage/when_creating_connected_message_with_keep_alive_disabled.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHubMessage;
+
+public class when_creating_connected_message_with_keep_alive_disabled : Specification
+{
+    const string ConnectionId = "test-connection-id";
+    ObservableQueryHubMessage _result;
+
+    void Because() => _result = ObservableQueryHubMessage.CreateConnected(ConnectionId, TimeSpan.Zero);
+
+    [Fact] void should_have_connected_type() => _result.Type.ShouldEqual(ObservableQueryHubMessageType.Connected);
+    [Fact] void should_advertise_keep_alive_as_disabled() => _result.KeepAliveIntervalMs.ShouldEqual(0L);
+}

--- a/Source/DotNET/Arc.Core/Queries/KeepAliveTracker.cs
+++ b/Source/DotNET/Arc.Core/Queries/KeepAliveTracker.cs
@@ -46,4 +46,22 @@ public class KeepAliveTracker
     /// <returns><see langword="true"/> if a keep-alive should be sent; otherwise <see langword="false"/>.</returns>
     public bool ShouldSendKeepAlive(TimeSpan interval) =>
         DateTimeOffset.UtcNow - _lastMessageSent >= interval;
+
+    /// <summary>
+    /// Gets how long remains until a keep-alive message is due, measured from the last message sent.
+    /// </summary>
+    /// <param name="interval">The keep-alive interval.</param>
+    /// <returns>The remaining time, or <see cref="TimeSpan.Zero"/> when a keep-alive is already due.</returns>
+    /// <remarks>
+    /// Keep-alive loops should wait for exactly this long rather than for a fixed interval. Waiting a
+    /// fixed interval schedules checks on a grid that is independent of when messages actually go out,
+    /// so a data message landing mid-interval defers the next keep-alive to the following tick — allowing
+    /// gaps of up to twice the interval. Clients that treat silence as a dead connection then disconnect
+    /// while the server still considers the connection healthy.
+    /// </remarks>
+    public TimeSpan GetTimeUntilNextKeepAlive(TimeSpan interval)
+    {
+        var remaining = _lastMessageSent + interval - DateTimeOffset.UtcNow;
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
 }

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -136,8 +136,14 @@ public class ObservableQueryDemultiplexer(
 
         try
         {
-            // Send the Connected message so the client knows its connection ID for POST requests.
-            await SendSseMessage(context, ObservableQueryHubMessage.CreateConnected(connectionId), state.KeepAliveTracker, linkedCts, state.WriteLock);
+            // Send the Connected message so the client knows its connection ID for POST requests, and the
+            // keep-alive interval it should expect messages on.
+            await SendSseMessage(
+                context,
+                ObservableQueryHubMessage.CreateConnected(connectionId, arcOptions.Value.Query.KeepAliveInterval),
+                state.KeepAliveTracker,
+                linkedCts,
+                state.WriteLock);
 
             // Block until the client disconnects or the server shuts down.
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -840,7 +846,33 @@ public class ObservableQueryDemultiplexer(
         }
     }
 
-    async Task RunWebSocketKeepAlive(IWebSocket webSocket, KeepAliveTracker keepAliveTracker, SemaphoreSlim writeLock, CancellationToken token)
+    Task RunWebSocketKeepAlive(IWebSocket webSocket, KeepAliveTracker keepAliveTracker, SemaphoreSlim writeLock, CancellationToken token) =>
+        RunKeepAlive(
+            keepAliveTracker,
+            () => SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, writeLock, token),
+            token);
+
+    Task RunSseKeepAlive(IHttpRequestContext context, KeepAliveTracker keepAliveTracker, CancellationTokenSource cts, SemaphoreSlim writeLock) =>
+        RunKeepAlive(
+            keepAliveTracker,
+            () => SendSseMessage(context, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, cts, writeLock),
+            cts.Token);
+
+    /// <summary>
+    /// Runs the transport-agnostic keep-alive loop, guaranteeing that no more than the configured
+    /// interval passes between messages sent to the client.
+    /// </summary>
+    /// <param name="keepAliveTracker">The <see cref="KeepAliveTracker"/> recording when messages were last sent.</param>
+    /// <param name="sendKeepAlive">Sends a keep-alive message over the transport.</param>
+    /// <param name="token">The <see cref="CancellationToken"/> that ends the loop.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// The loop waits until a keep-alive is actually due relative to the last message sent, rather than
+    /// waking on a fixed interval grid. A fixed grid defers the keep-alive to the next tick whenever a
+    /// data message lands mid-interval, which lets the gap between messages grow to nearly twice the
+    /// interval and causes clients watching for silence to drop an otherwise healthy connection.
+    /// </remarks>
+    async Task RunKeepAlive(KeepAliveTracker keepAliveTracker, Func<Task> sendKeepAlive, CancellationToken token)
     {
         var interval = arcOptions.Value.Query.KeepAliveInterval;
 
@@ -853,38 +885,22 @@ public class ObservableQueryDemultiplexer(
         {
             while (!token.IsCancellationRequested)
             {
-                await Task.Delay(interval, token);
+                var remaining = keepAliveTracker.GetTimeUntilNextKeepAlive(interval);
 
-                if (!token.IsCancellationRequested && keepAliveTracker.ShouldSendKeepAlive(interval))
+                if (remaining > TimeSpan.Zero)
                 {
-                    await SendWebSocketMessage(webSocket, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, writeLock, token);
+                    await Task.Delay(remaining, token);
+                    continue;
                 }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Normal shutdown — nothing to report.
-        }
-    }
 
-    async Task RunSseKeepAlive(IHttpRequestContext context, KeepAliveTracker keepAliveTracker, CancellationTokenSource cts, SemaphoreSlim writeLock)
-    {
-        var interval = arcOptions.Value.Query.KeepAliveInterval;
+                await sendKeepAlive();
 
-        if (interval <= TimeSpan.Zero)
-        {
-            return;
-        }
-
-        try
-        {
-            while (!cts.Token.IsCancellationRequested)
-            {
-                await Task.Delay(interval, cts.Token);
-
-                if (!cts.Token.IsCancellationRequested && keepAliveTracker.ShouldSendKeepAlive(interval))
+                // A successful send records activity, so the next iteration waits a full interval.
+                // If the send failed without recording anything, wait one interval anyway so that a
+                // persistently failing transport cannot spin this loop.
+                if (keepAliveTracker.GetTimeUntilNextKeepAlive(interval) <= TimeSpan.Zero)
                 {
-                    await SendSseMessage(context, ObservableQueryHubMessage.CreatePing(), keepAliveTracker, cts, writeLock);
+                    await Task.Delay(interval, token);
                 }
             }
         }

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryHubMessage.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryHubMessage.cs
@@ -37,6 +37,16 @@ public class ObservableQueryHubMessage
     public long? Timestamp { get; set; }
 
     /// <summary>
+    /// Gets or sets the server's keep-alive interval in milliseconds, or <c>0</c> when keep-alive is disabled.
+    /// </summary>
+    /// <remarks>
+    /// Only set on <see cref="ObservableQueryHubMessageType.Connected"/> messages. Clients derive their
+    /// idle threshold from this rather than assuming the default interval, so that reconfiguring the server
+    /// cannot leave a client declaring healthy connections dead.
+    /// </remarks>
+    public long? KeepAliveIntervalMs { get; set; }
+
+    /// <summary>
     /// Creates a <see cref="ObservableQueryHubMessageType.QueryResult"/> message.
     /// </summary>
     /// <param name="queryId">The query identifier.</param>
@@ -78,10 +88,17 @@ public class ObservableQueryHubMessage
         new() { Type = ObservableQueryHubMessageType.Ping, Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() };
 
     /// <summary>
-    /// Creates a <see cref="ObservableQueryHubMessageType.Connected"/> message carrying the server-assigned connection identifier.
+    /// Creates a <see cref="ObservableQueryHubMessageType.Connected"/> message carrying the server-assigned
+    /// connection identifier and the server's keep-alive interval.
     /// </summary>
     /// <param name="connectionId">The unique identifier for the SSE connection.</param>
+    /// <param name="keepAliveInterval">The server's keep-alive interval. Zero or negative means keep-alive is disabled.</param>
     /// <returns>A populated <see cref="ObservableQueryHubMessage"/>.</returns>
-    public static ObservableQueryHubMessage CreateConnected(string connectionId) =>
-        new() { Type = ObservableQueryHubMessageType.Connected, Payload = connectionId };
+    public static ObservableQueryHubMessage CreateConnected(string connectionId, TimeSpan keepAliveInterval) =>
+        new()
+        {
+            Type = ObservableQueryHubMessageType.Connected,
+            Payload = connectionId,
+            KeepAliveIntervalMs = keepAliveInterval > TimeSpan.Zero ? (long)keepAliveInterval.TotalMilliseconds : 0
+        };
 }

--- a/Source/JavaScript/Arc/queries/HubConnectionKeepAlive.ts
+++ b/Source/JavaScript/Arc/queries/HubConnectionKeepAlive.ts
@@ -22,7 +22,8 @@
 export class HubConnectionKeepAlive {
     private _lastActivityTime = Date.now();
     private _timer?: ReturnType<typeof setInterval>;
-    private readonly _idleThresholdMs: number;
+    private _intervalMs: number;
+    private _idleThresholdMs: number;
 
     /**
      * Initializes a new instance of {@link HubConnectionKeepAlive}.
@@ -35,11 +36,37 @@ export class HubConnectionKeepAlive {
      *   cadence to account for network latency and timer jitter.
      */
     constructor(
-        private readonly _intervalMs: number,
+        intervalMs: number,
         private readonly _onIdle: () => void,
         idleThresholdMs?: number,
     ) {
-        this._idleThresholdMs = idleThresholdMs ?? _intervalMs;
+        this._intervalMs = intervalMs;
+        this._idleThresholdMs = idleThresholdMs ?? intervalMs;
+    }
+
+    /**
+     * Gets how long (in milliseconds) without activity before the connection is considered idle.
+     */
+    get idleThresholdMs(): number {
+        return this._idleThresholdMs;
+    }
+
+    /**
+     * Change the check interval and idle threshold, restarting the timer when it is already running.
+     *
+     * Used when the peer advertises its actual keep-alive cadence after connecting, so the client
+     * stops relying on an assumed default that may not match the server's configuration.
+     * @param {number} intervalMs How often (in milliseconds) to check for idle connections.
+     * @param {number} idleThresholdMs How long (in milliseconds) without activity before the connection is considered idle.
+     */
+    reconfigure(intervalMs: number, idleThresholdMs: number): void {
+        const wasRunning = this._timer !== undefined;
+        this._intervalMs = intervalMs;
+        this._idleThresholdMs = idleThresholdMs;
+
+        if (wasRunning) {
+            this.start();
+        }
     }
 
     /**

--- a/Source/JavaScript/Arc/queries/QueryInstanceCache.ts
+++ b/Source/JavaScript/Arc/queries/QueryInstanceCache.ts
@@ -3,6 +3,7 @@
 
 import { QueryResultWithState } from './QueryResultWithState';
 import { CacheDiagnostics, CacheEntryDiagnostics } from './ObservableQueryDiagnosticsSnapshot';
+import { reconcileQueryData } from './reconcileQueryData';
 
 /**
  * Represents a key that uniquely identifies a query instance in the cache, based on the query type name and its serialized arguments.
@@ -171,25 +172,68 @@ export class QueryInstanceCache {
     setLastResult<TDataType>(key: QueryCacheKey, result: QueryResultWithState<TDataType>): void {
         const entry = this._entries.get(key);
 
-        if (entry) {
-            const previousResult = entry.lastResult as QueryResultWithState<TDataType> | undefined;
-            entry.lastResult = result as QueryResultWithState<unknown>;
-
-            // Suppress re-renders when the server re-sends identical data after a reconnect.
-            // We only compare `data` and `isSuccess` — other fields (e.g. changeSet) are
-            // ephemeral and do not affect what the user sees.
-            if (
-                previousResult !== undefined &&
-                previousResult.isSuccess === result.isSuccess &&
-                JSON.stringify(previousResult.data) === JSON.stringify(result.data)
-            ) {
-                return;
-            }
-
-            for (const listener of entry.listeners) {
-                (listener as QueryCacheListener<TDataType>)(result);
-            }
+        if (!entry) {
+            return;
         }
+
+        const previousResult = entry.lastResult as QueryResultWithState<TDataType> | undefined;
+
+        // Reconcile the incoming payload against the one already held so items that did not actually
+        // change keep their previous references. A full snapshot — which is what the server re-sends
+        // whenever a subscription is re-established — otherwise arrives as all-new references and
+        // makes every consumer treat every item as changed.
+        const reconciled = previousResult !== undefined
+            ? this.withReconciledData(previousResult, result)
+            : result;
+
+        entry.lastResult = reconciled as QueryResultWithState<unknown>;
+
+        // Reconciliation returns the previous data reference when nothing changed, so identity is
+        // enough to detect it. Only `data` and `isSuccess` matter here — the other fields (e.g.
+        // changeSet) are ephemeral and do not affect what the user sees.
+        if (
+            previousResult !== undefined &&
+            previousResult.isSuccess === reconciled.isSuccess &&
+            previousResult.data === reconciled.data
+        ) {
+            return;
+        }
+
+        for (const listener of entry.listeners) {
+            (listener as QueryCacheListener<TDataType>)(reconciled);
+        }
+    }
+
+    /**
+     * Returns the incoming result with its data reconciled against the previous result, or the
+     * incoming result unchanged when reconciliation found nothing to carry over.
+     * @template TDataType The type of data returned by the query.
+     * @param previous The previously held result.
+     * @param next The freshly received result.
+     * @returns A result whose data preserves references for everything that did not change.
+     */
+    private withReconciledData<TDataType>(
+        previous: QueryResultWithState<TDataType>,
+        next: QueryResultWithState<TDataType>
+    ): QueryResultWithState<TDataType> {
+        const reconciledData = reconcileQueryData(previous.data, next.data);
+
+        if (reconciledData === next.data) {
+            return next;
+        }
+
+        return new QueryResultWithState<TDataType>(
+            reconciledData,
+            next.paging,
+            next.isSuccess,
+            next.isAuthorized,
+            next.isValid,
+            next.validationResults,
+            next.hasExceptions,
+            next.exceptionMessages,
+            next.exceptionStackTrace,
+            next.isPerforming,
+            next.changeSet);
     }
 
     /**

--- a/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
@@ -18,6 +18,15 @@ interface ActiveSubscription {
 }
 
 /**
+ * How many keep-alive intervals of silence are tolerated before the connection is considered dead.
+ *
+ * The server guarantees a message every interval, so this is pure slack for latency and jitter.
+ * It must stay above 1 — a threshold at or below the server's own cadence makes the client and
+ * server timers race, and the client tears down connections the server considers healthy.
+ */
+const IDLE_THRESHOLD_FACTOR = 2;
+
+/**
  * A multiplexed SSE hub connection that uses EventSource for server→client streaming
  * and fetch POST requests for client→server subscribe/unsubscribe commands.
  *
@@ -45,8 +54,9 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
      * @param {string} _subscribeUrl The subscribe POST endpoint URL.
      * @param {string} _unsubscribeUrl The unsubscribe POST endpoint URL.
      * @param {string} _microservice The microservice name to pass as a query argument.
-     * @param {number} keepAliveIntervalMs How long without any server message before the connection
-     *   is considered stale and a reconnect is forced (default: 30 000 ms).
+     * @param {number} keepAliveIntervalMs The keep-alive cadence to assume until the server advertises
+     *   its own on the {@link HubMessageType.Connected} message (default: 30 000 ms). The connection is
+     *   considered stale after {@link IDLE_THRESHOLD_FACTOR} times this without any server message.
      * @param {number} connectTimeoutMs How long to wait for the {@link HubMessageType.Connected}
      *   message after the HTTP connection opens before giving up and retrying (default: 15 000 ms).
      * @param {IReconnectPolicy} _policy The reconnect policy to use (default: {@link ReconnectPolicy}).
@@ -64,18 +74,20 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
         // inactivity — if the server stops sending messages (including its own keep-alive
         // pings) for the entire idle threshold, the connection is stale and we reconnect.
         //
-        // The idle threshold is set to 1.5× the check interval so the server's keep-alive
-        // ping (which fires on the same cadence) has time to arrive over the network before
-        // the client declares the connection dead. Without this tolerance the client's timer
-        // and the server's timer race — the client often fires first and reconnects
-        // unnecessarily.
-        const idleThresholdMs = Math.round(keepAliveIntervalMs * 1.5);
+        // The server guarantees a message at least every keep-alive interval, so the threshold
+        // only has to absorb network latency, timer jitter and server-side scheduling hiccups.
+        // A hard TCP drop surfaces immediately through `onerror`, so this watchdog only needs to
+        // catch silent black-holes — that makes a generous tolerance strictly better than a tight
+        // one, which would tear down healthy connections.
+        //
+        // The interval below is only the starting assumption; the server advertises its real
+        // cadence on the Connected message and {@link handleConnected} reconfigures from it.
         this._keepAlive = new HubConnectionKeepAlive(keepAliveIntervalMs, () => {
             if (!this._disconnected && this._subscriptions.size > 0) {
-                console.warn(`SSE hub: no messages received for ${idleThresholdMs}ms, reconnecting '${this._sseUrl}'`);
+                console.warn(`SSE hub: no messages received for ${this._keepAlive.idleThresholdMs}ms, reconnecting '${this._sseUrl}'`);
                 this.reconnect();
             }
-        }, idleThresholdMs);
+        }, keepAliveIntervalMs * IDLE_THRESHOLD_FACTOR);
     }
 
     /** @inheritdoc */
@@ -277,11 +289,34 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
         // Connected message arrived — cancel the connect timeout.
         this.clearConnectTimeout();
 
+        this.applyServerKeepAliveInterval(message.keepAliveIntervalMs);
+
         // Send all pending subscriptions now that we have a connection ID.
         for (const [queryId, sub] of this._pendingSubscriptions) {
             this.sendSubscribe(queryId, sub.request);
         }
         this._pendingSubscriptions.clear();
+    }
+
+    /**
+     * Align the idle watchdog with the keep-alive cadence the server actually runs on.
+     *
+     * Without this the client assumes the default interval, so a server configured with a longer
+     * interval — or with keep-alive switched off entirely — would look silent and be reconnected
+     * on a loop even though it is perfectly healthy.
+     * @param {number | undefined} serverIntervalMs The interval advertised by the server, if any.
+     */
+    private applyServerKeepAliveInterval(serverIntervalMs?: number): void {
+        if (serverIntervalMs === undefined) return;
+
+        // Keep-alive disabled server-side: silence is expected, so watching for it would guarantee
+        // an endless reconnect loop. Hard drops still surface through `onerror`.
+        if (serverIntervalMs <= 0) {
+            this._keepAlive.stop();
+            return;
+        }
+
+        this._keepAlive.reconfigure(serverIntervalMs, serverIntervalMs * IDLE_THRESHOLD_FACTOR);
     }
 
     private handleQueryResult(message: HubMessage): void {

--- a/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/WebSocketHubConnection.ts
@@ -33,6 +33,12 @@ export interface HubMessage {
     queryId?: string;
     payload?: any;
     timestamp?: number;
+
+    /**
+     * The server's keep-alive interval in milliseconds, or 0 when keep-alive is disabled.
+     * Only present on {@link HubMessageType.Connected} messages.
+     */
+    keepAliveIntervalMs?: number;
 }
 
 /**

--- a/Source/JavaScript/Arc/queries/for_HubConnectionKeepAlive/when_reconfiguring/while_running.ts
+++ b/Source/JavaScript/Arc/queries/for_HubConnectionKeepAlive/when_reconfiguring/while_running.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { HubConnectionKeepAlive } from '../../HubConnectionKeepAlive';
+
+describe('when reconfiguring a running keep-alive', () => {
+    let clock: sinon.SinonFakeTimers;
+    let onIdle: sinon.SinonStub;
+    let keepAlive: HubConnectionKeepAlive;
+
+    const originalIntervalMs = 500;
+    const originalThresholdMs = 750;
+    const newIntervalMs = 1000;
+    const newThresholdMs = 2000;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        onIdle = sinon.stub();
+        keepAlive = new HubConnectionKeepAlive(originalIntervalMs, onIdle, originalThresholdMs);
+        keepAlive.start();
+        keepAlive.reconfigure(newIntervalMs, newThresholdMs);
+    });
+
+    afterEach(() => {
+        keepAlive.stop();
+        clock.restore();
+        sinon.restore();
+    });
+
+    it('should expose the new idle threshold', () => keepAlive.idleThresholdMs.should.equal(newThresholdMs));
+
+    describe('and the original threshold elapses', () => {
+        beforeEach(() => {
+            // Well past the original 750ms threshold, but short of the new 2000ms one.
+            clock.tick(originalThresholdMs + 1);
+        });
+
+        it('should not invoke the onIdle callback', () => onIdle.called.should.be.false);
+    });
+
+    describe('and the new threshold elapses', () => {
+        beforeEach(() => {
+            // Checks now fire every 1000ms; the tick at 2000ms sees 2000ms of inactivity.
+            clock.tick(newThresholdMs + 1);
+        });
+
+        it('should invoke the onIdle callback', () => onIdle.calledOnce.should.be.true);
+    });
+});

--- a/Source/JavaScript/Arc/queries/for_HubConnectionKeepAlive/when_reconfiguring/while_stopped.ts
+++ b/Source/JavaScript/Arc/queries/for_HubConnectionKeepAlive/when_reconfiguring/while_stopped.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { HubConnectionKeepAlive } from '../../HubConnectionKeepAlive';
+
+describe('when reconfiguring a keep-alive that has not been started', () => {
+    let clock: sinon.SinonFakeTimers;
+    let onIdle: sinon.SinonStub;
+    let keepAlive: HubConnectionKeepAlive;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        onIdle = sinon.stub();
+        keepAlive = new HubConnectionKeepAlive(500, onIdle, 750);
+        keepAlive.reconfigure(1000, 2000);
+        clock.tick(10000);
+    });
+
+    afterEach(() => {
+        keepAlive.stop();
+        clock.restore();
+        sinon.restore();
+    });
+
+    it('should not start the timer', () => onIdle.called.should.be.false);
+    it('should still apply the new idle threshold', () => keepAlive.idleThresholdMs.should.equal(2000));
+});

--- a/Source/JavaScript/Arc/queries/for_QueryInstanceCache/when_setting_last_result/with_a_partially_changed_result.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryInstanceCache/when_setting_last_result/with_a_partially_changed_result.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { QueryInstanceCache } from '../../QueryInstanceCache';
+import { QueryResultWithState } from '../../QueryResultWithState';
+
+type Item = { id: string; name: string };
+
+describe('when a re-delivered snapshot changed only one of its items', () => {
+    const key = 'MyQuery::';
+    let cache: QueryInstanceCache;
+    let listener: sinon.SinonStub;
+    let stored: QueryResultWithState<Item[]>;
+
+    const first = QueryResultWithState.empty<Item[]>([
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' }
+    ]);
+
+    const second = QueryResultWithState.empty<Item[]>([
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second changed' }
+    ]);
+
+    beforeEach(() => {
+        cache = new QueryInstanceCache();
+        cache.getOrCreate(key, () => ({}));
+        listener = sinon.stub();
+        cache.addListener(key, listener);
+
+        cache.setLastResult(key, first);
+        cache.setLastResult(key, second);
+        stored = cache.getLastResult<Item[]>(key)!;
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should notify for both results', () => listener.calledTwice.should.be.true);
+    it('should keep the reference of the unchanged item', () => stored.data[0].should.equal(first.data[0]));
+    it('should take the new reference for the changed item', () => stored.data[1].should.equal(second.data[1]));
+    it('should carry the changed value', () => stored.data[1].name.should.equal('Second changed'));
+});

--- a/Source/JavaScript/Arc/queries/for_QueryInstanceCache/when_setting_last_result/with_a_re_delivered_identical_result.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryInstanceCache/when_setting_last_result/with_a_re_delivered_identical_result.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { QueryInstanceCache } from '../../QueryInstanceCache';
+import { QueryResultWithState } from '../../QueryResultWithState';
+
+type Item = { id: string; name: string };
+
+describe('when the server re-delivers an identical snapshot after re-subscribing', () => {
+    const key = 'MyQuery::';
+    let cache: QueryInstanceCache;
+    let listener: sinon.SinonStub;
+
+    const first = QueryResultWithState.empty<Item[]>([{ id: 'a', name: 'First' }]);
+
+    // A fresh deserialization of the same payload — equal in value, all-new references.
+    const second = QueryResultWithState.empty<Item[]>([{ id: 'a', name: 'First' }]);
+
+    beforeEach(() => {
+        cache = new QueryInstanceCache();
+        cache.getOrCreate(key, () => ({}));
+        listener = sinon.stub();
+        cache.addListener(key, listener);
+
+        cache.setLastResult(key, first);
+        cache.setLastResult(key, second);
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should notify only for the first result', () => listener.calledOnce.should.be.true);
+    it('should keep holding the original data reference', () => cache.getLastResult<Item[]>(key)!.data.should.equal(first.data));
+});

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_server_advertises_a_longer_keep_alive_interval/does_not_reconnect_at_the_assumed_threshold.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_server_advertises_a_longer_keep_alive_interval/does_not_reconnect_at_the_assumed_threshold.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { a_server_sent_event_hub_connection } from '../given/a_server_sent_event_hub_connection';
+import { given } from '../../../given';
+import { HubMessageType } from '../../WebSocketHubConnection';
+
+const ASSUMED_KEEP_ALIVE_MS = 500;
+const SERVER_KEEP_ALIVE_MS = 2000;
+
+describe('when the server advertises a longer keep-alive interval than the client assumed', given(a_server_sent_event_hub_connection, context => {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        context.setup();
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+        const { ServerSentEventHubConnection } = require('../../ServerSentEventHubConnection');
+        context.connection = new ServerSentEventHubConnection(
+            'http://localhost/.cratis/queries/sse',
+            'http://localhost/.cratis/queries/sse/subscribe',
+            'http://localhost/.cratis/queries/sse/unsubscribe',
+            '',
+            ASSUMED_KEEP_ALIVE_MS,
+            15000,
+            context.policy
+        );
+
+        context.connection.subscribe('q1', { queryName: 'MyQuery' }, sinon.stub());
+        context.simulateOpen();
+
+        context.simulateMessage({
+            type: HubMessageType.Connected,
+            payload: 'conn-123',
+            keepAliveIntervalMs: SERVER_KEEP_ALIVE_MS
+        });
+    });
+
+    afterEach(() => {
+        clock.restore();
+        sinon.restore();
+    });
+
+    describe('and the assumed threshold elapses', () => {
+        beforeEach(() => {
+            // Far past the assumed threshold (2 × 500ms), but the server only promised a message
+            // every 2000ms — tearing the connection down here is exactly the bug being fixed.
+            clock.tick(ASSUMED_KEEP_ALIVE_MS * 2 + 1);
+        });
+
+        it('should not schedule a reconnect', () => (context.policy.schedule as sinon.SinonStub).called.should.be.false);
+    });
+
+    describe('and the advertised threshold elapses', () => {
+        beforeEach(() => {
+            // Checks now run on the server's 2000ms cadence; the tick at 4000ms sees 4000ms of silence.
+            clock.tick(SERVER_KEEP_ALIVE_MS * 2 + 1);
+        });
+
+        it('should schedule a reconnect', () => (context.policy.schedule as sinon.SinonStub).calledOnce.should.be.true);
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_server_reports_keep_alive_disabled/never_reconnects_from_idle.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_server_reports_keep_alive_disabled/never_reconnects_from_idle.ts
@@ -6,9 +6,9 @@ import { a_server_sent_event_hub_connection } from '../given/a_server_sent_event
 import { given } from '../../../given';
 import { HubMessageType } from '../../WebSocketHubConnection';
 
-const KEEP_ALIVE_MS = 500;
+const ASSUMED_KEEP_ALIVE_MS = 500;
 
-describe('when keep-alive interval elapses without any server message', given(a_server_sent_event_hub_connection, context => {
+describe('when the server reports that keep-alive is disabled', given(a_server_sent_event_hub_connection, context => {
     let clock: sinon.SinonFakeTimers;
 
     beforeEach(() => {
@@ -22,7 +22,7 @@ describe('when keep-alive interval elapses without any server message', given(a_
             'http://localhost/.cratis/queries/sse/subscribe',
             'http://localhost/.cratis/queries/sse/unsubscribe',
             '',
-            KEEP_ALIVE_MS,
+            ASSUMED_KEEP_ALIVE_MS,
             15000,
             context.policy
         );
@@ -30,14 +30,15 @@ describe('when keep-alive interval elapses without any server message', given(a_
         context.connection.subscribe('q1', { queryName: 'MyQuery' }, sinon.stub());
         context.simulateOpen();
 
-        // Deliver Connected so the connection is fully established.
-        context.simulateMessage({ type: HubMessageType.Connected, payload: 'conn-123' });
+        context.simulateMessage({
+            type: HubMessageType.Connected,
+            payload: 'conn-123',
+            keepAliveIntervalMs: 0
+        });
 
-        // Advance past the idle threshold (IDLE_THRESHOLD_FACTOR × keep-alive interval) without any
-        // further messages. The check interval fires every KEEP_ALIVE_MS; the idle threshold is
-        // KEEP_ALIVE_MS * 2. After the first interval tick (500ms) the elapsed idle time (500ms) is
-        // below the threshold (1000ms). At the second tick (1000ms) the elapsed time reaches it.
-        clock.tick(KEEP_ALIVE_MS * 2 + 1);
+        // A server that never pings is silent by design — watching for silence would otherwise
+        // reconnect on a loop forever. Hard drops still surface through onerror.
+        clock.tick(ASSUMED_KEEP_ALIVE_MS * 20);
     });
 
     afterEach(() => {
@@ -45,7 +46,5 @@ describe('when keep-alive interval elapses without any server message', given(a_
         sinon.restore();
     });
 
-    it('should schedule a reconnect via the policy', () => {
-        (context.policy.schedule as sinon.SinonStub).calledOnce.should.be.true;
-    });
+    it('should never schedule a reconnect from inactivity', () => (context.policy.schedule as sinon.SinonStub).called.should.be.false);
 }));

--- a/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_items_are_added_or_removed/reuses_the_surviving_items.ts
+++ b/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_items_are_added_or_removed/reuses_the_surviving_items.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { reconcileQueryData } from '../../reconcileQueryData';
+
+describe('when reconciling a snapshot with an item added', () => {
+    const previous = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' }
+    ];
+
+    const next = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' },
+        { id: 'c', name: 'Third' }
+    ];
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should return a new collection', () => result.should.not.equal(previous));
+    it('should have the new length', () => result.length.should.equal(3));
+    it('should keep the references of the surviving items', () => {
+        result[0].should.equal(previous[0]);
+        result[1].should.equal(previous[1]);
+    });
+    it('should take the new reference for the added item', () => result[2].should.equal(next[2]));
+});
+
+describe('when reconciling a snapshot with an item removed', () => {
+    const previous = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' },
+        { id: 'c', name: 'Third' }
+    ];
+
+    const next = [
+        { id: 'a', name: 'First' },
+        { id: 'c', name: 'Third' }
+    ];
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should have the new length', () => result.length.should.equal(2));
+    it('should keep the reference of the item that stayed in place', () => result[0].should.equal(previous[0]));
+    it('should keep the reference of the item that shifted position', () => result[1].should.equal(previous[2]));
+});

--- a/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_one_item_changed/only_the_changed_item_gets_a_new_reference.ts
+++ b/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_one_item_changed/only_the_changed_item_gets_a_new_reference.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { reconcileQueryData } from '../../reconcileQueryData';
+
+describe('when reconciling a snapshot in which a single item changed', () => {
+    const previous = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' },
+        { id: 'c', name: 'Third' }
+    ];
+
+    const next = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second changed' },
+        { id: 'c', name: 'Third' }
+    ];
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should return a new collection', () => result.should.not.equal(previous));
+    it('should keep the reference of the first unchanged item', () => result[0].should.equal(previous[0]));
+    it('should keep the reference of the last unchanged item', () => result[2].should.equal(previous[2]));
+    it('should take the new reference for the changed item', () => result[1].should.equal(next[1]));
+    it('should carry the changed value', () => result[1].name.should.equal('Second changed'));
+});

--- a/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_reconciling_an_unchanged_collection/preserves_all_references.ts
+++ b/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_reconciling_an_unchanged_collection/preserves_all_references.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { reconcileQueryData } from '../../reconcileQueryData';
+
+describe('when reconciling a re-delivered snapshot that did not change', () => {
+    const previous = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' }
+    ];
+
+    // A fresh deserialization of the same payload — equal in value, all-new references.
+    const next = [
+        { id: 'a', name: 'First' },
+        { id: 'b', name: 'Second' }
+    ];
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should return the previous collection itself', () => result.should.equal(previous));
+    it('should not adopt any of the new references', () => result.forEach((item, index) => item.should.equal(previous[index])));
+});

--- a/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_reconciling_non_collection_payloads/compares_by_value.ts
+++ b/Source/JavaScript/Arc/queries/for_reconcileQueryData/when_reconciling_non_collection_payloads/compares_by_value.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { reconcileQueryData } from '../../reconcileQueryData';
+
+describe('when reconciling a single object that did not change', () => {
+    const previous = { id: 'a', name: 'First' };
+    const next = { id: 'a', name: 'First' };
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should return the previous object', () => result.should.equal(previous));
+});
+
+describe('when reconciling a single object that changed', () => {
+    const previous = { id: 'a', name: 'First' };
+    const next = { id: 'a', name: 'Changed' };
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should return the new object', () => result.should.equal(next));
+});
+
+describe('when reconciling items that carry no identity', () => {
+    const previous = [{ name: 'First' }, { name: 'Second' }];
+    const next = [{ name: 'First' }, { name: 'Second' }];
+
+    const result = reconcileQueryData(previous, next);
+
+    it('should fall back to positional matching and preserve the collection', () => result.should.equal(previous));
+});

--- a/Source/JavaScript/Arc/queries/index.ts
+++ b/Source/JavaScript/Arc/queries/index.ts
@@ -35,6 +35,7 @@ export * from './ObservableQuerySubscription';
 export * from './WebSocketMessage';
 export * from './QueryTransportMethod';
 export * from './QueryInstanceCache';
+export * from './reconcileQueryData';
 export * from './IQueryProvider';
 export * from './QueryProvider';
 export * from './QueryValidator';

--- a/Source/JavaScript/Arc/queries/reconcileQueryData.ts
+++ b/Source/JavaScript/Arc/queries/reconcileQueryData.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { deepEqual } from '../deepEqual';
+
+/**
+ * Resolves the conventional identity of an item so it can be matched against its previous version.
+ *
+ * Uses the `id` property, the same strategy the server-side change-set computation applies, and
+ * reduces concept-style identities (objects with a meaningful `toString()`) to a comparable value.
+ * @param {unknown} item The item to resolve identity for.
+ * @returns {unknown} The identity value, or `undefined` when the item carries no usable identity.
+ */
+function getIdentity(item: unknown): unknown {
+    const id = (item as Record<string, unknown>)?.id;
+
+    if (id === null || id === undefined) {
+        return undefined;
+    }
+
+    if (typeof id === 'object') {
+        const stringValue = id.toString();
+        return stringValue !== '[object Object]' ? stringValue : JSON.stringify(id);
+    }
+
+    return id;
+}
+
+/**
+ * Reconciles a full payload against the previous one, carrying over the previous object references
+ * for every item that did not actually change.
+ *
+ * Observable queries re-deliver a complete snapshot whenever a subscription is (re-)established.
+ * Deserializing that snapshot produces entirely new object references, so consumers that compare by
+ * reference — memoized components, effect dependencies — treat every item as changed even when the
+ * payload is identical to what they already display. Reconciling restores referential stability:
+ * unchanged items keep their previous reference, and when nothing changed at all the previous
+ * payload itself is returned so callers can detect "no change" with a single `===`.
+ *
+ * Items are matched by their `id` when present, falling back to position for identity-less items.
+ * @template T The payload type.
+ * @param {T} previous The payload currently held.
+ * @param {T} next The freshly received payload.
+ * @returns {T} `previous` when nothing changed; otherwise the new payload with unchanged items carried over by reference.
+ */
+export function reconcileQueryData<T>(previous: T, next: T): T {
+    if (previous === next) {
+        return previous;
+    }
+
+    if (Array.isArray(previous) && Array.isArray(next)) {
+        return reconcileArray(previous, next) as T;
+    }
+
+    return deepEqual(previous, next) ? previous : next;
+}
+
+/**
+ * Reconciles two arrays element by element, preserving previous references for unchanged items.
+ * @param {unknown[]} previous The array currently held.
+ * @param {unknown[]} next The freshly received array.
+ * @returns {unknown[]} `previous` when the arrays are equivalent; otherwise a new array reusing unchanged items.
+ */
+function reconcileArray(previous: unknown[], next: unknown[]): unknown[] {
+    const previousByIdentity = new Map<unknown, unknown>();
+
+    for (const item of previous) {
+        const identity = getIdentity(item);
+
+        // Keep the first occurrence — duplicate identities are not a shape we can reconcile
+        // meaningfully, and preferring the first keeps the result deterministic.
+        if (identity !== undefined && !previousByIdentity.has(identity)) {
+            previousByIdentity.set(identity, item);
+        }
+    }
+
+    let changed = previous.length !== next.length;
+
+    const reconciled = next.map((item, index) => {
+        const identity = getIdentity(item);
+        const candidate = identity !== undefined ? previousByIdentity.get(identity) : previous[index];
+
+        if (candidate !== undefined && deepEqual(candidate, item)) {
+            // An unchanged item that moved still leaves the collection changed as a whole, but the
+            // item itself keeps its reference so only the ordering re-renders, not its content.
+            if (candidate !== previous[index]) {
+                changed = true;
+            }
+
+            return candidate;
+        }
+
+        changed = true;
+        return item;
+    });
+
+    return changed ? reconciled : previous;
+}


### PR DESCRIPTION
# Summary

Observable query connections were being torn down and rebuilt every few minutes on any app with live data. Each teardown re-subscribed every observable query and re-delivered every snapshot, which shows up in the UI as the whole page flickering while you work.

The cause was the two ends of the keep-alive contract disagreeing. The server only sent a keep-alive when a full interval had passed since its last message, but checked that on a fixed interval grid — so a data message landing mid-interval pushed the next keep-alive out by nearly another full interval. The SSE client, which treats silence as a dead connection, gave up before that keep-alive arrived and reconnected a connection the server considered perfectly healthy. The busier the connection, the more often it happened.

This fixes the reconnects, and separately makes the re-delivered snapshot that follows any reconnect cheap: the client now reconciles it against what it already holds, so only the items that actually changed re-render.

## Fixed

- Observable query connections no longer reconnect spuriously while data is flowing. The server now guarantees a message at least once per keep-alive interval instead of allowing gaps of up to twice the interval, so the SSE client stops tearing down healthy connections, re-subscribing every query and re-delivering every snapshot — which surfaced as UI flicker during normal use.
- Re-delivering a snapshot no longer re-renders everything. Incoming payloads are reconciled against the data already held, so items that did not change keep their object identity and only the items that actually changed re-render. An identical snapshot produces no update at all.
- Setting `Query.KeepAliveInterval` to a longer value no longer causes the SSE client to reconnect in a loop. The client now derives its idle threshold from the interval the server advertises rather than assuming the default.
- Disabling keep-alive by setting `Query.KeepAliveInterval` to zero or a negative value no longer leaves the SSE client reconnecting forever waiting for pings that were never going to come.

## Added

- `reconcileQueryData` in `@cratis/arc/queries`, which reconciles a freshly received payload against the previous one and preserves references for everything that did not change. Items are matched by their conventional `id`, falling back to position.

## Changed

- The `Connected` message on the observable query hub now carries the server's keep-alive interval so clients can align their idle detection with it.
- `ObservableQueryHubMessage.CreateConnected` now takes the keep-alive interval alongside the connection identifier. This type is the hub's wire protocol and is not constructed by application code, so no application-level change is needed.
