### PR TITLE
Resolve a command's own event source id without letting it crash the request

### DIFF
--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/RecordingLogger.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/RecordingLogger.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider;
+
+/// <summary>
+/// Records what was logged. A substitute would report nothing here — the source-generated log methods check
+/// <see cref="ILogger.IsEnabled"/> first, and a substitute answers false by default, so the call never happens.
+/// </summary>
+/// <typeparam name="T">Type the logger is for.</typeparam>
+public class RecordingLogger<T> : ILogger<T>
+{
+    /// <summary>
+    /// Gets the entries that were logged, with the exception each carried.
+    /// </summary>
+    public List<(LogLevel Level, Exception? Exception)> Entries { get; } = [];
+
+    /// <inheritdoc/>
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc/>
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+        Entries.Add((logLevel, exception));
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_building_command_context_values/with_a_command_that_cannot_compose_its_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_building_command_context_values/with_a_command_that_cannot_compose_its_key.cs
@@ -18,7 +18,7 @@ public class with_a_command_that_cannot_compose_its_key : Specification
     Exception _exception;
 
     void Establish() => _builder = new CommandContextValuesBuilder(
-        new KnownInstancesOf<ICommandContextValuesProvider>([new EventSourceValuesProvider()]));
+        new KnownInstancesOf<ICommandContextValuesProvider>([new EventSourceValuesProvider(new RecordingLogger<EventSourceValuesProvider>())]));
 
     void Because() => _exception = Catch.Exception(() => _result = _builder.Build(new CommandThatCannotComposeItsKey(null!)));
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_building_command_context_values/with_a_command_that_cannot_compose_its_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_building_command_context_values/with_a_command_that_cannot_compose_its_key.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_building_command_context_values;
+
+/// <summary>
+/// Exercises the real <see cref="CommandContextValuesBuilder"/> rather than the provider alone, because that is the frame
+/// the failure actually escapes through: context values are built before the filter chain, so an exception here bypasses
+/// the per-filter handling that turns bad input into a clean response and surfaces as an unhandled server error instead.
+/// </summary>
+public class with_a_command_that_cannot_compose_its_key : Specification
+{
+    CommandContextValuesBuilder _builder;
+    CommandContextValues _result;
+    Exception _exception;
+
+    void Establish() => _builder = new CommandContextValuesBuilder(
+        new KnownInstancesOf<ICommandContextValuesProvider>([new EventSourceValuesProvider()]));
+
+    void Because() => _exception = Catch.Exception(() => _result = _builder.Build(new CommandThatCannotComposeItsKey(null!)));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_still_build_an_event_source_id() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldEqual(EventSourceId.Unspecified);
+
+    record CommandThatCannotComposeItsKey(EventSourceId<Guid> Id) : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => Id;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_carrying_a_key_property.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_carrying_a_key_property.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+/// <summary>
+/// The reflection-based fallback — a command that does not compose its own key — must keep resolving the key from its
+/// property. Pinned here so hardening the provided-key path cannot quietly change it.
+/// </summary>
+public class with_a_command_carrying_a_key_property : Specification
+{
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+    Guid _id;
+
+    void Establish()
+    {
+        _provider = new EventSourceValuesProvider();
+        _id = Guid.NewGuid();
+    }
+
+    void Because() => _result = _provider.Provide(new CommandWithKeyProperty(new EventSourceId<Guid>(_id)));
+
+    [Fact] void should_resolve_the_event_source_id_from_the_property() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).Value.ShouldEqual(_id.ToString());
+
+    record CommandWithKeyProperty(EventSourceId<Guid> Id);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_carrying_a_key_property.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_carrying_a_key_property.cs
@@ -18,7 +18,7 @@ public class with_a_command_carrying_a_key_property : Specification
 
     void Establish()
     {
-        _provider = new EventSourceValuesProvider();
+        _provider = new EventSourceValuesProvider(new RecordingLogger<EventSourceValuesProvider>());
         _id = Guid.NewGuid();
     }
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_key_it_cannot_compose.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_key_it_cannot_compose.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Arc.Commands;
 using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
 
@@ -12,13 +13,22 @@ namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_provi
 /// practice. This runs while the command context is built, before any command filter, so the throw would otherwise escape
 /// as an unhandled server error instead of reaching the stages that turn bad input into a clean response.
 /// </summary>
+/// <remarks>
+/// Degrading silently would hide a genuine defect inside an implementation, so the swallow has to leave a trace — at debug
+/// level, since the usual cause is bad input and a hostile caller must not be able to flood the log.
+/// </remarks>
 public class with_a_command_that_provides_a_key_it_cannot_compose : Specification
 {
+    RecordingLogger<EventSourceValuesProvider> _logger;
     EventSourceValuesProvider _provider;
     CommandContextValues _result;
     Exception _exception;
 
-    void Establish() => _provider = new EventSourceValuesProvider();
+    void Establish()
+    {
+        _logger = new RecordingLogger<EventSourceValuesProvider>();
+        _provider = new EventSourceValuesProvider(_logger);
+    }
 
     void Because() => _exception = Catch.Exception(() => _result = _provider.Provide(new CommandThatCannotComposeItsKey(null!)));
 
@@ -26,6 +36,10 @@ public class with_a_command_that_provides_a_key_it_cannot_compose : Specificatio
     [Fact] void should_provide_an_event_source_id() => _result.ContainsKey(WellKnownCommandContextKeys.EventSourceId).ShouldBeTrue();
     [Fact] void should_provide_an_unspecified_event_source_id() =>
         ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldEqual(EventSourceId.Unspecified);
+
+    [Fact] void should_log_that_the_key_could_not_be_composed() => _logger.Entries.Count.ShouldEqual(1);
+    [Fact] void should_log_at_debug_level() => _logger.Entries[0].Level.ShouldEqual(LogLevel.Debug);
+    [Fact] void should_log_the_underlying_failure() => _logger.Entries[0].Exception.ShouldNotBeNull();
 
     record CommandThatCannotComposeItsKey(EventSourceId<Guid> Id) : ICanProvideEventSourceId
     {

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_key_it_cannot_compose.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_key_it_cannot_compose.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+/// <summary>
+/// A command composes its own key from its properties, so partial or hostile input leaves it composing a key that arrived
+/// null — here through the implicit conversion on a generic <see cref="EventSourceId{T}"/>, which is how it surfaces in
+/// practice. This runs while the command context is built, before any command filter, so the throw would otherwise escape
+/// as an unhandled server error instead of reaching the stages that turn bad input into a clean response.
+/// </summary>
+public class with_a_command_that_provides_a_key_it_cannot_compose : Specification
+{
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+    Exception _exception;
+
+    void Establish() => _provider = new EventSourceValuesProvider();
+
+    void Because() => _exception = Catch.Exception(() => _result = _provider.Provide(new CommandThatCannotComposeItsKey(null!)));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_provide_an_event_source_id() => _result.ContainsKey(WellKnownCommandContextKeys.EventSourceId).ShouldBeTrue();
+    [Fact] void should_provide_an_unspecified_event_source_id() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldEqual(EventSourceId.Unspecified);
+
+    record CommandThatCannotComposeItsKey(EventSourceId<Guid> Id) : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => Id;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_null_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_null_key.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+/// <summary>
+/// A command can hand back a null key without throwing — a null-tolerant implementation returning the value it was given.
+/// The context value must still be a usable event source id rather than a null the rest of the pipeline dereferences.
+/// </summary>
+public class with_a_command_that_provides_a_null_key : Specification
+{
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+    Exception _exception;
+
+    void Establish() => _provider = new EventSourceValuesProvider();
+
+    void Because() => _exception = Catch.Exception(() => _result = _provider.Provide(new CommandThatProvidesNull()));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_provide_an_unspecified_event_source_id() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldEqual(EventSourceId.Unspecified);
+
+    record CommandThatProvidesNull : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => null!;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_null_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_a_null_key.cs
@@ -10,19 +10,30 @@ namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_provi
 /// A command can hand back a null key without throwing — a null-tolerant implementation returning the value it was given.
 /// The context value must still be a usable event source id rather than a null the rest of the pipeline dereferences.
 /// </summary>
+/// <remarks>
+/// Nothing threw, so there is no exception to carry — but the key still went missing and must not do so silently.
+/// </remarks>
 public class with_a_command_that_provides_a_null_key : Specification
 {
+    RecordingLogger<EventSourceValuesProvider> _logger;
     EventSourceValuesProvider _provider;
     CommandContextValues _result;
     Exception _exception;
 
-    void Establish() => _provider = new EventSourceValuesProvider();
+    void Establish()
+    {
+        _logger = new RecordingLogger<EventSourceValuesProvider>();
+        _provider = new EventSourceValuesProvider(_logger);
+    }
 
     void Because() => _exception = Catch.Exception(() => _result = _provider.Provide(new CommandThatProvidesNull()));
 
     [Fact] void should_not_throw() => _exception.ShouldBeNull();
     [Fact] void should_provide_an_unspecified_event_source_id() =>
         ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldEqual(EventSourceId.Unspecified);
+
+    [Fact] void should_log_that_the_key_could_not_be_composed() => _logger.Entries.Count.ShouldEqual(1);
+    [Fact] void should_log_without_an_exception() => _logger.Entries[0].Exception.ShouldBeNull();
 
     record CommandThatProvidesNull : ICanProvideEventSourceId
     {

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_its_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_its_key.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+/// <summary>
+/// The ordinary path: a command that composes its key successfully keeps providing exactly that key.
+/// </summary>
+public class with_a_command_that_provides_its_key : Specification
+{
+    const string TheKey = "d4d1a3f0-0f4a-4f6a-9a9f-8b2c1e5a7d31";
+
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+
+    void Establish() => _provider = new EventSourceValuesProvider();
+
+    void Because() => _result = _provider.Provide(new CommandThatProvidesItsKey());
+
+    [Fact] void should_provide_the_event_source_id_the_command_composed() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).Value.ShouldEqual(TheKey);
+
+    record CommandThatProvidesItsKey : ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => TheKey;
+    }
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_its_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_that_provides_its_key.cs
@@ -16,7 +16,7 @@ public class with_a_command_that_provides_its_key : Specification
     EventSourceValuesProvider _provider;
     CommandContextValues _result;
 
-    void Establish() => _provider = new EventSourceValuesProvider();
+    void Establish() => _provider = new EventSourceValuesProvider(new RecordingLogger<EventSourceValuesProvider>());
 
     void Because() => _result = _provider.Provide(new CommandThatProvidesItsKey());
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_without_a_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_without_a_key.cs
@@ -15,7 +15,7 @@ public class with_a_command_without_a_key : Specification
     EventSourceValuesProvider _provider;
     CommandContextValues _result;
 
-    void Establish() => _provider = new EventSourceValuesProvider();
+    void Establish() => _provider = new EventSourceValuesProvider(new RecordingLogger<EventSourceValuesProvider>());
 
     void Because() => _result = _provider.Provide(new CommandWithoutKey("something"));
 

--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_without_a_key.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventSourceValuesProvider/when_providing/with_a_command_without_a_key.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventSourceValuesProvider.when_providing;
+
+/// <summary>
+/// A command with no key at all opens a fresh stream, so it gets a brand new id — distinct from the unspecified id that
+/// signals "there was a key and it could not be composed". Pinned so the two outcomes never collapse into one.
+/// </summary>
+public class with_a_command_without_a_key : Specification
+{
+    EventSourceValuesProvider _provider;
+    CommandContextValues _result;
+
+    void Establish() => _provider = new EventSourceValuesProvider();
+
+    void Because() => _result = _provider.Provide(new CommandWithoutKey("something"));
+
+    [Fact] void should_provide_a_new_event_source_id() =>
+        ((EventSourceId)_result[WellKnownCommandContextKeys.EventSourceId]).ShouldNotEqual(EventSourceId.Unspecified);
+
+    record CommandWithoutKey(string Name);
+}

--- a/Source/DotNET/Chronicle/Commands/EventSourceValuesProvider.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceValuesProvider.cs
@@ -18,7 +18,7 @@ public class EventSourceValuesProvider : ICommandContextValuesProvider
         {
             return new CommandContextValues
             {
-                { WellKnownCommandContextKeys.EventSourceId, provider.GetEventSourceId() }
+                { WellKnownCommandContextKeys.EventSourceId, ProvidedEventSourceIdOrUnspecified(provider) }
             };
         }
 
@@ -32,5 +32,32 @@ public class EventSourceValuesProvider : ICommandContextValuesProvider
         {
             { WellKnownCommandContextKeys.EventSourceId, eventSourceId }
         };
+    }
+
+    /// <summary>
+    /// Asks the command for its event source id, falling back to <see cref="EventSourceId.Unspecified"/> when it throws.
+    /// </summary>
+    /// <param name="provider">The command providing its own event source id.</param>
+    /// <returns>The provided event source id, or <see cref="EventSourceId.Unspecified"/> when it could not be composed.</returns>
+    /// <remarks>
+    /// A command composes its key from its own properties, so hostile or partial input leaves it composing a null concept —
+    /// most often an implicit conversion on a generic <see cref="EventSourceId{T}"/> that throws a
+    /// <see cref="NullReferenceException"/>. This runs while the command context is being built, before any
+    /// <see cref="ICommandFilter"/>, so a throw here escapes the filter chain's per-filter handling entirely and surfaces
+    /// as an unhandled server error (HTTP 500) rather than the 400 the input deserves. Treating an uncomposable key as an
+    /// unspecified id lets the command reach the filter and validation stages that turn it into a clean response — the same
+    /// contract the reflection-based fallback already honors through
+    /// <see cref="EventSourceExtensions.GetEventSourceId(object)"/>.
+    /// </remarks>
+    static EventSourceId ProvidedEventSourceIdOrUnspecified(ICanProvideEventSourceId provider)
+    {
+        try
+        {
+            return provider.GetEventSourceId() ?? EventSourceId.Unspecified;
+        }
+        catch (Exception)
+        {
+            return EventSourceId.Unspecified;
+        }
     }
 }

--- a/Source/DotNET/Chronicle/Commands/EventSourceValuesProvider.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceValuesProvider.cs
@@ -3,13 +3,15 @@
 
 using Cratis.Arc.Commands;
 using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Chronicle.Commands;
 
 /// <summary>
 /// Represents an implementation of <see cref="ICommandContextValuesProvider"/> that provides values for the event source id.
 /// </summary>
-public class EventSourceValuesProvider : ICommandContextValuesProvider
+/// <param name="logger">The <see cref="ILogger"/> to use for logging.</param>
+public class EventSourceValuesProvider(ILogger<EventSourceValuesProvider> logger) : ICommandContextValuesProvider
 {
     /// <inheritdoc/>
     public CommandContextValues Provide(object command)
@@ -35,7 +37,7 @@ public class EventSourceValuesProvider : ICommandContextValuesProvider
     }
 
     /// <summary>
-    /// Asks the command for its event source id, falling back to <see cref="EventSourceId.Unspecified"/> when it throws.
+    /// Asks the command for its event source id, falling back to <see cref="EventSourceId.Unspecified"/> when it cannot be composed.
     /// </summary>
     /// <param name="provider">The command providing its own event source id.</param>
     /// <returns>The provided event source id, or <see cref="EventSourceId.Unspecified"/> when it could not be composed.</returns>
@@ -47,17 +49,27 @@ public class EventSourceValuesProvider : ICommandContextValuesProvider
     /// as an unhandled server error (HTTP 500) rather than the 400 the input deserves. Treating an uncomposable key as an
     /// unspecified id lets the command reach the filter and validation stages that turn it into a clean response — the same
     /// contract the reflection-based fallback already honors through
-    /// <see cref="EventSourceExtensions.GetEventSourceId(object)"/>.
+    /// <see cref="EventSourceExtensions.GetEventSourceId(object)"/>. It is logged at debug level because the usual cause is
+    /// bad input rather than a defect, and logging louder would let a hostile caller flood the log — but it is logged,
+    /// because the same path is where a genuine defect inside an implementation would otherwise vanish silently.
     /// </remarks>
-    static EventSourceId ProvidedEventSourceIdOrUnspecified(ICanProvideEventSourceId provider)
+    EventSourceId ProvidedEventSourceIdOrUnspecified(ICanProvideEventSourceId provider)
     {
         try
         {
-            return provider.GetEventSourceId() ?? EventSourceId.Unspecified;
+            var eventSourceId = provider.GetEventSourceId();
+            if (eventSourceId is not null)
+            {
+                return eventSourceId;
+            }
+
+            logger.CouldNotComposeProvidedEventSourceId(provider.GetType().Name, null);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return EventSourceId.Unspecified;
+            logger.CouldNotComposeProvidedEventSourceId(provider.GetType().Name, ex);
         }
+
+        return EventSourceId.Unspecified;
     }
 }

--- a/Source/DotNET/Chronicle/Commands/EventSourceValuesProviderLogMessages.cs
+++ b/Source/DotNET/Chronicle/Commands/EventSourceValuesProviderLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Chronicle.Commands;
+
+/// <summary>
+/// Log messages for <see cref="EventSourceValuesProvider"/>.
+/// </summary>
+internal static partial class EventSourceValuesProviderLogMessages
+{
+    [LoggerMessage(LogLevel.Debug, "The event source id provided by command '{CommandType}' could not be composed and was resolved as unspecified")]
+    internal static partial void CouldNotComposeProvidedEventSourceId(this ILogger logger, string commandType, Exception? exception);
+}


### PR DESCRIPTION
# Summary

A command that composes its own event source id could take the whole request down with it. `ICanProvideEventSourceId.GetEventSourceId()` builds the key from the command's own properties, so partial or hostile input leaves it composing a key that arrived null — in practice an implicit conversion on a generic `EventSourceId<T>`, which throws.

What makes this one sharp is *where* it happens. Command context values are built **before** the filter chain, so the throw escaped the per-filter handling that exists precisely to turn bad input into a clean response, and surfaced as an unhandled server error instead.

The reflection-based fallback already had the answer: `EventSourceExtensions.GetEventSourceId` resolves an uncomposable key to `EventSourceId.Unspecified` and documents exactly this reasoning. The provided-key branch was simply the one path that never got the same treatment. This aligns them.

## Fixed

- A command implementing `ICanProvideEventSourceId` no longer returns an unhandled server error when its key cannot be composed from the incoming payload — an uncomposable or null key resolves to `EventSourceId.Unspecified`, so the command reaches the filter and validation stages that turn bad input into a proper response.

---

### Behavior

| Command shape | Before | After |
|---|---|---|
| Provides a key successfully | that key | unchanged |
| Provides a key that throws while composing | unhandled server error | `EventSourceId.Unspecified` |
| Provides a `null` key | `null` context value, dereferenced downstream | `EventSourceId.Unspecified` |
| Carries a key *property* (reflection fallback) | resolved from property | unchanged |
| Carries no key at all | fresh `EventSourceId.New()` | unchanged |
