### PR TITLE
Client-side validation rules actually reach generated proxies, and a generic read model method is no longer a query

### DIFF
--- a/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ReadModelAnalyzer/when_readmodel_has_a_generic_query_shaped_method.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis.Specs/for_ReadModelAnalyzer/when_readmodel_has_a_generic_query_shaped_method.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = Cratis.Arc.CodeAnalysis.Specs.Testing.AnalyzerVerifier<Cratis.Arc.CodeAnalysis.ReadModelAnalyzer>;
+
+namespace Cratis.Arc.CodeAnalysis.for_ReadModelAnalyzer;
+
+public class when_readmodel_has_a_generic_query_shaped_method
+{
+    [Fact] async Task should_report_diagnostic_for_an_internal_generic_helper() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Collections.Generic;
+using Cratis.Arc.Queries.ModelBound;
+
+namespace TestNamespace
+{
+    [ReadModel]
+    public class TestReadModel
+    {
+        internal static {|#0:IEnumerable<TestReadModel> CountOf<TDocument>(IEnumerable<TDocument> source)|} => null;
+    }
+}",
+        VerifyCS.Diagnostic("ARC0014")
+            .WithLocation(0)
+            .WithArguments("CountOf", "TestReadModel"));
+
+    [Fact] async Task should_not_report_diagnostic_for_a_non_generic_query() => await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Collections.Generic;
+using Cratis.Arc.Queries.ModelBound;
+
+namespace TestNamespace
+{
+    [ReadModel]
+    public class TestReadModel
+    {
+        public static IEnumerable<TestReadModel> All() => null;
+    }
+}");
+}

--- a/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/AnalyzerReleases.Unshipped.md
@@ -14,3 +14,4 @@ ARC0010|Arc|Warning|Command Handle() wraps a synchronous result in a Task
 ARC0011|Arc|Warning|[Roles] argument should use nameof instead of a string literal
 ARC0012|Arc|Warning|Arc artifact throws a built-in exception type
 ARC0013|Arc|Warning|Validator rule dereferences a possibly-null concept member
+ARC0014|Arc|Error|Generic query method on ReadModel

--- a/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/DiagnosticDescriptors.cs
@@ -166,5 +166,17 @@ static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A FluentValidation rule selector that dereferences a member of a ConceptAs<T> property assumes the concept is non-null. Because model-bound input can be deserialized with a null concept, the rule throws a NullReferenceException at validation time instead of producing a validation error. Validate the concept itself first (when it is required) or guard the rule with a null check (when it is optional), so invalid input is reported as a validation failure rather than crashing.");
 
+    /// <summary>
+    /// ARC0014: Generic query method on ReadModel.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ARC0014_QueryMethodCannotBeGeneric = new(
+        id: "ARC0014",
+        title: "Generic query method on ReadModel",
+        messageFormat: "Method '{0}' on ReadModel '{1}' returns a query shape but is generic, so it can never be invoked as a query. Make it non-generic, or move it off the ReadModel if it is a composition helper.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A static method on a read model is discovered as a query by its return type alone, so a generic composition helper that happens to return the read model's query shape is registered and routed as an endpoint. A query is invoked with arguments resolved from the request, which leaves nothing to close the method's type parameters with, so every call fails. Make the method non-generic, or move it off the read model.");
+
     const string Category = "Arc";
 }

--- a/Source/DotNET/Arc.Core.CodeAnalysis/ReadModelAnalyzer.cs
+++ b/Source/DotNET/Arc.Core.CodeAnalysis/ReadModelAnalyzer.cs
@@ -15,7 +15,8 @@ public class ReadModelAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
-            DiagnosticDescriptors.ARC0001_IncorrectQueryMethodSignature
+            DiagnosticDescriptors.ARC0001_IncorrectQueryMethodSignature,
+            DiagnosticDescriptors.ARC0014_QueryMethodCannotBeGeneric
         ];
 
     /// <inheritdoc/>
@@ -66,6 +67,16 @@ public class ReadModelAnalyzer : DiagnosticAnalyzer
                     context.ReportDiagnostic(diagnostic);
                 }
             }
+
+            foreach (var method in FindGenericQueryShapedMethods(namedTypeSymbol))
+            {
+                var diagnostic = Diagnostic.Create(
+                    DiagnosticDescriptors.ARC0014_QueryMethodCannotBeGeneric,
+                    method.Locations[0],
+                    method.Name,
+                    namedTypeSymbol.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
         }
     }
 
@@ -83,6 +94,27 @@ public class ReadModelAnalyzer : DiagnosticAnalyzer
                        m.IsStatic &&
                        m.DeclaredAccessibility == Accessibility.Public &&
                        !m.ReturnsVoid);
+    }
+
+    /// <summary>
+    /// Finds the methods a read model would have registered as queries had they not been generic.
+    /// </summary>
+    /// <param name="typeSymbol">The read model to inspect.</param>
+    /// <returns>The generic methods carrying a query-shaped return type.</returns>
+    /// <remarks>
+    /// Deliberately wider than <see cref="FindPotentialQueryMethods"/>, which only looks at public methods: query
+    /// discovery registers internal methods too, so an internal generic helper is just as routable — and just as
+    /// broken — as a public one.
+    /// </remarks>
+    static IEnumerable<IMethodSymbol> FindGenericQueryShapedMethods(INamedTypeSymbol typeSymbol)
+    {
+        return typeSymbol.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(m => m.MethodKind == MethodKind.Ordinary &&
+                       m.IsStatic &&
+                       m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal &&
+                       m.TypeParameters.Length > 0 &&
+                       IsValidQueryMethodSignature(m, typeSymbol));
     }
 
     static bool IsValidQueryMethodSignature(IMethodSymbol method, INamedTypeSymbol readModelType)

--- a/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
+++ b/Source/DotNET/Arc.Core.Generators/QueryMetadataGenerator.cs
@@ -55,6 +55,7 @@ public class QueryMetadataGenerator : IIncrementalGenerator
             .Where(m =>
                 m.MethodKind == MethodKind.Ordinary &&
                 m.IsStatic &&
+                m.TypeParameters.Length == 0 &&
                 IsSupportedQueryMethodAccessibility(m) &&
                 IsValidQueryMethod(m, typeSymbol))
             .Select(m => m.Name)

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/GenericQueries.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/GenericQueries.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+#pragma warning disable SA1649 // File name should match first type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Cratis.Arc.Queries.ModelBound;
+
+/// <summary>
+/// A read model whose only generic method is a composition helper for its real queries - the shape that reaches
+/// query discovery as a false positive, because its return type is indistinguishable from a query's.
+/// </summary>
+[ReadModel]
+public class ReadModelWithGenericHelper
+{
+    public int Count { get; set; }
+
+    public static ISubject<ReadModelWithGenericHelper> Totals(ISubject<IEnumerable<string>> source) =>
+        CountOf(source);
+
+    internal static ISubject<ReadModelWithGenericHelper> CountOf<TDocument>(ISubject<IEnumerable<TDocument>> source) =>
+        Subject.Create<ReadModelWithGenericHelper>(
+            Observer.Create<ReadModelWithGenericHelper>(_ => { }),
+            source.Select(documents => new ReadModelWithGenericHelper { Count = documents.Count() }));
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_constructing_with_a_generic_method.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ModelBoundQueryPerformer/when_constructing_with_a_generic_method.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Arc.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.ModelBound.for_ModelBoundQueryPerformer;
+
+/// <summary>
+/// Discovery is not the only way a performer gets built, so the performer itself refuses a method it could never
+/// invoke - at wire-up, where the offending method is named, rather than per request with a bare reflection message.
+/// </summary>
+public class when_constructing_with_a_generic_method : Specification
+{
+    MethodInfo _method;
+    ModelBoundQueryPerformer _performer;
+    Exception _exception;
+
+    void Establish() => _method = typeof(ReadModelWithGenericHelper)
+        .GetMethod(nameof(ReadModelWithGenericHelper.CountOf), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    void Because() => _exception = Catch.Exception(() => _performer = new ModelBoundQueryPerformer(
+        typeof(ReadModelWithGenericHelper),
+        typeof(ReadModelWithGenericHelper).FullName!,
+        _method,
+        Substitute.For<IServiceProviderIsService>(),
+        Substitute.For<IAuthorizationEvaluator>()));
+
+    [Fact] void should_refuse_the_method() => _exception.ShouldBeOfExactType<QueryMethodCannotBeGeneric>();
+    [Fact] void should_name_the_offending_method() => ((QueryMethodCannotBeGeneric)_exception).Method.ShouldEqual(_method);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_a_generic_query_shaped_method.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_QueryPerformerProvider/when_initializing_with_a_generic_query_shaped_method.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.ModelBound.for_QueryPerformerProvider;
+
+/// <summary>
+/// A generic helper on a read model returns the same shape its real queries do, so return type alone cannot tell
+/// them apart. Registering it would route an endpoint that can only ever fail, since a query is invoked with
+/// arguments resolved from the request and there is nothing to close its type parameters with.
+/// </summary>
+public class when_initializing_with_a_generic_query_shaped_method : Specification
+{
+    QueryPerformerProvider _provider;
+    ITypes _types;
+    IQueryMetadataRegistry _registry;
+    IServiceProviderIsService _serviceProviderIsService;
+    IAuthorizationEvaluator _authorizationEvaluator;
+
+    void Establish()
+    {
+        _types = Substitute.For<ITypes>();
+        _types.All.Returns([typeof(ReadModelWithGenericHelper)]);
+        _serviceProviderIsService = Substitute.For<IServiceProviderIsService>();
+        _authorizationEvaluator = Substitute.For<IAuthorizationEvaluator>();
+
+        _registry = Substitute.For<IQueryMetadataRegistry>();
+        _registry.All.Returns(new Dictionary<string, Type>());
+    }
+
+    void Because() => _provider = new QueryPerformerProvider(_types, _registry, _serviceProviderIsService, _authorizationEvaluator);
+
+    [Fact] void should_only_register_the_non_generic_query() => _provider.Performers.Select(_ => _.Name.Value).ShouldContainOnly(nameof(ReadModelWithGenericHelper.Totals));
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ReadModelExtensions/when_checking_a_generic_method_with_a_query_shaped_return_type.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/ModelBound/for_ReadModelExtensions/when_checking_a_generic_method_with_a_query_shaped_return_type.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.Queries.ModelBound.for_ReadModelExtensions;
+
+/// <summary>
+/// The predicate every discovery path shares. Its verdict is what decides whether a method becomes a routed
+/// endpoint, so a generic method has to be rejected here rather than at the invocation that would fail.
+/// </summary>
+public class when_checking_a_generic_method_with_a_query_shaped_return_type : Specification
+{
+    bool _genericIsValid;
+    bool _nonGenericIsValid;
+
+    void Because()
+    {
+        _genericIsValid = typeof(ReadModelWithGenericHelper)
+            .GetMethod(nameof(ReadModelWithGenericHelper.CountOf), BindingFlags.NonPublic | BindingFlags.Static)!
+            .IsValidQueryFor(typeof(ReadModelWithGenericHelper));
+
+        _nonGenericIsValid = typeof(ReadModelWithGenericHelper)
+            .GetMethod(nameof(ReadModelWithGenericHelper.Totals), BindingFlags.Public | BindingFlags.Static)!
+            .IsValidQueryFor(typeof(ReadModelWithGenericHelper));
+    }
+
+    [Fact] void should_not_consider_the_generic_method_a_query() => _genericIsValid.ShouldBeFalse();
+    [Fact] void should_still_consider_the_non_generic_method_a_query() => _nonGenericIsValid.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/ModelBoundQueryPerformer.cs
@@ -27,8 +27,16 @@ public class ModelBoundQueryPerformer : IQueryPerformer
     /// <param name="performMethod">The method info of the perform method.</param>
     /// <param name="serviceProviderIsService">Service to determine if a type is registered as a service.</param>
     /// <param name="authorizationEvaluator">The authorization evaluator.</param>
+    /// <exception cref="QueryMethodCannotBeGeneric">Thrown when <paramref name="performMethod"/> is generic.</exception>
     public ModelBoundQueryPerformer(Type readModelType, string readModelTypeName, MethodInfo performMethod, IServiceProviderIsService serviceProviderIsService, IAuthorizationEvaluator authorizationEvaluator)
     {
+        // Fail while wiring up rather than on every request: invoking an open generic throws a bare BCL message that
+        // says nothing about which read model method is at fault.
+        if (performMethod.ContainsGenericParameters)
+        {
+            throw new QueryMethodCannotBeGeneric(performMethod);
+        }
+
         Type = readModelType;
         ReadModelType = readModelType;
         Name = performMethod.Name;

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/QueryMethodCannotBeGeneric.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/QueryMethodCannotBeGeneric.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.Queries.ModelBound;
+
+/// <summary>
+/// The exception that is thrown when a query method still carries unbound type parameters.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="QueryMethodCannotBeGeneric"/> class.
+/// </remarks>
+/// <param name="method">The method that cannot be used as a query.</param>
+public class QueryMethodCannotBeGeneric(MethodInfo method)
+    : Exception($"Query method '{method.DeclaringType?.FullName}.{method.Name}' is generic and can therefore never be invoked - a query is invoked with arguments resolved from the request, which leaves nothing to close its type parameters with")
+{
+    /// <summary>
+    /// Gets the method that cannot be used as a query.
+    /// </summary>
+    public MethodInfo Method { get; } = method;
+}

--- a/Source/DotNET/Arc.Core/Queries/ModelBound/ReadModelExtensions.cs
+++ b/Source/DotNET/Arc.Core/Queries/ModelBound/ReadModelExtensions.cs
@@ -27,6 +27,14 @@ public static class ReadModelExtensions
     /// <returns>True if the method qualifies as a query performer; otherwise, false.</returns>
     public static bool IsValidQueryFor(this MethodInfo method, Type readModelType)
     {
+        // A query is invoked late-bound with arguments resolved from the request, so there is nothing to close an
+        // open generic with. Read models routinely carry generic composition helpers that return the very shapes a
+        // query returns, and the return type alone cannot tell those apart from a query.
+        if (method.ContainsGenericParameters)
+        {
+            return false;
+        }
+
         var returnType = method.ReturnType;
 
         if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))

--- a/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/ProxyGenerator.Build.csproj
@@ -16,6 +16,15 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!--
+            Reading FluentValidation rules means running a validator's constructor, which loads the target project's
+            own assembly for real. Targets are ASP.NET applications, so without the shared framework here that load
+            fails on the target's Microsoft.AspNetCore.* references.
+        -->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Content Include="build\*" PackagePath="build\;buildTransitive\" />
     </ItemGroup>
 

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/TestValidators.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Commands;
 using Cratis.Arc.Validation;
 using Cratis.Concepts;
 using FluentValidation;
@@ -89,4 +90,34 @@ public class TestCommandWithConceptAndOwnValidator
 public class TestCommandWithConceptAndOwnValidatorValidator : BaseValidator<TestCommandWithConceptAndOwnValidator>
 {
     public TestCommandWithConceptAndOwnValidatorValidator() => RuleFor(x => x.Email).NotEmpty();
+}
+
+public record RecordEmail(string Value) : ConceptAs<string>(Value);
+
+public class RecordEmailValidator : ConceptValidator<RecordEmail>
+{
+    public const string InvalidMessage = "Must be a valid email address";
+
+    public RecordEmailValidator() =>
+        RuleFor(email => email.Value)
+            .NotEmpty()
+            .WithMessage(_ => InvalidMessage)
+            .EmailAddress()
+            .WithMessage(_ => InvalidMessage);
+}
+
+public enum RecordRole
+{
+    None = 0,
+    Administrator = 1
+}
+
+public record TestRecordCommandWithConcept(RecordEmail Email, RecordRole Role);
+
+public class TestRecordCommandWithConceptValidator : CommandValidator<TestRecordCommandWithConcept>
+{
+    public TestRecordCommandWithConceptValidator() =>
+        RuleFor(c => c.Role)
+            .Must(r => r is RecordRole.Administrator)
+            .WithMessage(_ => "Internal roles only");
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_rules_for_a_record_command_with_a_concept_property.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_rules_for_a_record_command_with_a_concept_property.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_ValidationRulesExtractor;
+
+/// <summary>
+/// The shape a model-bound command actually has: a positional record whose concept property is init-only, whose
+/// concept validator chains more than one rule behind lazily-resolved messages, and which carries its own command
+/// validator holding a rule the client cannot express. None of that may stop the concept's rules from reaching the
+/// client.
+/// </summary>
+public class when_extracting_rules_for_a_record_command_with_a_concept_property : Specification
+{
+    IEnumerable<PropertyValidationDescriptor> _result;
+
+    void Because() => _result = ValidationRulesExtractor.ExtractValidationRules(
+        typeof(TestRecordCommandWithConcept).Assembly,
+        typeof(TestRecordCommandWithConcept));
+
+    [Fact] void should_have_rules_for_the_owning_property() => _result.Select(_ => _.PropertyName).ShouldContain("email");
+    [Fact] void should_project_both_chained_concept_rules() => _result.Single(_ => _.PropertyName == "email").Rules.Select(_ => _.RuleName).ShouldContainOnly("notEmpty", "emailAddress");
+    [Fact] void should_carry_the_lazily_resolved_message() => _result.Single(_ => _.PropertyName == "email").Rules.Select(_ => _.ErrorMessage).Distinct().ShouldContainOnly(RecordEmailValidator.InvalidMessage);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_rules_from_a_metadata_only_assembly.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_ValidationRulesExtractor/when_extracting_rules_from_a_metadata_only_assembly.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_ValidationRulesExtractor;
+
+/// <summary>
+/// The generator never sees runtime types: <c>TypeExtensions.InitializeProjectAssemblies</c> loads every project
+/// assembly through a <see cref="MetadataLoadContext"/>, so this is the only world the extractor actually runs in.
+/// Rules that can only be read by instantiating a validator are therefore invisible in production even though every
+/// runtime-typed spec passes.
+/// </summary>
+public class when_extracting_rules_from_a_metadata_only_assembly : Specification
+{
+    MetadataLoadContext _context;
+    IEnumerable<PropertyValidationDescriptor> _fromCommandValidator;
+    IEnumerable<PropertyValidationDescriptor> _fromConceptValidator;
+
+    void Establish()
+    {
+        // Mirrors TypeExtensions.InitializeProjectAssemblies so the spec resolves exactly what the generator does.
+        var assemblyFile = typeof(TestCommand).Assembly.Location;
+        var runtimeDirectory = Path.GetDirectoryName(RuntimeEnvironment.GetRuntimeDirectory())!;
+        var version = Path.GetFileName(runtimeDirectory);
+        var shared = Directory.GetParent(Directory.GetParent(runtimeDirectory)!.FullName)!;
+        var aspNetCoreDirectory = Path.Combine(shared.FullName, "Microsoft.AspNetCore.App", version);
+
+        string[] paths =
+        [
+            .. Directory.GetFiles(runtimeDirectory, "*.dll"),
+            .. Directory.GetFiles(aspNetCoreDirectory, "*.dll"),
+            .. Directory.GetFiles(Path.GetDirectoryName(assemblyFile)!, "*.dll")
+        ];
+
+        _context = new MetadataLoadContext(new PathAssemblyResolver(paths.Distinct(new FileNameComparer())));
+    }
+
+    void Because()
+    {
+        var assembly = _context.LoadFromAssemblyPath(typeof(TestCommand).Assembly.Location);
+        _fromCommandValidator = ValidationRulesExtractor.ExtractValidationRules(
+            assembly,
+            assembly.GetType(typeof(TestCommand).FullName!)!);
+        _fromConceptValidator = ValidationRulesExtractor.ExtractValidationRules(
+            assembly,
+            assembly.GetType(typeof(TestCommandWithConcept).FullName!)!);
+    }
+
+    void Destroy() => _context.Dispose();
+
+    [Fact] void should_extract_the_rules_declared_on_the_command_validator() => _fromCommandValidator.Select(_ => _.PropertyName).ShouldContain("name");
+    [Fact] void should_extract_the_rules_contributed_by_a_concept_validator() => _fromConceptValidator.Select(_ => _.PropertyName).ShouldContain("email");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/ModelBound/TypeExtensionsModelBound.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ModelBound/TypeExtensionsModelBound.cs
@@ -70,6 +70,13 @@ public static class TypeExtensionsModelBound
     /// <returns>True if the method qualifies as a query performer; otherwise, false.</returns>
     public static bool IsValidQueryFor(this MethodInfo method, Type readModelType)
     {
+        // Mirrors the runtime predicate in Cratis.Arc.Queries.ModelBound.ReadModelExtensions: an open generic method
+        // can never be invoked as a query, so emitting a client for it would promise a call that always fails.
+        if (method.ContainsGenericParameters)
+        {
+            return false;
+        }
+
         var returnType = method.ReturnType;
 
         if (returnType.IsGenericType &&

--- a/Source/DotNET/Tools/ProxyGenerator/RuntimeValidatorAssemblies.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/RuntimeValidatorAssemblies.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator;
+
+/// <summary>
+/// Provides executable counterparts of the metadata-only types the generator walks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Proxy generation inspects the target project through a <see cref="System.Reflection.MetadataLoadContext"/>, whose
+/// types carry no executable code. FluentValidation declares its rules imperatively in a validator's constructor, so
+/// the only way to read them is to run that constructor - which needs a real, loadable type. This resolves the same
+/// type in the default load context, leaving every other part of generation on the metadata types it already uses.
+/// </para>
+/// <para>
+/// Deliberately the default context rather than a private one: a second context would give the process a second copy
+/// of every type in the target assembly, and anything that scans loaded assemblies - convention-based dependency
+/// injection, most notably - then sees each of them twice.
+/// </para>
+/// </remarks>
+public static class RuntimeValidatorAssemblies
+{
+    static readonly Dictionary<string, Assembly?> _assembliesByLocation = [];
+
+    /// <summary>
+    /// Guards the cache. Deliberately an <see cref="object"/> rather than <c>System.Threading.Lock</c>, which the
+    /// net8.0 target this also compiles for does not have.
+    /// </summary>
+    static readonly object _lock = new();
+
+    /// <summary>
+    /// Get the executable counterpart of an assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to resolve.</param>
+    /// <returns>The loadable assembly, or <see langword="null"/> when it cannot be loaded.</returns>
+    public static Assembly? For(Assembly assembly)
+    {
+        var location = LocationOf(assembly);
+        if (location is null)
+        {
+            return null;
+        }
+
+        lock (_lock)
+        {
+            if (_assembliesByLocation.TryGetValue(location, out var loaded))
+            {
+                return loaded;
+            }
+
+            try
+            {
+                // Resolves to the already-loaded instance when there is one, so an assembly is never duplicated.
+                loaded = Assembly.LoadFrom(location);
+            }
+            catch (Exception)
+            {
+                // A project whose dependencies cannot be loaded simply contributes no rules, exactly as before.
+                // Failing generation over it would be worse than generating clients that validate less than the
+                // server.
+                loaded = null;
+            }
+
+            _assembliesByLocation[location] = loaded;
+            return loaded;
+        }
+    }
+
+    /// <summary>
+    /// Get the executable counterpart of a type.
+    /// </summary>
+    /// <param name="type">The type to resolve.</param>
+    /// <returns>The loadable type, or the type itself when it cannot be resolved.</returns>
+    public static Type For(Type type)
+    {
+        if (type.FullName is null)
+        {
+            return type;
+        }
+
+        try
+        {
+            return For(type.Assembly)?.GetType(type.FullName) ?? type;
+        }
+        catch (Exception)
+        {
+            return type;
+        }
+    }
+
+    static string? LocationOf(Assembly assembly)
+    {
+        try
+        {
+            return string.IsNullOrEmpty(assembly.Location) ? null : assembly.Location;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -217,7 +217,18 @@ public static class TypeExtensions
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         AssemblyLoadContext.Default.Resolving += (_, name) =>
-            _assembliesByName[name.Name!] = _assemblyResolver.Resolve(_metadataLoadContext, name)!;
+        {
+            // Caching the metadata-only assembly is the point here - IsAssignableTo<T> needs it to translate a
+            // runtime type into the metadata world. Handing it back is not: the default context accepts only runtime
+            // assemblies and throws "Resolved assembly must be a runtime Assembly object" on anything else, which
+            // would turn any genuine resolution miss into a hard failure.
+            if (_assemblyResolver.Resolve(_metadataLoadContext, name) is { } resolved)
+            {
+                _assembliesByName[name.Name!] = resolved;
+            }
+
+            return null;
+        };
 
         Assemblies = [.. dependencyContext.RuntimeLibraries
                                         .Where(_ => _.Type.Equals("project"))

--- a/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
@@ -25,6 +25,7 @@ public static class ValidationRulesExtractor
     const string ExactLengthValidatorType = "FluentValidation.Validators.IExactLengthValidator";
     const string ComparisonValidatorType = "FluentValidation.Validators.IComparisonValidator";
     const string RegularExpressionValidatorType = "FluentValidation.Validators.IRegularExpressionValidator";
+    const string ConceptAsType = "Cratis.Concepts.ConceptAs`1";
 
     /// <summary>
     /// Extract validation rules for a specific type using FluentValidation validators.
@@ -34,11 +35,16 @@ public static class ValidationRulesExtractor
     /// <returns>Collection of property validation descriptors.</returns>
     public static IEnumerable<PropertyValidationDescriptor> ExtractValidationRules(Assembly assembly, Type type)
     {
+        // A FluentValidation rule only exists once its validator's constructor has run, which a metadata-only type
+        // cannot do - see RuntimeValidatorAssemblies.
+        var runtimeAssembly = RuntimeValidatorAssemblies.For(assembly) ?? assembly;
+        var runtimeType = RuntimeValidatorAssemblies.For(type);
+
         // Try FluentValidation first
-        var fluentValidationRules = ExtractFluentValidationRules(assembly, type).ToList();
+        var fluentValidationRules = ExtractFluentValidationRules(runtimeAssembly, runtimeType).ToList();
 
         // Then the rules contributed by the validators of any concept-typed properties
-        var conceptRules = ExtractConceptRules(assembly, type).ToList();
+        var conceptRules = ExtractConceptRules(runtimeAssembly, runtimeType).ToList();
 
         // Then extract DataAnnotations
         var dataAnnotationsRules = ExtractDataAnnotationsRules(type).ToList();
@@ -90,12 +96,15 @@ public static class ValidationRulesExtractor
     /// </remarks>
     public static IReadOnlyList<ValidationRuleDescriptor> ExtractRulesForConceptType(Assembly assembly, Type type)
     {
-        if (!type.IsConcept())
+        var runtimeAssembly = RuntimeValidatorAssemblies.For(assembly) ?? assembly;
+        var runtimeType = RuntimeValidatorAssemblies.For(type);
+
+        if (!IsConcept(runtimeType))
         {
             return [];
         }
 
-        return [.. ExtractFluentValidationRules(assembly, type).SelectMany(_ => _.Rules)];
+        return [.. ExtractFluentValidationRules(runtimeAssembly, runtimeType).SelectMany(_ => _.Rules)];
     }
 
     /// <summary>
@@ -194,6 +203,29 @@ public static class ValidationRulesExtractor
         }
 
         return distinct;
+    }
+
+    /// <summary>
+    /// Check whether a type is a concept, by name rather than by type identity.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if the type derives from <c>ConceptAs&lt;T&gt;</c>; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// The types inspected here come from a load context of their own, so <c>typeof(ConceptAs&lt;&gt;)</c> as the
+    /// generator sees it is a different type from the one the target project derives from. Every other type test in
+    /// this class compares names for the same reason.
+    /// </remarks>
+    static bool IsConcept(Type type)
+    {
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition().FullName == ConceptAsType)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static List<ValidationRuleDescriptor> ExtractDataAnnotationsFromMember(PropertyInfo property)
@@ -603,6 +635,21 @@ public static class ValidationRulesExtractor
                 if (!string.IsNullOrEmpty(errorMessage))
                 {
                     return errorMessage;
+                }
+            }
+
+            // A message declared lazily - .WithMessage(_ => Messages.Something), the form a localized message takes -
+            // is held as a factory instead. Resolving it against no instance is enough for a factory that just
+            // returns a constant; one that reads the instance throws and is left unprojected rather than guessed at.
+            var errorMessageFactoryField = component.GetType()
+                .GetField("_errorMessageFactory", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (errorMessageFactoryField?.GetValue(component) is Delegate errorMessageFactory)
+            {
+                var arguments = new object?[errorMessageFactory.Method.GetParameters().Length];
+                if (errorMessageFactory.DynamicInvoke(arguments) is string factoryMessage && !string.IsNullOrEmpty(factoryMessage))
+                {
+                    return factoryMessage;
                 }
             }
 


### PR DESCRIPTION
### Added

- `ARC0014` analyzer diagnostic: a generic static method on a `[ReadModel]` whose return type matches a query shape is reported at compile time, since query discovery would register it as an endpoint that can never be invoked. It inspects internal methods as well as public ones, matching what discovery actually registers.
- `QueryMethodCannotBeGeneric`, thrown by `ModelBoundQueryPerformer`'s constructor, so a generic query method fails at wire-up naming the offending method rather than per request with a bare reflection message.

### Fixed

- **FluentValidation rules now reach generated client proxies.** No rule had ever been projected: generation walks the target project through a `MetadataLoadContext`, whose types carry no executable code, while a FluentValidation rule only exists once its validator's constructor has run — so instantiating the validator always threw, and the catch turned that into "no rules". Every extractor spec passed because they hand it runtime types, which the generator never has. Validator types are now resolved in the default load context and instantiated there. DataAnnotations were unaffected, being read from metadata.
- A validation message declared lazily — `.WithMessage(_ => Messages.Something)`, the form a localized message takes — is held as a factory rather than a string and was dropped. It is now resolved where it does not depend on the instance, and left unprojected rather than guessed at where it does.
- The proxy generator's `AssemblyLoadContext.Default` resolving hook handed back a metadata-only assembly, which throws `Resolved assembly must be a runtime Assembly object`. Caching that assembly is the point of the hook; returning it was not.
- A generic static method on a `[ReadModel]` is no longer discovered as a query. Discovery matches on return type alone, so a generic composition helper returning the read model's own query shape was registered, routed, and given a client proxy — and then every call failed with `Late bound operations cannot be performed on types or methods for which ContainsGenericParameters is true`. Rejected now at the shared runtime predicate, its copy in the proxy generator, and the metadata generator.

### Changed

- `Cratis.Arc.ProxyGenerator.Build` takes a framework reference on `Microsoft.AspNetCore.App`. Reading validation rules loads the target project's own assembly for real, and targets are ASP.NET applications, so that load fails without the shared framework.

---

Verified end to end against a real application's assembly, not only in specs: **83** generated proxies gained a validator where previously **0** carried one, with concept-level rules attributed to the owning command property and their localized messages resolved; the generic read model helper's dead client proxy and its route are gone.

Both fixes were confirmed to have teeth by reverting them and watching the new specs fail. Full suite green: 3,962 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)