### PR TITLE
Emit valid client validators for pre-escaped regex slashes and exact-length rules

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/Infrastructure/JavaScriptRuntime.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Microsoft.ClearScript.V8;
 
 namespace Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
@@ -49,9 +50,26 @@ public sealed class JavaScriptRuntime : IDisposable
     /// <returns>The transpiled JavaScript code.</returns>
     public string TranspileTypeScript(string typeScriptCode)
     {
-        var escapedCode = typeScriptCode.Replace("\\", "\\\\").Replace("`", "\\`").Replace("$", "\\$");
+        var escapedCode = EscapeForTemplateLiteral(typeScriptCode);
         var result = Evaluate($"ts.transpile(`{escapedCode}`, {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, experimentalDecorators: true, emitDecoratorMetadata: true }})");
         return result?.ToString() ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the syntactic diagnostics the TypeScript compiler reports for a piece of code.
+    /// </summary>
+    /// <param name="typeScriptCode">The TypeScript code to check.</param>
+    /// <returns>The diagnostic messages; empty when the code parses cleanly.</returns>
+    /// <remarks>
+    /// <see cref="TranspileTypeScript"/> emits best-effort output even for code that does not parse, so a non-empty
+    /// transpilation proves nothing. This surfaces what the compiler actually objects to, so a spec can assert on an
+    /// empty collection and show the offending messages when it fails.
+    /// </remarks>
+    public IReadOnlyList<string> GetSyntacticDiagnostics(string typeScriptCode)
+    {
+        var escapedCode = EscapeForTemplateLiteral(typeScriptCode);
+        var result = Evaluate($"JSON.stringify((ts.transpileModule(`{escapedCode}`, {{ compilerOptions: {{ target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS, experimentalDecorators: true, emitDecoratorMetadata: true }}, reportDiagnostics: true }}).diagnostics || []).map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')))");
+        return JsonSerializer.Deserialize<string[]>(result?.ToString() ?? "[]") ?? [];
     }
 
     /// <summary>
@@ -161,6 +179,9 @@ public sealed class JavaScriptRuntime : IDisposable
         var fullPath = Path.GetFullPath(Path.Combine(baseDir, relativePath));
         return File.Exists(fullPath);
     }
+
+    static string EscapeForTemplateLiteral(string code) =>
+        code.Replace("\\", "\\\\").Replace("`", "\\`").Replace("$", "\\$");
 
     static string? FindDirectoryInHierarchy(string startPath, string directoryName)
     {

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithEveryRuleShape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/CommandWithEveryRuleShape.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using FluentValidation;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+/// <summary>
+/// Carries one property per client-projectable validation rule shape, so the generation scenario can pin down the
+/// exact TypeScript each shape produces — and that the shapes which cannot be projected are dropped cleanly.
+/// </summary>
+public class CommandWithEveryRuleShape
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Nickname { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string Bio { get; set; } = string.Empty;
+    public string Pin { get; set; } = string.Empty;
+    public int Age { get; set; }
+    public int Seats { get; set; }
+    public decimal Price { get; set; }
+    public string ApiRoute { get; set; } = string.Empty;
+    public string BirthDate { get; set; } = string.Empty;
+    public DateOnly When { get; set; }
+}
+
+/// <summary>
+/// Declares every rule shape the extractor can project, plus the ones it deliberately drops: a comparison over a
+/// non-numeric value has no client rule, and a lazily declared message is resolved when it does not read the
+/// instance.
+/// </summary>
+public class CommandWithEveryRuleShapeValidator : BaseValidator<CommandWithEveryRuleShape>
+{
+    public CommandWithEveryRuleShapeValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().Length(2, 50);
+        RuleFor(x => x.Nickname).NotNull();
+        RuleFor(x => x.Email).EmailAddress();
+        RuleFor(x => x.Bio).MinimumLength(10).MaximumLength(200);
+        RuleFor(x => x.Pin).Length(4).WithMessage(_ => "Pin must be exactly four digits");
+        RuleFor(x => x.Age).GreaterThanOrEqualTo(18).LessThan(150);
+        RuleFor(x => x.Seats).GreaterThan(0).LessThanOrEqualTo(64);
+        RuleFor(x => x.Price).GreaterThan(0.5m);
+        RuleFor(x => x.ApiRoute).Matches("^/api/[a-z]+$");
+        RuleFor(x => x.BirthDate).Matches(@"^\d{2}\/\d{2}$");
+        RuleFor(x => x.When).GreaterThan(DateOnly.MinValue);
+    }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_every_rule_shape.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_every_rule_shape.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Scenarios.Infrastructure;
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.Scenarios.for_ProxyGeneration;
+
+/// <summary>
+/// The corpus scenario for client validation projection: every rule shape the extractor can project is pinned to the
+/// exact TypeScript it produces, the shapes it deliberately drops are proven absent, and the whole generated proxy is
+/// held against the compiler's own diagnostics — not just a best-effort transpilation.
+/// </summary>
+public class when_generating_command_with_every_rule_shape : Specification, IDisposable
+{
+    JavaScriptRuntime _runtime = null!;
+    string _generatedCode = null!;
+    CommandDescriptor _descriptor = null!;
+    IReadOnlyList<string> _diagnostics = null!;
+
+    void Establish()
+    {
+        _runtime = new JavaScriptRuntime();
+
+        var commandType = typeof(CommandWithEveryRuleShape);
+        var method = commandType.GetMethod("Handle") ?? typeof(object).GetMethod("GetHashCode");
+        var properties = commandType.GetProperties()
+            .Select(p => p.ToPropertyDescriptor())
+            .ToList();
+
+        var validationRules = ValidationRulesExtractor.ExtractValidationRules(commandType.Assembly, commandType);
+
+        _descriptor = new CommandDescriptor(
+            commandType,
+            method,
+            "/api/commands/command-with-every-rule-shape",
+            "CommandWithEveryRuleShape",
+            properties,
+            Enumerable.Empty<ImportStatement>().OrderBy(_ => _.Module),
+            [],
+            false,
+            ModelDescriptor.Empty,
+            [],
+            null,
+            validationRules,
+            false,
+            []);
+    }
+
+    void Because()
+    {
+        _generatedCode = InMemoryProxyGenerator.GenerateCommand(_descriptor);
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_generatedCode);
+    }
+
+    [Fact] void should_emit_not_empty() => _generatedCode.ShouldContain(".notEmpty()");
+    [Fact] void should_emit_length_range() => _generatedCode.ShouldContain(".length(2, 50)");
+    [Fact] void should_emit_not_null() => _generatedCode.ShouldContain(".notNull()");
+    [Fact] void should_emit_email_address() => _generatedCode.ShouldContain(".emailAddress()");
+    [Fact] void should_emit_min_length() => _generatedCode.ShouldContain(".minLength(10)");
+    [Fact] void should_emit_max_length() => _generatedCode.ShouldContain(".maxLength(200)");
+    [Fact] void should_emit_exact_length_as_a_range() => _generatedCode.ShouldContain(".length(4, 4)");
+    [Fact] void should_resolve_the_lazily_declared_message() => _generatedCode.ShouldContain(".withMessage('Pin must be exactly four digits')");
+    [Fact] void should_emit_greater_than_or_equal() => _generatedCode.ShouldContain(".greaterThanOrEqual(18)");
+    [Fact] void should_emit_less_than() => _generatedCode.ShouldContain(".lessThan(150)");
+    [Fact] void should_emit_greater_than() => _generatedCode.ShouldContain(".greaterThan(0)");
+    [Fact] void should_emit_less_than_or_equal() => _generatedCode.ShouldContain(".lessThanOrEqual(64)");
+    [Fact] void should_emit_a_decimal_comparison_with_invariant_formatting() => _generatedCode.ShouldContain(".greaterThan(0.5)");
+    [Fact] void should_escape_a_bare_slash_in_a_regex() => _generatedCode.ShouldContain(@".matches(/^\/api\/[a-z]+$/)");
+    [Fact] void should_not_double_escape_a_slash_the_pattern_already_escapes() => _generatedCode.ShouldContain(@".matches(/^\d{2}\/\d{2}$/)");
+    [Fact] void should_drop_the_non_numeric_comparison() => _generatedCode.ShouldNotContain("this.ruleFor(c => c.when)");
+    [Fact] void should_produce_typescript_the_compiler_accepts() => _diagnostics.ShouldBeEmpty();
+
+    public void Dispose() => _runtime?.Dispose();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_command_with_validation.cs
@@ -11,7 +11,7 @@ public class when_generating_command_with_validation : Specification, IDisposabl
     JavaScriptRuntime _runtime = null!;
     string _generatedCode = null!;
     CommandDescriptor _descriptor = null!;
-    bool _typeScriptIsValid;
+    IReadOnlyList<string> _diagnostics = null!;
 
     void Establish()
     {
@@ -45,16 +45,7 @@ public class when_generating_command_with_validation : Specification, IDisposabl
     void Because()
     {
         _generatedCode = InMemoryProxyGenerator.GenerateCommand(_descriptor);
-
-        try
-        {
-            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
-            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
-        }
-        catch
-        {
-            _typeScriptIsValid = false;
-        }
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_generatedCode);
     }
 
     [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
@@ -69,7 +60,7 @@ public class when_generating_command_with_validation : Specification, IDisposabl
     [Fact] void should_contain_min_length_rule_for_name() => _generatedCode.ShouldContain(".minLength(2)");
     [Fact] void should_contain_max_length_rule_for_name() => _generatedCode.ShouldContain(".maxLength(50)");
     [Fact] void should_emit_the_regex_rule_as_a_regular_expression_literal() => _generatedCode.ShouldContain(@".matches(/^\d{4}$/)");
-    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+    [Fact] void should_produce_typescript_the_compiler_accepts() => _diagnostics.ShouldBeEmpty();
 
     public void Dispose() => _runtime?.Dispose();
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_observable_query_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_observable_query_with_validation.cs
@@ -15,7 +15,7 @@ public class when_generating_observable_query_with_validation : Specification, I
     JavaScriptRuntime _runtime = null!;
     string _generatedCode = null!;
     QueryDescriptor _descriptor = null!;
-    bool _typeScriptIsValid;
+    IReadOnlyList<string> _diagnostics = null!;
 
     void Establish()
     {
@@ -52,16 +52,7 @@ public class when_generating_observable_query_with_validation : Specification, I
     void Because()
     {
         _generatedCode = InMemoryProxyGenerator.GenerateQuery(_descriptor);
-
-        try
-        {
-            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
-            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
-        }
-        catch
-        {
-            _typeScriptIsValid = false;
-        }
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_generatedCode);
     }
 
     [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
@@ -73,7 +64,7 @@ public class when_generating_observable_query_with_validation : Specification, I
     [Fact] void should_contain_less_than_or_equal_rule() => _generatedCode.ShouldContain(".lessThanOrEqual(150)");
     [Fact] void should_contain_rule_for_search_term() => _generatedCode.ShouldContain("this.ruleFor(c => c.searchTerm)");
     [Fact] void should_contain_min_length_rule() => _generatedCode.ShouldContain(".minLength(3)");
-    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+    [Fact] void should_produce_typescript_the_compiler_accepts() => _diagnostics.ShouldBeEmpty();
 
     public void Dispose() => _runtime?.Dispose();
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_query_with_validation.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/Scenarios/for_ProxyGeneration/when_generating_query_with_validation.cs
@@ -11,7 +11,7 @@ public class when_generating_query_with_validation : Specification, IDisposable
     JavaScriptRuntime _runtime = null!;
     string _generatedCode = null!;
     QueryDescriptor _descriptor = null!;
-    bool _typeScriptIsValid;
+    IReadOnlyList<string> _diagnostics = null!;
 
     void Establish()
     {
@@ -48,16 +48,7 @@ public class when_generating_query_with_validation : Specification, IDisposable
     void Because()
     {
         _generatedCode = InMemoryProxyGenerator.GenerateQuery(_descriptor);
-
-        try
-        {
-            var transpiledCode = _runtime.TranspileTypeScript(_generatedCode);
-            _typeScriptIsValid = !string.IsNullOrEmpty(transpiledCode);
-        }
-        catch
-        {
-            _typeScriptIsValid = false;
-        }
+        _diagnostics = _runtime.GetSyntacticDiagnostics(_generatedCode);
     }
 
     [Fact] void should_generate_code() => _generatedCode.ShouldNotBeEmpty();
@@ -68,7 +59,7 @@ public class when_generating_query_with_validation : Specification, IDisposable
     [Fact] void should_contain_less_than_or_equal_rule() => _generatedCode.ShouldContain(".lessThanOrEqual(150)");
     [Fact] void should_contain_rule_for_search_term() => _generatedCode.ShouldContain("this.ruleFor(c => c.searchTerm)");
     [Fact] void should_contain_min_length_rule() => _generatedCode.ShouldContain(".minLength(3)");
-    [Fact] void should_be_valid_typescript() => _typeScriptIsValid.ShouldBeTrue();
+    [Fact] void should_produce_typescript_the_compiler_accepts() => _diagnostics.ShouldBeEmpty();
 
     public void Dispose() => _runtime?.Dispose();
 }

--- a/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Templates/TemplateTypes.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Text;
 using HandlebarsDotNet;
 
 namespace Cratis.Arc.ProxyGenerator.Templates;
@@ -102,8 +103,11 @@ public static class TemplateTypes
     /// <param name="pattern">The pattern to format.</param>
     /// <returns>The regular-expression literal.</returns>
     /// <remarks>
-    /// An empty pattern becomes <c>/(?:)/</c> rather than <c>//</c>, which JavaScript reads as a line comment; a
-    /// literal slash in the pattern is escaped so it does not close the literal early.
+    /// An empty pattern becomes <c>/(?:)/</c> rather than <c>//</c>, which JavaScript reads as a line comment. An
+    /// unescaped slash is escaped so it does not close the literal early, while a slash the pattern already escapes
+    /// passes through untouched — <c>\/</c> must not become <c>\\/</c>, whose escaped backslash would leave the
+    /// slash free to terminate the literal. A line terminator cannot appear in a regex literal at all, so it is
+    /// rewritten to its escape sequence.
     /// </remarks>
     static string FormatRegularExpression(string pattern)
     {
@@ -112,8 +116,50 @@ public static class TemplateTypes
             return "/(?:)/";
         }
 
-        var escaped = pattern.Replace("\r", "\\r").Replace("\n", "\\n").Replace("/", "\\/");
-        return $"/{escaped}/";
+        var literal = new StringBuilder(pattern.Length + 2);
+        var escaped = false;
+
+        foreach (var character in pattern)
+        {
+            if (character == '\\' && !escaped)
+            {
+                literal.Append('\\');
+                escaped = true;
+                continue;
+            }
+
+            switch (character)
+            {
+                case '/' when !escaped:
+                    literal.Append("\\/");
+                    break;
+                case '\r':
+                    literal.Append(escaped ? "r" : "\\r");
+                    break;
+                case '\n':
+                    literal.Append(escaped ? "n" : "\\n");
+                    break;
+                case '\u2028':
+                    literal.Append(escaped ? "u2028" : "\\u2028");
+                    break;
+                case '\u2029':
+                    literal.Append(escaped ? "u2029" : "\\u2029");
+                    break;
+                default:
+                    literal.Append(character);
+                    break;
+            }
+
+            escaped = false;
+        }
+
+        // A trailing lone backslash would escape the closing slash; doubling it keeps the literal well formed.
+        if (escaped)
+        {
+            literal.Append('\\');
+        }
+
+        return $"/{literal}/";
     }
 
     /// <summary>

--- a/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/ValidationRulesExtractor.cs
@@ -726,9 +726,11 @@ public static class ValidationRulesExtractor
 
     static ValidationRuleDescriptor ExtractExactLengthRule(object validator, string? errorMessage)
     {
+        // ExactLengthValidator has no Length property - it is a LengthValidator whose Min and Max both carry the
+        // exact length.
         var validatorType = validator.GetType();
-        var lengthProperty = validatorType.GetProperty("Length", BindingFlags.Public | BindingFlags.Instance);
-        var length = lengthProperty?.GetValue(validator) as int? ?? 0;
+        var minProperty = validatorType.GetProperty("Min", BindingFlags.Public | BindingFlags.Instance);
+        var length = minProperty?.GetValue(validator) as int? ?? 0;
         return new ValidationRuleDescriptor("length", [length, length], errorMessage);
     }
 


### PR DESCRIPTION
## Fixed

- A regex validation rule whose pattern already escapes a slash — `Matches(@"^\d{2}\/\d{2}$")` — generated a client validator that did not parse: the slash was escaped a second time, and the resulting `\\/` let the slash terminate the regex literal early. Slash escaping is now escape-aware, so a pattern's own escapes pass through untouched and only a bare slash is escaped.
- An exact-length rule — `Length(4)` — projected to the client as `length(0, 0)`, since the extractor read a `Length` property that `ExactLengthValidator` does not have. It reads the validator's `Min` (which carries the exact length) instead, so `length(4, 4)` is generated.

---

Both were latent in the client validation projection introduced by #2363. The generation scenarios now hold the emitted proxy against the TypeScript compiler's own diagnostics rather than a best-effort transpilation — `ts.transpile` emits output even for code that does not parse, so the previous check could not fail — and a corpus scenario pins every projectable rule shape to its exact emission; it caught the exact-length defect on its first run. Both fixes verified to have teeth by reverting them and watching the specs fail. Full suite green: 3,987 passed, 0 failed.