### PR TITLE
Fix tenant resolution and remove AOT-incompatible validation reflection

### DIFF
--- a/Source/DotNET/Arc.Core/Tenancy/Constants.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/Constants.cs
@@ -4,17 +4,17 @@
 namespace Cratis.Arc.Tenancy;
 
 /// <summary>
-/// Holds constants related to correlation id.
+/// Holds constants related to tenant id.
 /// </summary>
 public static class Constants
 {
     /// <summary>
-    /// Gets the header name for the correlation id.
+    /// Gets the default header name for the tenant id.
     /// </summary>
     public const string DefaultTenantIdHeader = "x-cratis-tenant-id";
 
     /// <summary>
-    /// Gets the item key for the correlation id.
+    /// Gets the item key for the tenant id.
     /// </summary>
     public const string TenantIdItemKey = "TenantId";
 }

--- a/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenancyOptionsExtensions.cs
@@ -12,7 +12,7 @@ public static class TenancyOptionsExtensions
     /// Configure tenancy to use HTTP headers for resolving tenant IDs.
     /// </summary>
     /// <param name="options">The <see cref="ArcOptions"/> to configure.</param>
-    /// <param name="headerName">Optional header name to use. Defaults to 'X-Tenant-ID'.</param>
+    /// <param name="headerName">Optional header name to use. Defaults to 'x-cratis-tenant-id'.</param>
     /// <returns>The <see cref="ArcOptions"/> for continuation.</returns>
     public static ArcOptions UseHeaderTenancy(this ArcOptions options, string? headerName = null)
     {
@@ -76,7 +76,7 @@ public static class TenancyOptionsExtensions
     /// Configure tenancy to resolve the tenant ID from the request subdomain, with the HTTP header as fallback.
     /// </summary>
     /// <param name="options">The <see cref="ArcOptions"/> to configure.</param>
-    /// <param name="fallbackHeaderName">Optional header name used as fallback. Defaults to 'X-Tenant-ID'.</param>
+    /// <param name="fallbackHeaderName">Optional header name used as fallback. Defaults to 'x-cratis-tenant-id'.</param>
     /// <returns>The <see cref="ArcOptions"/> for continuation.</returns>
     public static ArcOptions UseSubdomainTenancy(this ArcOptions options, string? fallbackHeaderName = null)
     {

--- a/Source/DotNET/Arc.Core/Validation/BaseValidator.cs
+++ b/Source/DotNET/Arc.Core/Validation/BaseValidator.cs
@@ -47,14 +47,16 @@ public class BaseValidator<T> : AbstractValidator<T>
     public IRuleBuilderInitial<T, TValue> RuleFor<TValue>(Expression<Func<T, ConceptAs<TValue>>> expression)
         where TValue : IComparable
     {
+        // CreateValueExpression handles both shapes: when the body is the parameter itself (the concept is the model
+        // being validated) it reads the parameter's Value directly, which is identical to compiling and invoking the
+        // identity lambda — only without the Expression.Compile() that NativeAOT cannot honor.
+        var valueExpression = CreateValueExpression(expression);
         if (expression.Body is ParameterExpression)
         {
-            var transformExpression = CreateTransformExpression(expression);
-            return ((AbstractValidator<T>)this).RuleFor(transformExpression);
+            return ((AbstractValidator<T>)this).RuleFor(valueExpression);
         }
 
         var propertyName = GetPropertyName(expression);
-        var valueExpression = CreateValueExpression(expression);
         return ((AbstractValidator<T>)this).RuleFor(valueExpression).OverridePropertyName(propertyName);
     }
 
@@ -68,22 +70,6 @@ public class BaseValidator<T> : AbstractValidator<T>
         // This prevents NullReferenceException when accessing .Value on a null concept
         var nullCheck = Expression.NotEqual(body, Expression.Constant(null, body.Type));
         var valueProperty = Expression.Property(body, nameof(ConceptAs<TProperty>.Value));
-        var defaultValue = Expression.Default(typeof(TProperty));
-        var conditional = Expression.Condition(nullCheck, valueProperty, defaultValue);
-
-        return Expression.Lambda<Func<T, TProperty>>(conditional, parameter);
-    }
-
-    static Expression<Func<T, TProperty>> CreateTransformExpression<TProperty>(Expression<Func<T, ConceptAs<TProperty>>> expression)
-        where TProperty : IComparable
-    {
-        var parameter = expression.Parameters[0];
-
-        // Create: arg => expression.Compile().Invoke(arg) != null ? expression.Compile().Invoke(arg).Value : default
-        var compiled = expression.Compile();
-        var invokeExpression = Expression.Invoke(Expression.Constant(compiled), parameter);
-        var nullCheck = Expression.NotEqual(invokeExpression, Expression.Constant(null, invokeExpression.Type));
-        var valueProperty = Expression.Property(invokeExpression, nameof(ConceptAs<TProperty>.Value));
         var defaultValue = Expression.Default(typeof(TProperty));
         var conditional = Expression.Condition(nullCheck, valueProperty, defaultValue);
 

--- a/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
+++ b/Source/DotNET/Arc.Core/Validation/DiscoverableValidators.cs
@@ -39,7 +39,7 @@ public class DiscoverableValidators : IDiscoverableValidators
             var interfaces = _.GetInterfaces();
             var validatorType = interfaces.Single(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IDiscoverableValidator<>));
             var modelType = validatorType.GetGenericArguments()[0];
-            return !_.IsAssignableTo(typeof(AbstractValidator<>).MakeGenericType(modelType));
+            return !DerivesFromAbstractValidatorOf(_, modelType);
         }).ToArray();
 
         if (invalidValidators.Length > 0)
@@ -75,6 +75,34 @@ public class DiscoverableValidators : IDiscoverableValidators
         }
 
         validator = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a type derives from <see cref="AbstractValidator{T}"/> closed over the given model type.
+    /// </summary>
+    /// <param name="type">The candidate validator type.</param>
+    /// <param name="modelType">The model type the validator must be for.</param>
+    /// <returns>True when the type derives from <c>AbstractValidator&lt;modelType&gt;</c>; otherwise false.</returns>
+    /// <remarks>
+    /// This replaces <c>IsAssignableTo(typeof(AbstractValidator&lt;&gt;).MakeGenericType(modelType))</c>. Constructing a
+    /// closed generic through <c>MakeGenericType</c> at runtime is not statically analyzable and breaks under
+    /// NativeAOT/trimming, whereas reading the generic argument off an already-constructed base type in the chain is
+    /// AOT-safe and preserves the exact "must be an AbstractValidator for this model" semantics — including rejecting a
+    /// validator whose <see cref="AbstractValidator{T}"/> is closed over a different model type.
+    /// </remarks>
+    static bool DerivesFromAbstractValidatorOf(Type type, Type modelType)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType &&
+                current.GetGenericTypeDefinition() == typeof(AbstractValidator<>) &&
+                current.GetGenericArguments()[0] == modelType)
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/Source/DotNET/Arc.Core/Validation/RuleBuilderInitialExtensions.cs
+++ b/Source/DotNET/Arc.Core/Validation/RuleBuilderInitialExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
 using FluentValidation;
 
 namespace Cratis.Arc.Validation;
@@ -19,25 +18,17 @@ public static class RuleBuilderInitialExtensions
     /// <param name="ruleBuilder">The rule builder.</param>
     /// <param name="propertyName">The property name to use.</param>
     /// <returns>The same rule builder for chaining.</returns>
+    /// <remarks>
+    /// FluentValidation's own <c>OverridePropertyName</c> is a public extension on
+    /// <see cref="IRuleBuilderOptions{T, TProperty}"/>. The concrete rule builder behind an
+    /// <see cref="IRuleBuilderInitial{T, TProperty}"/> also implements that interface and returns itself, so this
+    /// simply forwards to it — avoiding the private-member reflection that NativeAOT and trimming cannot preserve.
+    /// </remarks>
     public static IRuleBuilderInitial<T, TProperty> OverridePropertyName<T, TProperty>(
         this IRuleBuilderInitial<T, TProperty> ruleBuilder,
         string propertyName)
     {
-        // Use reflection to access the internal Rule property
-        var ruleProperty = ruleBuilder.GetType().GetProperty("Rule", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        if (ruleProperty != null)
-        {
-            var rule = ruleProperty.GetValue(ruleBuilder);
-            if (rule != null)
-            {
-                var propertyNameProperty = rule.GetType().GetProperty("PropertyName", BindingFlags.Public | BindingFlags.Instance);
-                if (propertyNameProperty?.CanWrite == true)
-                {
-                    propertyNameProperty.SetValue(rule, propertyName);
-                }
-            }
-        }
-
+        ((IRuleBuilderOptions<T, TProperty>)ruleBuilder).OverridePropertyName(propertyName);
         return ruleBuilder;
     }
 }

--- a/Source/DotNET/Arc.Core/Validation/ValidatorInvoker.cs
+++ b/Source/DotNET/Arc.Core/Validation/ValidatorInvoker.cs
@@ -30,8 +30,12 @@ public class ValidatorInvoker(ILogger<ValidatorInvoker> logger) : IValidatorInvo
     {
         try
         {
-            var validationContextType = typeof(ValidationContext<>).MakeGenericType(instance.GetType());
-            var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
+            // A ValidationContext<object> wrapping the instance is enough: FluentValidation's own
+            // AbstractValidator<T>.ValidateAsync rebuilds a ValidationContext<T> from any non-generic context whose
+            // InstanceToValidate is a T. Constructing ValidationContext<object> directly keeps this statically
+            // analyzable, unlike typeof(ValidationContext<>).MakeGenericType(...) + Activator.CreateInstance which
+            // NativeAOT and trimming cannot preserve.
+            var validationContext = new ValidationContext<object>(instance);
             var validationResult = await validator.ValidateAsync(validationContext, cancellationToken);
             if (validationResult.IsValid)
             {

--- a/Source/DotNET/Arc.Specs/Http/for_AspNetCoreHttpRequestContext/when_reading_headers/with_a_differently_cased_header.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_AspNetCoreHttpRequestContext/when_reading_headers/with_a_differently_cased_header.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Cratis.Arc.Http.for_AspNetCoreHttpRequestContext.when_reading_headers;
+
+/// <summary>
+/// HTTP/2 lowercases header names on the wire, so a header configured as <c>Tenant-ID</c> arrives as
+/// <c>tenant-id</c>. The lookup must still find it, otherwise header-based tenant resolution silently yields nothing.
+/// </summary>
+public class with_a_differently_cased_header : Specification
+{
+    AspNetCoreHttpRequestContext _context;
+    bool _found;
+    string? _value;
+
+    void Establish()
+    {
+        var headers = new HeaderDictionary { { "tenant-id", "acme" } };
+        var httpContext = Substitute.For<HttpContext>();
+        var request = Substitute.For<HttpRequest>();
+        httpContext.Request.Returns(request);
+        request.Headers.Returns(headers);
+        _context = new AspNetCoreHttpRequestContext(httpContext);
+    }
+
+    void Because() => _found = _context.Headers.TryGetValue("Tenant-ID", out _value);
+
+    [Fact] void should_find_the_header_ignoring_case() => _found.ShouldBeTrue();
+    [Fact] void should_return_the_header_value() => _value.ShouldEqual("acme");
+}

--- a/Source/DotNET/Arc.Specs/Http/for_HttpRequestContextMiddleware/when_invoking.cs
+++ b/Source/DotNET/Arc.Specs/Http/for_HttpRequestContextMiddleware/when_invoking.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Cratis.Arc.Http.for_HttpRequestContextMiddleware;
+
+public class when_invoking : Specification
+{
+    HttpRequestContextMiddleware _middleware;
+    HttpContext _httpContext;
+    IHttpRequestContextAccessor _accessor;
+    RequestDelegate _next;
+    IHttpRequestContext? _currentWhenNextInvoked;
+
+    void Establish()
+    {
+        _httpContext = Substitute.For<HttpContext>();
+        _accessor = Substitute.For<IHttpRequestContextAccessor>();
+        _next = Substitute.For<RequestDelegate>();
+
+        // Capture what the accessor exposes at the moment the next delegate runs, to prove the context is published
+        // before the rest of the pipeline — not only by the time the request completes.
+        _next.Invoke(Arg.Any<HttpContext>()).Returns(_ =>
+        {
+            _currentWhenNextInvoked = _accessor.Current;
+            return Task.CompletedTask;
+        });
+
+        _middleware = new HttpRequestContextMiddleware(_accessor);
+    }
+
+    Task Because() => _middleware.InvokeAsync(_httpContext, _next);
+
+    [Fact] void should_publish_the_request_context() => _accessor.Current.ShouldBeOfExactType<AspNetCoreHttpRequestContext>();
+    [Fact] void should_publish_it_before_invoking_the_next_delegate() => _currentWhenNextInvoked.ShouldNotBeNull();
+    [Fact] void should_invoke_the_next_delegate() => _next.Received(1).Invoke(_httpContext);
+}

--- a/Source/DotNET/Arc/ArcStartupFilter.cs
+++ b/Source/DotNET/Arc/ArcStartupFilter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.AspNetCore.Http;
 using Cratis.Arc.Execution;
 using Microsoft.AspNetCore.Hosting;
 
@@ -16,7 +17,10 @@ public class ArcStartupFilter : IStartupFilter
     {
         return app =>
         {
-            // Add Arc middlewares at the beginning of the pipeline
+            // Add Arc middlewares at the beginning of the pipeline. The request context is published first so it is
+            // available to everything downstream — tenant resolution in particular, which otherwise silently sees no
+            // request and resolves no tenant when it runs before an endpoint delegate assigns the context.
+            app.UseMiddleware<HttpRequestContextMiddleware>();
             app.UseMiddleware<CorrelationIdMiddleware>();
 
             // Continue with the rest of the pipeline

--- a/Source/DotNET/Arc/Http/AspNetCoreHttpRequestContext.cs
+++ b/Source/DotNET/Arc/Http/AspNetCoreHttpRequestContext.cs
@@ -22,9 +22,15 @@ public class AspNetCoreHttpRequestContext(HttpContext httpContext) : IHttpReques
         kvp => kvp.Value.ToString());
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// HTTP header names are case-insensitive, and HTTP/2 lowercases them on the wire. The lookup is therefore
+    /// case-insensitive so a configured header such as <c>Tenant-ID</c> still matches when it arrives as
+    /// <c>tenant-id</c>. This mirrors the self-hosted <c>HttpListenerRequestContext</c>.
+    /// </remarks>
     public IReadOnlyDictionary<string, string> Headers => httpContext.Request.Headers.ToDictionary(
         kvp => kvp.Key,
-        kvp => kvp.Value.ToString());
+        kvp => kvp.Value.ToString(),
+        StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, string> Cookies => httpContext.Request.Cookies.ToDictionary(

--- a/Source/DotNET/Arc/Http/HttpRequestContextMiddleware.cs
+++ b/Source/DotNET/Arc/Http/HttpRequestContextMiddleware.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.AspNetCore.Http;
+
+/// <summary>
+/// Represents an <see cref="IMiddleware"/> that publishes the current <see cref="IHttpRequestContext"/> to the
+/// <see cref="IHttpRequestContextAccessor"/> for the whole request.
+/// </summary>
+/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> to publish the context to.</param>
+/// <remarks>
+/// The built-in tenant resolvers — and anything else that reads the request — go through
+/// <see cref="IHttpRequestContextAccessor"/>. Assigning it only inside individual endpoint delegates leaves it unset
+/// for work that runs earlier in the request, such as identity resolution that reads tenant-scoped data. That work
+/// then sees no request context and silently resolves no tenant. Publishing the context in early middleware makes it
+/// available for the entire pipeline, so tenant resolution is consistent regardless of where in the request it runs.
+/// </remarks>
+public class HttpRequestContextMiddleware(IHttpRequestContextAccessor httpRequestContextAccessor) : IMiddleware
+{
+    /// <inheritdoc/>
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        httpRequestContextAccessor.Current = new AspNetCoreHttpRequestContext(context);
+        await next(context);
+    }
+}

--- a/Source/DotNET/Arc/ServiceCollectionExtensions.cs
+++ b/Source/DotNET/Arc/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc;
+using Cratis.Arc.AspNetCore.Http;
 using Cratis.Arc.Commands;
 using Cratis.Arc.ModelBinding;
 using Cratis.Arc.Queries;
@@ -33,6 +34,7 @@ public static class ServiceCollectionExtensions
         var discoverableValidators = new DiscoverableValidators(types);
         services.AddSingleton<IDiscoverableValidators>(discoverableValidators);
         services.AddTransient<IStartupFilter, ArcStartupFilter>();
+        services.AddTransient<HttpRequestContextMiddleware>();
         services.AddCorrelationId();
         services
             .AddActivitySource<CommandActionFilter>(Internals.ActivitySourceName)


### PR DESCRIPTION
## Fixed

- Header-based tenant resolution now applies for the whole request instead of only inside endpoint delegates, so tenant-scoped work that runs earlier no longer falls back to the default namespace and database; header lookup is now case-insensitive so a configured header still matches when HTTP/2 delivers it lowercased (#2351)
