### PR TITLE
Keep observable emissions safe across subscription teardown

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_gate_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_gate_is_disposed.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_SerializedEmissionGate.when_emitting;
+
+/// <summary>
+/// The subscription tears the gate down before the underlying subject has stopped delivering. The emission that
+/// slips through must be dropped rather than throwing, because it runs from an async-void observer whose escaping
+/// exception would crash the process.
+/// </summary>
+public class and_the_gate_is_disposed : Specification
+{
+    SerializedEmissionGate _gate;
+    bool _ran;
+    Exception _error;
+
+    void Establish()
+    {
+        _gate = new SerializedEmissionGate();
+        _gate.Dispose();
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _gate.Emit(() =>
+    {
+        _ran = true;
+        return Task.CompletedTask;
+    }, CancellationToken.None));
+
+    [Fact] void should_not_run_the_emission() => _ran.ShouldBeFalse();
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_gate_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_gate_is_disposed.cs
@@ -20,11 +20,15 @@ public class and_the_gate_is_disposed : Specification
         _gate.Dispose();
     }
 
-    async Task Because() => _error = await Catch.Exception(() => _gate.Emit(() =>
+    async Task Because() => _error = await Catch.Exception(Emit);
+
+    Task Emit() => _gate.Emit(Run, CancellationToken.None);
+
+    Task Run()
     {
         _ran = true;
         return Task.CompletedTask;
-    }, CancellationToken.None));
+    }
 
     [Fact] void should_not_run_the_emission() => _ran.ShouldBeFalse();
     [Fact] void should_not_throw() => _error.ShouldBeNull();

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_token_is_cancelled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_token_is_cancelled.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_SerializedEmissionGate.when_emitting;
+
+public class and_the_token_is_cancelled : Specification
+{
+    SerializedEmissionGate _gate;
+    bool _ran;
+    Exception _error;
+
+    void Establish() => _gate = new SerializedEmissionGate();
+
+    async Task Because() => _error = await Catch.Exception(() => _gate.Emit(() =>
+    {
+        _ran = true;
+        return Task.CompletedTask;
+    }, new CancellationToken(canceled: true)));
+
+    [Fact] void should_not_run_the_emission() => _ran.ShouldBeFalse();
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+
+    void Destroy() => _gate.Dispose();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_token_is_cancelled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/and_the_token_is_cancelled.cs
@@ -11,11 +11,15 @@ public class and_the_token_is_cancelled : Specification
 
     void Establish() => _gate = new SerializedEmissionGate();
 
-    async Task Because() => _error = await Catch.Exception(() => _gate.Emit(() =>
+    async Task Because() => _error = await Catch.Exception(Emit);
+
+    Task Emit() => _gate.Emit(Run, new CancellationToken(canceled: true));
+
+    Task Run()
     {
         _ran = true;
         return Task.CompletedTask;
-    }, new CancellationToken(canceled: true)));
+    }
 
     [Fact] void should_not_run_the_emission() => _ran.ShouldBeFalse();
     [Fact] void should_not_throw() => _error.ShouldBeNull();

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/normally.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/normally.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_SerializedEmissionGate.when_emitting;
+
+public class normally : Specification
+{
+    SerializedEmissionGate _gate;
+    bool _ran;
+
+    void Establish() => _gate = new SerializedEmissionGate();
+
+    async Task Because() => await _gate.Emit(() =>
+    {
+        _ran = true;
+        return Task.CompletedTask;
+    }, CancellationToken.None);
+
+    [Fact] void should_run_the_emission() => _ran.ShouldBeTrue();
+
+    void Destroy() => _gate.Dispose();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/normally.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/normally.cs
@@ -10,11 +10,13 @@ public class normally : Specification
 
     void Establish() => _gate = new SerializedEmissionGate();
 
-    async Task Because() => await _gate.Emit(() =>
+    async Task Because() => await _gate.Emit(Run, CancellationToken.None);
+
+    Task Run()
     {
         _ran = true;
         return Task.CompletedTask;
-    }, CancellationToken.None);
+    }
 
     [Fact] void should_run_the_emission() => _ran.ShouldBeTrue();
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/while_another_emission_is_in_flight.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/while_another_emission_is_in_flight.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_SerializedEmissionGate.when_emitting;
+
+/// <summary>
+/// Emissions must not overlap: the per-emission interception and the change-set bookkeeping the gate protects rely
+/// on one emission finishing before the next begins.
+/// </summary>
+public class while_another_emission_is_in_flight : Specification
+{
+    SerializedEmissionGate _gate;
+    TaskCompletionSource _firstStarted;
+    TaskCompletionSource _releaseFirst;
+    Task _first;
+    Task _second;
+    bool _secondRanWhileFirstHeldTheGate;
+
+    void Establish()
+    {
+        _gate = new SerializedEmissionGate();
+        _firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    async Task Because()
+    {
+        var secondRan = false;
+
+        _first = _gate.Emit(async () =>
+        {
+            _firstStarted.SetResult();
+            await _releaseFirst.Task;
+        }, CancellationToken.None);
+
+        // The first emission is now holding the gate.
+        await _firstStarted.Task;
+
+        _second = _gate.Emit(() =>
+        {
+            secondRan = true;
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+
+        // Give the second emission ample opportunity to run if the gate were not serializing.
+        await Task.Delay(100);
+        _secondRanWhileFirstHeldTheGate = secondRan;
+
+        _releaseFirst.SetResult();
+        await Task.WhenAll(_first, _second);
+    }
+
+    [Fact] void should_hold_the_second_emission_until_the_first_releases() => _secondRanWhileFirstHeldTheGate.ShouldBeFalse();
+
+    void Destroy() => _gate.Dispose();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/while_another_emission_is_in_flight.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_SerializedEmissionGate/when_emitting/while_another_emission_is_in_flight.cs
@@ -14,6 +14,7 @@ public class while_another_emission_is_in_flight : Specification
     TaskCompletionSource _releaseFirst;
     Task _first;
     Task _second;
+    bool _secondRan;
     bool _secondRanWhileFirstHeldTheGate;
 
     void Establish()
@@ -25,29 +26,31 @@ public class while_another_emission_is_in_flight : Specification
 
     async Task Because()
     {
-        var secondRan = false;
-
-        _first = _gate.Emit(async () =>
-        {
-            _firstStarted.SetResult();
-            await _releaseFirst.Task;
-        }, CancellationToken.None);
+        _first = _gate.Emit(FirstEmission, CancellationToken.None);
 
         // The first emission is now holding the gate.
         await _firstStarted.Task;
 
-        _second = _gate.Emit(() =>
-        {
-            secondRan = true;
-            return Task.CompletedTask;
-        }, CancellationToken.None);
+        _second = _gate.Emit(SecondEmission, CancellationToken.None);
 
         // Give the second emission ample opportunity to run if the gate were not serializing.
         await Task.Delay(100);
-        _secondRanWhileFirstHeldTheGate = secondRan;
+        _secondRanWhileFirstHeldTheGate = _secondRan;
 
         _releaseFirst.SetResult();
         await Task.WhenAll(_first, _second);
+    }
+
+    async Task FirstEmission()
+    {
+        _firstStarted.SetResult();
+        await _releaseFirst.Task;
+    }
+
+    Task SecondEmission()
+    {
+        _secondRan = true;
+        return Task.CompletedTask;
     }
 
     [Fact] void should_hold_the_second_emission_until_the_first_releases() => _secondRanWhileFirstHeldTheGate.ShouldBeFalse();

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -576,7 +576,9 @@ public class ObservableQueryDemultiplexer(
         // Interception (compliance/PII release) is asynchronous. Emissions are serialized through this gate so
         // the per-emission interception and the ChangeSet's previous/current item bookkeeping stay ordered even
         // when the underlying subject delivers the next value before the previous one has finished interception.
-        var emissionGate = new SemaphoreSlim(1, 1);
+        // The gate also keeps the async-void observer callback below safe across teardown: once it is disposed or
+        // the token is cancelled, emissions are dropped rather than throwing out of the callback.
+        var emissionGate = new SerializedEmissionGate();
 
         // Capture the per-subscription query context here, while the AsyncLocal still carries the
         // context set up by the query pipeline. Observer callbacks below are invoked from the MongoDB
@@ -588,14 +590,12 @@ public class ObservableQueryDemultiplexer(
 
         return new CompositeDisposable(subscription, emissionGate);
 
-        async void OnEmission(T data)
-        {
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
+        // The subject invokes this synchronously from the change-stream thread; it must not throw. The gate runs the
+        // actual emission serialized and swallows teardown, so this is a plain hand-off that never faults.
+        void OnEmission(T data) => _ = emissionGate.Emit(() => EmitCore(data), token);
 
-            await emissionGate.WaitAsync(token);
+        async Task EmitCore(T data)
+        {
             try
             {
                 var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
@@ -659,10 +659,6 @@ public class ObservableQueryDemultiplexer(
                     logger.SubscriptionError(queryId, error);
                     _ = onError(queryId, error.Message);
                 }
-            }
-            finally
-            {
-                emissionGate.Release();
             }
         }
 

--- a/Source/DotNET/Arc.Core/Queries/SerializedEmissionGate.cs
+++ b/Source/DotNET/Arc.Core/Queries/SerializedEmissionGate.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Serializes asynchronous observable-query emissions and stays safe across subscription teardown.
+/// </summary>
+/// <remarks>
+/// Emissions are gated one at a time so the per-emission read-model interception and the change-set's
+/// previous/current bookkeeping stay ordered even when the underlying subject delivers the next value before the
+/// previous one has finished. The emissions are driven from an <c>async void</c> observer callback on the
+/// change-stream thread, so an exception escaping an emission would be unobserved and would terminate the process.
+/// Once the gate is disposed or the subscription's token is cancelled — both of which happen as a connection is
+/// torn down, and in either order — further emissions are dropped rather than throwing.
+/// </remarks>
+internal sealed class SerializedEmissionGate : IDisposable
+{
+    readonly SemaphoreSlim _gate = new(1, 1);
+    volatile bool _disposed;
+
+    /// <summary>
+    /// Runs an emission serialized against every other emission through this gate, dropping it (without throwing)
+    /// once the gate is disposed or the token is cancelled.
+    /// </summary>
+    /// <param name="emission">The emission to run while holding the gate.</param>
+    /// <param name="cancellationToken">The subscription's <see cref="CancellationToken"/>.</param>
+    /// <returns>A <see cref="Task"/> that completes when the emission has run or been dropped.</returns>
+    public async Task Emit(Func<Task> emission, CancellationToken cancellationToken)
+    {
+        if (_disposed || cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        try
+        {
+            await _gate.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // The subscription was torn down while waiting for the gate — nothing to emit.
+            return;
+        }
+        catch (ObjectDisposedException)
+        {
+            // The gate was disposed while waiting — nothing to emit.
+            return;
+        }
+
+        try
+        {
+            // Disposal can win the race between the guard above and acquiring the gate; a parked emission that
+            // wakes up after teardown is dropped rather than pushed to a dead connection.
+            if (_disposed)
+            {
+                return;
+            }
+
+            await emission();
+        }
+        finally
+        {
+            try
+            {
+                _gate.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The subscription was disposed mid-emission; the gate is gone and nothing waits on it.
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _disposed = true;
+        _gate.Dispose();
+    }
+}


### PR DESCRIPTION
## Fixed

- An observable query no longer crashes the server when a client disconnects while an emission is in flight — emissions are dropped cleanly once the subscription is torn down, in either teardown order
