### PR TITLE
Fix serialization of float- and DateTime-backed concepts

### DIFF
--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/DateTimeConcept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/DateTimeConcept.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public record DateTimeConcept(DateTime Value) : ConceptAs<DateTime>(Value);

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/FloatConcept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/FloatConcept.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Concepts;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+public record FloatConcept(float Value) : ConceptAs<float>(Value);

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/a_concept_serializer.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/given/a_concept_serializer.cs
@@ -23,4 +23,22 @@ public class a_concept_serializer : Specification
         reader.ReadEndDocument();
         return result;
     }
+
+    protected static T Roundtrip<T>(T value)
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+        {
+            writer.WriteStartDocument();
+            writer.WriteName("value");
+
+            var serializer = new ConceptSerializer<T>();
+            var context = BsonSerializationContext.CreateRoot(writer);
+            serializer.Serialize(context, new BsonSerializationArgs { NominalType = typeof(T) }, value);
+
+            writer.WriteEndDocument();
+        }
+
+        return Deserialize<T>(document["value"]);
+    }
 }

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_date_time_concept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_date_time_concept.cs
@@ -7,12 +7,15 @@ namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
 
 public class when_round_tripping_a_date_time_concept : a_concept_serializer
 {
-    // A UTC value keeps the round-trip independent of the machine's local time zone: the serializer normalizes to
-    // UTC on the way out, and the deserializer hands back the same wall clock.
     static readonly DateTime _value = new(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
     DateTimeConcept _result;
 
-    void Because() => _result = Roundtrip(new DateTimeConcept(_value));
+    void Because()
+    {
+        // A UTC value keeps the round-trip independent of the machine's local time zone: the serializer normalizes
+        // to UTC on the way out and the deserializer hands back the same wall clock.
+        _result = Roundtrip(new DateTimeConcept(_value));
+    }
 
     [Fact] void should_preserve_the_value() => _result.Value.ShouldEqual(_value);
 }

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_date_time_concept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_date_time_concept.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_round_tripping_a_date_time_concept : a_concept_serializer
+{
+    // A UTC value keeps the round-trip independent of the machine's local time zone: the serializer normalizes to
+    // UTC on the way out, and the deserializer hands back the same wall clock.
+    static readonly DateTime _value = new(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+    DateTimeConcept _result;
+
+    void Because() => _result = Roundtrip(new DateTimeConcept(_value));
+
+    [Fact] void should_preserve_the_value() => _result.Value.ShouldEqual(_value);
+}

--- a/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_float_concept.cs
+++ b/Source/DotNET/MongoDB.Specs/for_ConceptSerializer/when_round_tripping_a_float_concept.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB.for_ConceptSerializer.given;
+
+namespace Cratis.Arc.MongoDB.for_ConceptSerializer;
+
+public class when_round_tripping_a_float_concept : a_concept_serializer
+{
+    FloatConcept _result;
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _result = Roundtrip(new FloatConcept(3.5f)));
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_preserve_the_value() => _result.Value.ShouldEqual(3.5f);
+}

--- a/Source/DotNET/MongoDB/ConceptSerializer.cs
+++ b/Source/DotNET/MongoDB/ConceptSerializer.cs
@@ -94,7 +94,9 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         }
         else if (underlyingValueType == typeof(float))
         {
-            bsonWriter.WriteDouble((double)underlyingValue);
+            // underlyingValue is a boxed float; unboxing goes to the exact type first, then widens. A direct
+            // (double)underlyingValue unbox-casts the boxed float straight to double and throws InvalidCastException.
+            bsonWriter.WriteDouble((double)(float)underlyingValue);
         }
         else if (underlyingValueType == typeof(int))
         {
@@ -126,8 +128,11 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         }
         else if (underlyingValueType == typeof(DateTime))
         {
+            // BSON DateTime is milliseconds since the Unix epoch, which is what the deserializer reads back with
+            // DateTimeOffset.FromUnixTimeMilliseconds. Writing ticks-since-0001 (Ticks / TicksPerMillisecond) used a
+            // different epoch, so every value read back as a wildly wrong date.
             var dateTime = (DateTime)underlyingValue;
-            bsonWriter.WriteDateTime(dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond);
+            bsonWriter.WriteDateTime(new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeMilliseconds());
         }
         else if (underlyingValueType == typeof(DateTimeOffset))
         {


### PR DESCRIPTION
## Fixed

- A `float`-backed concept can now be persisted to MongoDB — it previously threw on every write
- A `DateTime`-backed concept now round-trips correctly instead of being read back as a wildly wrong date
