### PR TITLE
Guard against a null event in the command response value handler

### DIFF
--- a/Source/DotNET/Chronicle.Specs/Commands/for_EventsCommandResponseValueHandler/when_checking_can_handle/with_a_null_element_in_the_collection.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_EventsCommandResponseValueHandler/when_checking_can_handle/with_a_null_element_in_the_collection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Chronicle.Commands.for_EventsCommandResponseValueHandler.when_checking_can_handle;
+
+public class with_a_null_element_in_the_collection : given.an_events_command_response_value_handler
+{
+    IEnumerable<object> _events;
+    bool _result;
+
+    void Establish()
+    {
+        _events = [new TestEvent("Test"), null!];
+        _eventTypes.HasFor(typeof(TestEvent)).Returns(true);
+    }
+
+    void Because() => _result = _handler.CanHandle(_commandContext, _events);
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Chronicle/Commands/EventsCommandResponseValueHandler.cs
+++ b/Source/DotNET/Chronicle/Commands/EventsCommandResponseValueHandler.cs
@@ -17,7 +17,7 @@ public class EventsCommandResponseValueHandler(IEventLog eventLog, IEventTypes e
     /// <inheritdoc/>
     public bool CanHandle(CommandContext commandContext, object value) =>
         (value is IEnumerable<object> objects) &&
-        objects.All(o => eventTypes.HasFor(o.GetType())) &&
+        objects.All(o => o is not null && eventTypes.HasFor(o.GetType())) &&
         commandContext.HasEventSourceId();
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Fixed

- A command that returns an event collection containing a null element no longer fails with a server error during response detection — the collection is simply treated as not handled
