### PR TITLE
Generate proxies for enums not backed by int

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_converting_to_enum_descriptor/and_enum_is_byte_backed.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_converting_to_enum_descriptor/and_enum_is_byte_backed.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_converting_to_enum_descriptor;
+
+public class and_enum_is_byte_backed : Specification
+{
+    enum ByteEnum : byte
+    {
+        First = 1,
+        Second = 200
+    }
+
+    EnumDescriptor _result;
+
+    void Because() => _result = typeof(ByteEnum).ToEnumDescriptor();
+
+    [Fact] void should_have_both_members() => _result.Values.Count().ShouldEqual(2);
+    [Fact] void should_preserve_the_first_value() => Convert.ToInt64(_result.Values.First().Value).ShouldEqual(1L);
+    [Fact] void should_preserve_the_second_value() => Convert.ToInt64(_result.Values.Last().Value).ShouldEqual(200L);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_converting_to_enum_descriptor/and_enum_is_long_flags.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_converting_to_enum_descriptor/and_enum_is_long_flags.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.ProxyGenerator.Templates;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.when_converting_to_enum_descriptor;
+
+public class and_enum_is_long_flags : Specification
+{
+    [Flags]
+    enum LongFlagsEnum : long
+    {
+        None = 0,
+        Low = 1L,
+        High = 1L << 40
+    }
+
+    EnumDescriptor _result;
+
+    void Because() => _result = typeof(LongFlagsEnum).ToEnumDescriptor();
+
+    [Fact] void should_have_all_members() => _result.Values.Count().ShouldEqual(3);
+    [Fact] void should_preserve_the_large_flag_value() => Convert.ToInt64(_result.Values.Last().Value).ShouldEqual(1L << 40);
+    [Fact] void should_build_the_all_flags_expression_from_non_zero_flags() => _result.AllFlagsExpression.ShouldEqual("LongFlagsEnum.low | LongFlagsEnum.high");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -684,7 +684,11 @@ public static class TypeExtensions
     /// <returns>Converted <see cref="EnumDescriptor"/>.</returns>
     public static EnumDescriptor ToEnumDescriptor(this Type type)
     {
-        var values = Enum.GetValuesAsUnderlyingType(type).Cast<int>();
+        // Keep the underlying values boxed as-is. GetValuesAsUnderlyingType returns the enum's actual underlying
+        // type (byte, long, ...), and Cast<int> unbox-casts each element to int, which throws for any enum not
+        // backed by int — e.g. `enum X : byte` or `[Flags] enum X : long`. EnumMemberDescriptor.Value is object
+        // and the flags math uses Convert.ToInt64, so the boxed underlying value flows through unchanged.
+        var values = Enum.GetValuesAsUnderlyingType(type).Cast<object>();
         var names = Enum.GetNames(type);
         var members = values.Select((value, index) => new EnumMemberDescriptor(names[index], value)).ToArray();
         var isFlags = type.IsFlagsEnum();


### PR DESCRIPTION
## Fixed

- A command, query, or read model that references an enum not backed by `int` (for example `enum X : byte` or `[Flags] enum X : long`) no longer breaks TypeScript proxy generation
