### PR TITLE
Map Uri to a TypeScript string, not Date

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_uri.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_getting_target_type_for_uri.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+public class when_getting_target_type_for_uri : Specification
+{
+    TargetType _result = null!;
+
+    void Because() => _result = typeof(Uri).GetTargetType();
+
+    [Fact] void should_map_to_the_string_type() => _result.Type.ShouldEqual("string");
+    [Fact] void should_construct_with_the_string_constructor() => _result.Constructor.ShouldEqual("String");
+}

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -68,7 +68,7 @@ public static class TypeExtensions
         { typeof(System.Text.Json.Nodes.JsonObject).FullName!, ObjectTypeFinal },
         { typeof(System.Text.Json.Nodes.JsonArray).FullName!, ObjectTypeFinal },
         { typeof(System.Text.Json.JsonDocument).FullName!, ObjectTypeFinal },
-        { typeof(Uri).FullName!, _dateTargetType },
+        { typeof(Uri).FullName!, _stringTargetType },
         { "Cratis.Geospatial.Point", new(typeof(object), "Point", "Point", "@cratis/fundamentals", FromPackage: true) },
         { "Cratis.Geospatial.LineString", new(typeof(object), "LineString", "LineString", "@cratis/fundamentals", FromPackage: true) },
         { "Cratis.Geospatial.Polygon", new(typeof(object), "Polygon", "Polygon", "@cratis/fundamentals", FromPackage: true) }


### PR DESCRIPTION
## Fixed

- A `Uri` property now generates a TypeScript `string` instead of a `Date`, so its value is no longer silently lost to an invalid date on the client
