### PR TITLE
Update dependencies including Chronicle to 16.6.1

### DIFF
--- a/Directory.Packages.NET8-9.props
+++ b/Directory.Packages.NET8-9.props
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageVersion Update="Microsoft.EntityFrameworkCore" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.EntityFrameworkCore.Relational" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.EntityFrameworkCore" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.EntityFrameworkCore.Relational" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.18" />
         <PackageVersion Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-        <PackageVersion Update="Microsoft.Extensions.Logging" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.Extensions.Logging" Version="9.0.18" />
         <!-- Tracks Microsoft.Extensions.Logging; the base props pin it at 10.x for net10, so it must be
              overridden to 9.x here or Logging.Debug 10.x drags Logging back to 10.x on net8/net9. -->
-        <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.17" />
-        <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.Extensions.Logging.Debug" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.18" />
+        <PackageVersion Update="System.Reflection.MetadataLoadContext" Version="9.0.18" />
         <PackageVersion Update="Microsoft.Build.Framework" Version="17.14.28" />
         <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.14.28" />
         <!-- Cratis.Chronicle 14.12.4 has a bug where it requires System.Text.Json 10.0.0 for all TFMs.
              This causes NSubstitute/Castle.DynamicProxy failures in tests when 9.x version is used.
              Only apply the 9.x override for non-test projects. -->
-        <PackageVersion Update="System.Text.Json" Version="9.0.17" Condition="'$(IsTestProject)' != 'true'" />
-        <PackageVersion Update="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.17" />
+        <PackageVersion Update="System.Text.Json" Version="9.0.18" Condition="'$(IsTestProject)' != 'true'" />
+        <PackageVersion Update="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.18" />
         <PackageVersion Update="Microsoft.Extensions.Telemetry" Version="9.10.0" />
-        <PackageVersion Update="Microsoft.Extensions.Hosting" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.Extensions.Hosting" Version="9.0.18" />
         <PackageVersion Update="Microsoft.Extensions.Resilience" Version="9.10.0" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.NET8.props
+++ b/Directory.Packages.NET8.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" />
+        <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.29" />
         <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
         <!-- The shared net8/net9 file keeps EF Core at 9.x, and EF Core 9.x requires DependencyModel 9.x,
              so net8 must use the 9.x DependencyModel too rather than the 8.x line. -->
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.18" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.NET9.props
+++ b/Directory.Packages.NET9.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.17" />
-        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.17" />
+        <PackageVersion Update="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.18" />
+        <PackageVersion Update="Microsoft.Extensions.DependencyModel" Version="9.0.18" />
     </ItemGroup>
    
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,47 +9,47 @@
     <!-- Transitive security pins -->
     <!-- SQLitePCLRaw 2.1.10/2.1.11 (pulled in transitively by EF Core Sqlite) has a high-severity advisory
          (GHSA-2m69-gcr7-jv3q). Pin the native library to the patched release. -->
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <!-- Microsoft.OpenApi 2.0.0 (pulled in transitively by Microsoft.AspNetCore.OpenApi) has a high-severity
          advisory (GHSA-v5pm-xwqc-g5wc). Pin to the patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle" Version="16.1.0" />
-    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.1.0" />
-    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.1.0" />
+    <PackageVersion Include="Cratis.Chronicle" Version="16.6.1" />
+    <PackageVersion Include="Cratis.Chronicle.AspNetCore" Version="16.6.1" />
+    <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.6.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.6" />
     <!-- MAUI -->
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
     <!-- Microsoft -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="18.7.1" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.8.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <!-- System -->
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.9" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
-    <PackageVersion Include="System.Reactive" Version="6.1.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Reactive" Version="7.0.0" />
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
     <PackageVersion Include="SharpCompress" Version="1.0.0" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="castle.core" Version="5.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.8.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <PackageVersion Include="snappier" Version="1.3.1" />
@@ -68,19 +68,19 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <!-- Override vulnerable/incompatible transitive dependencies from analyzer testing packages -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.122" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.125" />
     <!-- Specifications -->
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.1" />

--- a/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
+++ b/Source/DotNET/Chronicle.Testing/EventStoreForScenario.cs
@@ -66,6 +66,10 @@ internal sealed class EventStoreForScenario(EventScenario eventScenario, IReadMo
         throw new NotSupportedException("Reactors are not supported for command scenarios.");
 
     /// <inheritdoc/>
+    public IReadModelReactors ReadModelReactors =>
+        throw new NotSupportedException("Read model reactors are not supported for command scenarios.");
+
+    /// <inheritdoc/>
     public IReducers Reducers =>
         throw new NotSupportedException("Reducers are not supported for command scenarios.");
 

--- a/TestApps/Chronicle/CustomArtifactsProvider.cs
+++ b/TestApps/Chronicle/CustomArtifactsProvider.cs
@@ -15,6 +15,8 @@ public class CustomArtifactsProvider : IClientArtifactsProvider
 
     public IEnumerable<Type> Reactors => throw new NotImplementedException();
 
+    public IEnumerable<Type> ReadModelReactors => throw new NotImplementedException();
+
     public IEnumerable<Type> Reducers => throw new NotImplementedException();
 
     public IEnumerable<Type> ReactorMiddlewares => throw new NotImplementedException();


### PR DESCRIPTION
## Changed

- Updated Cratis Chronicle to 16.6.1
- Updated System.Reactive to 7.0.0
- Updated Entity Framework Core and other Microsoft/.NET dependencies to the latest 10.0.10 servicing releases
