### PR TITLE
Resolve the default tenant to the unsuffixed read model database

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenantId/when_asking_whether_it_is_the_default.cs
+++ b/Source/DotNET/Arc.Core.Specs/Tenancy/for_TenantId/when_asking_whether_it_is_the_default.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Tenancy.for_TenantId;
+
+public class when_asking_whether_it_is_the_default : Specification
+{
+    [Fact] void should_consider_an_unset_tenant_the_default() => TenantId.NotSet.IsDefault.ShouldBeTrue();
+
+    [Fact] void should_consider_the_default_tenant_the_default() => TenantId.Default.IsDefault.ShouldBeTrue();
+
+    [Fact] void should_consider_the_default_tenant_by_value_the_default() => new TenantId("Default").IsDefault.ShouldBeTrue();
+
+    [Fact] void should_not_consider_a_named_tenant_the_default() => new TenantId("tenant-123").IsDefault.ShouldBeFalse();
+}

--- a/Source/DotNET/Arc.Core/Tenancy/TenantId.cs
+++ b/Source/DotNET/Arc.Core/Tenancy/TenantId.cs
@@ -15,6 +15,22 @@ public record TenantId(string Value) : ConceptAs<string>(Value)
     public static readonly TenantId NotSet = new("[NotSet]");
 
     /// <summary>
+    /// Represents the default tenant.
+    /// </summary>
+    /// <remarks>
+    /// A host that resolves no tenant and a host that resolves this tenant by name address the same data. Storage
+    /// that partitions by tenant must therefore treat the two identically — Chronicle names the default namespace
+    /// "Default" and materializes its read models without a tenant suffix, so a reader that suffixes this tenant
+    /// resolves a database that does not exist and reads come back empty rather than failing.
+    /// </remarks>
+    public static readonly TenantId Default = new("Default");
+
+    /// <summary>
+    /// Gets a value indicating whether this is the default tenant — either unset, or the default tenant by name.
+    /// </summary>
+    public bool IsDefault => this == NotSet || this == Default;
+
+    /// <summary>
     /// Implicitly convert from a <see cref="string"/> to a <see cref="TenantId"/>.
     /// </summary>
     /// <param name="value">Value to convert from.</param>

--- a/Source/DotNET/Chronicle.Specs/Tenancy/for_TenantNamespaceResolver/when_resolving/and_tenant_id_is_the_default_tenant.cs
+++ b/Source/DotNET/Chronicle.Specs/Tenancy/for_TenantNamespaceResolver/when_resolving/and_tenant_id_is_the_default_tenant.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Tenancy;
+using Cratis.Chronicle;
+
+namespace Cratis.Arc.Chronicle.Tenancy.for_TenantNamespaceResolver.when_resolving;
+
+/// <summary>
+/// Naming the default tenant explicitly has to land on the same namespace as resolving no tenant at all —
+/// otherwise the write side and the tenant-partitioned read side address different databases.
+/// </summary>
+public class and_tenant_id_is_the_default_tenant : Specification
+{
+    TenantNamespaceResolver _resolver;
+    ITenantIdAccessor _tenantIdAccessor;
+    EventStoreNamespaceName _result;
+
+    void Establish()
+    {
+        _tenantIdAccessor = Substitute.For<ITenantIdAccessor>();
+        _tenantIdAccessor.Current.Returns(TenantId.Default);
+
+        _resolver = new TenantNamespaceResolver(_tenantIdAccessor);
+    }
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_the_default_namespace() => _result.ShouldEqual(EventStoreNamespaceName.Default);
+}

--- a/Source/DotNET/Chronicle/Tenancy/TenantNamespaceResolver.cs
+++ b/Source/DotNET/Chronicle/Tenancy/TenantNamespaceResolver.cs
@@ -13,10 +13,15 @@ namespace Cratis.Arc.Chronicle.Tenancy;
 public class TenantNamespaceResolver(ITenantIdAccessor tenantIdAccessor) : IEventStoreNamespaceResolver
 {
     /// <inheritdoc/>
+    /// <remarks>
+    /// The default tenant — unset, or named <see cref="TenantId.Default"/> — maps to Chronicle's default
+    /// namespace. Storage that partitions by tenant has to agree with this mapping; see
+    /// <see cref="TenantId.IsDefault"/>.
+    /// </remarks>
     public EventStoreNamespaceName Resolve()
     {
         var tenantId = tenantIdAccessor.Current;
-        return tenantId == TenantId.NotSet
+        return tenantId.IsDefault
             ? EventStoreNamespaceName.Default
             : new EventStoreNamespaceName(tenantId.Value);
     }

--- a/Source/DotNET/MongoDB.Specs/for_DefaultMongoDatabaseNameResolver/when_resolving/and_tenant_id_is_the_default_tenant.cs
+++ b/Source/DotNET/MongoDB.Specs/for_DefaultMongoDatabaseNameResolver/when_resolving/and_tenant_id_is_the_default_tenant.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Tenancy;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.MongoDB.for_DefaultMongoDatabaseNameResolver.when_resolving;
+
+/// <summary>
+/// A host that names the default tenant explicitly must address the same database as one that resolves no tenant
+/// at all. Chronicle materializes the default namespace's read models into the bare database name, so suffixing
+/// this tenant addresses a database nothing writes to — and reading a database that does not exist returns no
+/// rows rather than failing.
+/// </summary>
+public class and_tenant_id_is_the_default_tenant : Specification
+{
+    DefaultMongoDatabaseNameResolver _resolver;
+    IOptionsMonitor<MongoDBOptions> _options;
+    ITenantIdAccessor _tenantIdAccessor;
+    string _databaseName;
+    string _result;
+
+    void Establish()
+    {
+        _databaseName = "test-database";
+
+        _options = Substitute.For<IOptionsMonitor<MongoDBOptions>>();
+        _options.CurrentValue.Returns(new MongoDBOptions { Database = _databaseName });
+
+        _tenantIdAccessor = Substitute.For<ITenantIdAccessor>();
+        _tenantIdAccessor.Current.Returns(TenantId.Default);
+
+        _resolver = new DefaultMongoDatabaseNameResolver(_options, _tenantIdAccessor);
+    }
+
+    void Because() => _result = _resolver.Resolve();
+
+    [Fact] void should_return_the_database_name_without_a_tenant_suffix() => _result.ShouldEqual(_databaseName);
+}

--- a/Source/DotNET/MongoDB/DefaultMongoDatabaseNameResolver.cs
+++ b/Source/DotNET/MongoDB/DefaultMongoDatabaseNameResolver.cs
@@ -14,12 +14,17 @@ namespace Cratis.Arc.MongoDB;
 public class DefaultMongoDatabaseNameResolver(IOptionsMonitor<MongoDBOptions> options, ITenantIdAccessor tenantIdAccessor) : IMongoDatabaseNameResolver
 {
     /// <inheritdoc/>
+    /// <remarks>
+    /// The default tenant — unset, or named <see cref="TenantId.Default"/> — resolves the bare database name.
+    /// Suffixing it instead would address a database that nothing writes to, and a read of a database that does
+    /// not exist returns no rows rather than failing, so the mistake surfaces as silently empty results.
+    /// </remarks>
     public string Resolve()
     {
         var databaseName = options.CurrentValue.Database;
         var tenantId = tenantIdAccessor.Current;
 
-        if (tenantId == TenantId.NotSet)
+        if (tenantId.IsDefault)
         {
             return databaseName;
         }


### PR DESCRIPTION
# Summary

A tenant named `Default` read from a database that does not exist, so every read model query silently returned no rows.

## Added

- `TenantId.Default` and `TenantId.IsDefault` for treating the default tenant — unset, or named — consistently across tenant-partitioned storage.

## Fixed

- A tenant named `Default` now resolves the unsuffixed MongoDB database, matching where Chronicle materializes the default namespace's read models. Previously it resolved `<database>+Default`, which does not exist, so both `IMongoCollection<TReadModel>` one-shot reads and `.Observe()` live queries returned no rows without erroring.
