### PR TITLE
Add optional eventSourceFactory for custom SSE transport

### DIFF
--- a/Documentation/frontend/react/arc.md
+++ b/Documentation/frontend/react/arc.md
@@ -31,6 +31,7 @@ The `<Arc />` component provides centralized configuration for all commands and 
 | basePath | String | Base path for the application |
 | apiBasePath | String | Base path prepended to all Command and Query requests |
 | httpHeadersCallback | Function | Optional callback function that returns additional HTTP headers to include with all commands, queries, and identity requests (e.g., for including cookies or authentication tokens) |
+| eventSourceFactory | `(url: string) => EventSource` | Optional factory for creating the `EventSource` instances used by SSE observable query connections. Falls back to the global `EventSource` constructor when not set — see [Custom EventSource Factory](./queries/configuration.md#custom-eventsource-factory) |
 | queryTransportMethod | `QueryTransportMethod` | Transport used by observable queries (`ServerSentEvents` or `WebSocket`) |
 | queryDirectMode | Boolean | Whether observable queries bypass the central hub and connect directly per-query |
 | queryConnectionCount | Number | Number of observable query hub connection slots |

--- a/Documentation/frontend/react/queries/configuration.md
+++ b/Documentation/frontend/react/queries/configuration.md
@@ -14,6 +14,7 @@ Configure query behavior centrally through the `<Arc />` component instead of pe
 | `queryConnectionCount` | `number` | `1` | Number of observable query hub connection slots. |
 | `observableQueryTransferMode` | `ObservableQueryTransferMode` | `Delta` | Controls how `useChangeStream()` processes incoming snapshots and deltas. |
 | `queryCacheRetentionMs` | `number` | `30000` | How long to keep cached query data alive after the last subscriber unmounts. |
+| `eventSourceFactory` | `(url: string) => EventSource` | `undefined` | Custom factory for creating the `EventSource` instances used by SSE observable query connections. Falls back to the global `EventSource` constructor when not set. |
 
 ## Example
 
@@ -75,6 +76,33 @@ Globals.queryCacheRetentionMs = 60_000;
 Use `queryTransportMethod`, `queryDirectMode`, and `queryConnectionCount` to control observable query connection behavior.
 
 For transport semantics, hub behavior, SSE limits, and pooling details, see [Observable Query Multiplexing](./observable-query-multiplexing.md).
+
+## Custom EventSource Factory
+
+By default, SSE observable query connections create their transport with the global `EventSource` constructor. Some environments either lack a native `EventSource` — React Native does not ship one — or ship one with unreliable streaming behavior. JS-based polyfills built on `XMLHttpRequest` are known to deliver messages in bulk instead of streaming them, silently drop connections when the app is backgrounded, and provide no reliable way to detect a dead connection on Android.
+
+Set `eventSourceFactory` to substitute your own SSE client without changing anything else about how observable queries work:
+
+```tsx
+import { Arc } from '@cratis/arc.react';
+import RNEventSource from 'react-native-nitro-sse';
+
+export const App = () => (
+    <Arc eventSourceFactory={(url) => new RNEventSource(url)}>
+        <MyRoutes />
+    </Arc>
+);
+```
+
+The factory receives the fully-qualified connection URL and must return an object implementing the standard `EventSource` interface (`onmessage`, `onerror`, `close()`, `readyState`). This applies to both direct-mode and hub-mode SSE connections.
+
+The default can also be set globally without the React component:
+
+```typescript
+import { Globals } from '@cratis/arc';
+
+Globals.eventSourceFactory = (url) => new RNEventSource(url);
+```
 
 ## Change Stream Transfer Mode
 

--- a/Source/JavaScript/Arc.React/Arc.tsx
+++ b/Source/JavaScript/Arc.React/Arc.tsx
@@ -5,7 +5,7 @@ import { CommandScope } from './commands';
 import { IdentityProvider } from './identity';
 import { Bindings } from './Bindings';
 import { ArcConfiguration, ArcContext } from './ArcContext';
-import { GetHttpHeaders, Globals, ObservableQueryTransferMode } from '@cratis/arc';
+import { GetHttpHeaders, EventSourceFactory, Globals, ObservableQueryTransferMode } from '@cratis/arc';
 import { QueryTransportMethod, QueryInstanceCache } from '@cratis/arc/queries';
 import { resetSharedMultiplexer } from '@cratis/arc/queries';
 import { ObservableQueryDiagnostics, getSharedMultiplexer } from '@cratis/arc/queries';
@@ -25,6 +25,13 @@ export interface ArcProps {
     basePath?: string;
     apiBasePath?: string;
     httpHeadersCallback?: GetHttpHeaders;
+    /**
+     * Optional factory used to create the {@link EventSource} instances that back SSE
+     * observable query connections. Falls back to the global {@link EventSource}
+     * constructor when not set — override it to supply a custom SSE client (e.g. a
+     * native implementation on React Native, where the global constructor is unavailable).
+     */
+    eventSourceFactory?: EventSourceFactory;
     /**
      * The transport method used for observable query subscriptions.
      * Defaults to {@link QueryTransportMethod.ServerSentEvents}.
@@ -99,6 +106,7 @@ export const Arc = (props: ArcProps) => {
         basePath: props.basePath ?? '',
         apiBasePath: props.apiBasePath ?? '',
         httpHeadersCallback: props.httpHeadersCallback,
+        eventSourceFactory: props.eventSourceFactory,
         queryTransportMethod: props.queryTransportMethod ?? QueryTransportMethod.ServerSentEvents,
         queryConnectionCount: props.queryConnectionCount ?? 1,
         queryDirectMode: props.queryDirectMode ?? false,
@@ -117,7 +125,8 @@ export const Arc = (props: ArcProps) => {
         configuration.queryTransportMethod,
         configuration.queryConnectionCount,
         configuration.queryDirectMode,
-        configuration.observableQueryTransferMode);
+        configuration.observableQueryTransferMode,
+        configuration.eventSourceFactory);
 
     useEffect(() => {
         const cache = queryInstanceCache.current;

--- a/Source/JavaScript/Arc.React/ArcContext.ts
+++ b/Source/JavaScript/Arc.React/ArcContext.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { GetHttpHeaders, ObservableQueryTransferMode, Globals } from '@cratis/arc';
+import { GetHttpHeaders, EventSourceFactory, ObservableQueryTransferMode, Globals } from '@cratis/arc';
 import { QueryTransportMethod } from '@cratis/arc/queries';
 import type { IObservableQueryDiagnostics } from '@cratis/arc/queries';
 import { IMessenger, Messenger } from '@cratis/arc/messaging';
@@ -15,6 +15,12 @@ export interface ArcConfiguration {
     basePath?: string;
     apiBasePath?: string;
     httpHeadersCallback?: GetHttpHeaders;
+    /**
+     * Optional factory used to create the {@link EventSource} instances that back SSE
+     * observable query connections. Mirrors {@link Globals.eventSourceFactory}.
+     * Falls back to the global {@link EventSource} constructor when not set.
+     */
+    eventSourceFactory?: EventSourceFactory;
     queryTransportMethod?: QueryTransportMethod;
     /**
      * Number of hub connections maintained for observable queries.

--- a/Source/JavaScript/Arc.React/Bindings.ts
+++ b/Source/JavaScript/Arc.React/Bindings.ts
@@ -4,11 +4,11 @@
 import { container } from 'tsyringe';
 import { Constructor } from '@cratis/fundamentals';
 import { IQueryProvider, QueryProvider, QueryTransportMethod } from '@cratis/arc/queries';
-import { Globals, GetHttpHeaders, ObservableQueryTransferMode } from '@cratis/arc';
+import { Globals, GetHttpHeaders, EventSourceFactory, ObservableQueryTransferMode } from '@cratis/arc';
 import { WellKnownBindings } from './WellKnownBindings';
 
 export class Bindings {
-    static initialize(microservice: string, apiBasePath?: string, origin?: string, httpHeadersCallback?: GetHttpHeaders, queryTransportMethod?: QueryTransportMethod, queryConnectionCount?: number, queryDirectMode?: boolean, observableQueryTransferMode?: ObservableQueryTransferMode): void {
+    static initialize(microservice: string, apiBasePath?: string, origin?: string, httpHeadersCallback?: GetHttpHeaders, queryTransportMethod?: QueryTransportMethod, queryConnectionCount?: number, queryDirectMode?: boolean, observableQueryTransferMode?: ObservableQueryTransferMode, eventSourceFactory?: EventSourceFactory): void {
         Globals.microservice = microservice;
         Globals.apiBasePath = apiBasePath ?? '';
         Globals.origin = origin ?? '';
@@ -17,6 +17,7 @@ export class Bindings {
         Globals.queryDirectMode = queryDirectMode ?? false;
         Globals.observableQueryTransferMode = observableQueryTransferMode ?? ObservableQueryTransferMode.Delta;
         Globals.httpHeadersCallback = httpHeadersCallback ?? (() => ({}));
+        Globals.eventSourceFactory = eventSourceFactory;
         container.registerSingleton(WellKnownBindings.microservice, microservice);
         container.register(IQueryProvider as Constructor<IQueryProvider>, { useValue: new QueryProvider(microservice, apiBasePath ?? '', origin ?? '', httpHeadersCallback ?? (() => ({}))) });
     }

--- a/Source/JavaScript/Arc.React/for_Bindings/when_initializing_with_event_source_factory.ts
+++ b/Source/JavaScript/Arc.React/for_Bindings/when_initializing_with_event_source_factory.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { Bindings } from '../Bindings';
+import { Globals, EventSourceFactory } from '@cratis/arc';
+import { bindings_context } from './given/bindings_context';
+import { given } from '../given';
+
+describe('when initializing bindings with a custom event source factory', given(bindings_context, () => {
+    let originalFactory: EventSourceFactory | undefined;
+    let factory: sinon.SinonStub;
+
+    beforeEach(() => {
+        originalFactory = Globals.eventSourceFactory;
+        factory = sinon.stub();
+
+        Bindings.initialize('test-microservice', '/test/api', 'http://test.com', undefined, undefined, undefined, undefined, undefined, factory as unknown as EventSourceFactory);
+    });
+
+    afterEach(() => {
+        Globals.eventSourceFactory = originalFactory;
+        sinon.restore();
+    });
+
+    it('should set globals event source factory', () => Globals.eventSourceFactory!.should.equal(factory));
+}));

--- a/Source/JavaScript/Arc/EventSourceFactory.ts
+++ b/Source/JavaScript/Arc/EventSourceFactory.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * Represents a function that creates an {@link EventSource} for a given URL.
+ *
+ * Arc uses the global {@link EventSource} constructor by default. Provide a factory to
+ * substitute a custom implementation — for example a native SSE client on React Native,
+ * where {@link EventSource} is unavailable and JS-based polyfills built on
+ * `XMLHttpRequest` have unreliable streaming behavior on Android.
+ */
+export type EventSourceFactory = (url: string) => EventSource;

--- a/Source/JavaScript/Arc/Globals.ts
+++ b/Source/JavaScript/Arc/Globals.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { GetHttpHeaders } from './GetHttpHeaders';
+import { EventSourceFactory } from './EventSourceFactory';
 import { QueryTransportMethod } from './queries/QueryTransportMethod';
 import { QueryHttpMethod } from './queries/QueryHttpMethod';
 import { QueryHttpMethodResolver } from './queries/QueryHttpMethodResolver';
@@ -67,6 +68,13 @@ export interface IGlobals {
      * (e.g. SSE subscribe/unsubscribe POST calls).
      */
     httpHeadersCallback: GetHttpHeaders;
+    /**
+     * Optional factory used to create the {@link EventSource} instances that back SSE
+     * observable query connections. Falls back to the global {@link EventSource}
+     * constructor when not set — override it to supply a custom SSE client (e.g. a
+     * native implementation on React Native, where the global constructor is unavailable).
+     */
+    eventSourceFactory?: EventSourceFactory;
     /**
      * How long in milliseconds to retain a query cache entry after the last subscriber
      * releases it before evicting the subscription and the cached data.

--- a/Source/JavaScript/Arc/index.ts
+++ b/Source/JavaScript/Arc/index.ts
@@ -13,6 +13,7 @@ export * from './deepEqual';
 export * from './Globals';
 export * from './ICanBeConfigured';
 export * from './GetHttpHeaders';
+export * from './EventSourceFactory';
 
 export {
     commands,

--- a/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventHubConnection.ts
@@ -192,7 +192,7 @@ export class ServerSentEventHubConnection implements IObservableQueryHubConnecti
         }
 
         this._connectionId = undefined;
-        this._eventSource = new EventSource(url);
+        this._eventSource = Globals.eventSourceFactory ? Globals.eventSourceFactory(url) : new EventSource(url);
 
         this._eventSource.onopen = () => {
             if (this._disconnected) return;

--- a/Source/JavaScript/Arc/queries/ServerSentEventQueryConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventQueryConnection.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { Globals } from '../Globals';
 import { IObservableQueryConnection } from './IObservableQueryConnection';
 import { DataReceived } from './ObservableQueryConnection';
 import { QueryResult } from './QueryResult';
@@ -39,8 +40,9 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
     connect(dataReceived: DataReceived<TDataType>, queryArguments?: object): void {
         if (this._disconnected) return;
 
-        // Guard against environments where EventSource is not available (e.g. Node.js, SSR).
-        if (typeof EventSource === 'undefined') {
+        // Guard against environments where EventSource is not available (e.g. Node.js, SSR)
+        // and no custom factory has been supplied to substitute it.
+        if (!Globals.eventSourceFactory && typeof EventSource === 'undefined') {
             return;
         }
 
@@ -56,7 +58,7 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
             }
         }
 
-        this._eventSource = new EventSource(url);
+        this._eventSource = Globals.eventSourceFactory ? Globals.eventSourceFactory(url) : new EventSource(url);
 
         this._eventSource.onmessage = (event: MessageEvent) => {
             if (this._disconnected) return;

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_subscribing/uses_custom_event_source_factory.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventHubConnection/when_subscribing/uses_custom_event_source_factory.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { Globals } from '../../../Globals';
+import { EventSourceFactory } from '../../../EventSourceFactory';
+import { a_server_sent_event_hub_connection } from '../given/a_server_sent_event_hub_connection';
+import { given } from '../../../given';
+import { HubMessageType } from '../../WebSocketHubConnection';
+
+interface FakeEventSource {
+    onopen: (() => void) | null;
+    onmessage: ((event: MessageEvent) => void) | null;
+    onerror: (() => void) | null;
+    close: sinon.SinonStub;
+    readyState: number;
+}
+
+describe('when subscribing with a custom event source factory configured', given(a_server_sent_event_hub_connection, context => {
+    let customEventSource: FakeEventSource;
+    let factoryStub: sinon.SinonStub;
+    let originalFactory: EventSourceFactory | undefined;
+
+    beforeEach(() => {
+        originalFactory = Globals.eventSourceFactory;
+
+        customEventSource = {
+            onopen: null,
+            onmessage: null,
+            onerror: null,
+            close: sinon.stub(),
+            readyState: 1, // OPEN
+        };
+        factoryStub = sinon.stub().returns(customEventSource);
+        Globals.eventSourceFactory = factoryStub as unknown as EventSourceFactory;
+
+        context.setup();
+        context.connection.subscribe('q1', { queryName: 'MyQuery' }, sinon.stub());
+    });
+
+    afterEach(() => {
+        Globals.eventSourceFactory = originalFactory;
+        sinon.restore();
+    });
+
+    it('should call the custom factory with the SSE hub url', () => factoryStub.calledOnce.should.be.true);
+    it('should pass the hub url to the factory', () => factoryStub.getCall(0).args[0].should.equal('http://localhost/.cratis/queries/sse'));
+    it('should not use the default global EventSource', () => (context.fakeEventSource.onopen === null).should.be.true);
+
+    describe('when the custom event source receives the Connected message', () => {
+        beforeEach(() => {
+            customEventSource.onmessage!({ data: JSON.stringify({ type: HubMessageType.Connected, payload: 'conn-1' }) } as MessageEvent);
+        });
+
+        it('should record the connection as open', () => context.connection.isConnected.should.be.true);
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventQueryConnection/when_connecting/with_custom_event_source_factory.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventQueryConnection/when_connecting/with_custom_event_source_factory.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { Globals } from '../../../Globals';
+import { EventSourceFactory } from '../../../EventSourceFactory';
+import { ServerSentEventQueryConnection } from '../../ServerSentEventQueryConnection';
+import { QueryResult } from '../../QueryResult';
+
+interface FakeEventSource {
+    onmessage: ((event: MessageEvent) => void) | null;
+    onerror: (() => void) | null;
+    close: sinon.SinonStub;
+}
+
+describe('when connecting with a custom event source factory configured and no global EventSource available', () => {
+    let originalEventSource: typeof EventSource;
+    let originalFactory: EventSourceFactory | undefined;
+    let fakeEventSource: FakeEventSource;
+    let factoryStub: sinon.SinonStub;
+    let connection: ServerSentEventQueryConnection<string[]>;
+    let receivedData: QueryResult<string[]>[];
+
+    beforeEach(() => {
+        originalEventSource = (globalThis as Record<string, unknown>)['EventSource'] as typeof EventSource;
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+
+        originalFactory = Globals.eventSourceFactory;
+
+        fakeEventSource = {
+            onmessage: null,
+            onerror: null,
+            close: sinon.stub(),
+        };
+        factoryStub = sinon.stub().returns(fakeEventSource);
+        Globals.eventSourceFactory = factoryStub as unknown as EventSourceFactory;
+
+        receivedData = [];
+        connection = new ServerSentEventQueryConnection<string[]>(new URL('http://localhost/.cratis/queries/sse?query=Test'));
+        connection.connect((result: QueryResult<string[]>) => receivedData.push(result));
+    });
+
+    afterEach(() => {
+        if (originalEventSource !== undefined) {
+            (globalThis as Record<string, unknown>)['EventSource'] = originalEventSource;
+        }
+        Globals.eventSourceFactory = originalFactory;
+        sinon.restore();
+    });
+
+    it('should call the custom factory instead of the global EventSource constructor', () => factoryStub.calledOnce.should.be.true);
+    it('should pass the connection url to the factory', () => (factoryStub.getCall(0).args[0] as string).should.contain('/.cratis/queries/sse'));
+
+    describe('when a message arrives on the custom event source', () => {
+        const result = { data: ['a', 'b'], isSuccess: true, isAuthorized: true, isValid: true, hasExceptions: false, hasData: true, validationResults: [], exceptionMessages: [], exceptionStackTrace: '', paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 } };
+
+        beforeEach(() => {
+            fakeEventSource.onmessage!({ data: JSON.stringify(result) } as MessageEvent);
+        });
+
+        it('should deliver the payload to the callback', () => receivedData.length.should.equal(1));
+    });
+});


### PR DESCRIPTION
## Added
- Optional `eventSourceFactory` prop on `<Arc />` (and `Globals.eventSourceFactory`) that lets you substitute the `EventSource` implementation used by SSE observable query connections, falling back to the global `EventSource` constructor when not set. This unblocks environments like React Native that lack a native `EventSource` or need a more reliable native SSE client (#2376)

## Documentation
- Document `eventSourceFactory` in the Arc configuration reference and add a "Custom EventSource Factory" section with a React Native example