### PR TITLE
Screenplay generation and proxy generator hardening fixes

### DIFF
--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_generated_members_sit_under_obj.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_whose_generated_members_sit_under_obj.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A source generator writes partial members into a slice's namespace and emits them to disk under <c>obj/</c>. Those
+/// files contribute symbols to the slice but say nothing about where its source - and therefore its screens - live, so
+/// the slice is not spread over the folder they sit in and screen discovery must not scan it.
+/// </summary>
+public class a_slice_whose_generated_members_sit_under_obj : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [Command]
+        public partial record RegisterAuthor(string Name)
+        {
+            public AuthorRegistered Handle() => new(Name);
+        }
+        """;
+
+    const string Generated = """
+        namespace Library.Authors.Registration;
+
+        public partial record RegisterAuthor
+        {
+        }
+        """;
+
+    static readonly DeclaredUserInterfaceFiles _files = new(
+        "Library/Authors/Registration/AddAuthor.tsx");
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ScreenModel> _screens;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(
+            _files,
+            ("Library/Authors/Registration/Registration.cs", Source),
+            ("Library/obj/Debug/net10.0/Generator/RegisterAuthor.Logging.g.cs", Generated));
+        _screens = _analysis.Slice().Screens;
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Authors/Registration/Registration.cs", Source), ("Library/obj/Debug/net10.0/Generator/RegisterAuthor.Logging.g.cs", Generated)).ShouldBeEmpty();
+    [Fact] void should_not_report_the_slice_as_spread_over_folders() => _analysis.Diagnostics.Select(_ => _.Code).ShouldNotContain(ScreenplayDiagnosticCodes.AmbiguousScreenFile);
+    [Fact] void should_still_recover_the_screen_from_the_authored_folder() => _screens.Select(_ => _.Name).ShouldContainOnly(["AddAuthor"]);
+    [Fact] void should_point_at_the_file_realizing_the_screen() => _screens.Single().FilePath.ShouldEqual("Authors/Registration/AddAuthor.tsx");
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_whose_message_is_a_lambda_returning_a_constant.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_whose_message_is_a_lambda_returning_a_constant.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// FluentValidation lets a message be a value or a lambda producing one, and keeping messages in one place behind a
+/// constant - <c>WithMessage(_ =&gt; Messages.NameRequired)</c> - is the common way an application writes them. The
+/// lambda body is a plain reference the semantic model reads a compile-time constant from, so the message is
+/// recovered exactly as it would be from a value written inline.
+/// </summary>
+public class a_validator_whose_message_is_a_lambda_returning_a_constant : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        public static class AuthorMessages
+        {
+            public const string NameRequired = "An author must have a name";
+        }
+
+        [Command]
+        public record RegisterAuthor(string Name, string Email)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).NotEmpty().WithMessage(_ => AuthorMessages.NameRequired);
+                RuleFor(_ => _.Email).EmailAddress().WithMessage(_ => "An email must look like one");
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ValidationRuleModel> _rules;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _rules = _analysis.Slice().Commands.First().Validations;
+    }
+
+    ValidationRuleModel Rule(ValidationRuleKind kind) => _rules.First(_ => _.Kind == kind);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_recover_a_message_from_a_lambda_returning_a_constant() => Rule(ValidationRuleKind.NotEmpty).Message.ShouldEqual("An author must have a name");
+    [Fact] void should_recover_a_message_from_a_lambda_returning_a_literal() => Rule(ValidationRuleKind.Matches).Message.ShouldEqual("An email must look like one");
+    [Fact] void should_leave_no_message_unrecovered() => _analysis.Diagnostics.Select(_ => _.Code).ShouldNotContain(ScreenplayDiagnosticCodes.UnmappableValidationRule);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_whose_message_is_computed.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_validator_whose_message_is_computed.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A message a lambda computes at runtime - an interpolation, a call, a culture-dependent lookup - has no
+/// compile-time constant to read, so there is nothing to write into the document. It stays reported rather than
+/// guessed at, which is what keeps the recovery of the constant forms honest.
+/// </summary>
+public class a_validator_whose_message_is_computed : Specification
+{
+    const string Source = """
+        using Cratis.Arc.Commands;
+        using Cratis.Arc.Commands.ModelBound;
+        using FluentValidation;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(string Name)
+        {
+            public void Handle()
+            {
+            }
+        }
+
+        public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+        {
+            public RegisterAuthorValidator()
+            {
+                RuleFor(_ => _.Name).NotEmpty().WithMessage(_ => $"The name '{_.Name}' is not allowed");
+            }
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+    IEnumerable<ValidationRuleModel> _rules;
+
+    void Establish()
+    {
+        _analysis = Analyzed.Source(Source);
+        _rules = _analysis.Slice().Commands.First().Validations;
+    }
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_leave_the_rule_without_a_message() => _rules.First(_ => _.Kind == ValidationRuleKind.NotEmpty).Message.ShouldBeNull();
+    [Fact] void should_report_the_message_it_could_not_recover() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableValidationRule);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_carried_only_inside_a_record.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/concepts_carried_only_inside_a_record.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A record is referred to by name and never declared, so nothing inside it is ever named on its own. Collecting only
+/// the types written straight onto an artifact therefore lost every concept reached through one - and a concept marked
+/// as personal data lost that way leaves a document understating what the application holds about people, which is the
+/// one thing declaring concepts is most for. A concept can be declared wherever it was reached from, so it is.
+/// </summary>
+public class concepts_carried_only_inside_a_record : Specification
+{
+    const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Compliance.GDPR;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorId(Guid Value) : ConceptAs<Guid>(Value);
+
+        [PII("The name of a person")]
+        public record FirstName(string Value) : ConceptAs<string>(Value);
+
+        public record MentorNote(string Value) : ConceptAs<string>(Value);
+
+        public record ShelfCode(string Value) : ConceptAs<string>(Value);
+
+        public enum ContactPreference { Email, Phone }
+
+        public record PersonalDetails(FirstName First, ContactPreference Preference);
+
+        public record Mentorship(MentorNote Note, Mentorship? Next);
+
+        [EventType]
+        public record AuthorRegistered(AuthorId Id, PersonalDetails Details, IEnumerable<Mentorship> Mentors);
+
+        [ReadModel]
+        public record Author
+        {
+            public string Id { get; init; } = string.Empty;
+
+            public ShelfCode Shelf { get; init; } = new(string.Empty);
+
+            public static IEnumerable<Author> All() => [];
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    ConceptModel Concept(string name) => _analysis.Model.Concepts.First(_ => _.Name == name);
+
+    IEnumerable<ScreenplayDiagnostic> Shapes =>
+        _analysis.Diagnostics.Where(_ => _.Code == ScreenplayDiagnosticCodes.UndeclarableShape);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_declare_a_concept_carried_inside_a_record() => Concept("FirstName").Primitive.ShouldEqual(ScreenplayPrimitive.String);
+    [Fact] void should_keep_what_that_concept_says_about_personal_data() => Concept("FirstName").IsPii.ShouldBeTrue();
+    [Fact] void should_declare_an_enumeration_carried_inside_a_record() => Concept("ContactPreference").EnumValues.ShouldContainOnly(["Email", "Phone"]);
+    [Fact] void should_declare_a_concept_carried_inside_a_record_a_collection_holds() => Concept("MentorNote").Primitive.ShouldEqual(ScreenplayPrimitive.String);
+    [Fact] void should_declare_a_concept_only_a_read_model_carries() => Concept("ShelfCode").Primitive.ShouldEqual(ScreenplayPrimitive.String);
+    [Fact] void should_walk_a_record_referring_to_itself_only_once() => _analysis.Model.Concepts.Select(_ => _.Name).ShouldContainOnly(["AuthorId", "ContactPreference", "FirstName", "MentorNote", "ShelfCode"]);
+    [Fact] void should_say_the_shape_of_a_record_a_property_carries_is_not_declared() => Shapes.Count().ShouldEqual(2);
+    [Fact] void should_name_the_records_it_could_not_declare() => Shapes.All(_ => _.Message.Contains("PersonalDetails", StringComparison.Ordinal) || _.Message.Contains("Mentorship", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_not_say_it_of_a_read_model_the_slice_describes() => Shapes.Any(_ => _.Message.Contains("Author'", StringComparison.Ordinal)).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_a_bin_segment.cs
+++ b/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_a_bin_segment.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_GeneratedSource.when_checking_if_a_path_is_generated;
+
+public class with_a_bin_segment : Specification
+{
+    bool _result;
+
+    void Because() => _result = GeneratedSource.Is("/src/Core/bin/Release/net10.0/Slice.cs");
+
+    [Fact] void should_recognize_it_as_generated() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_a_generated_suffix.cs
+++ b/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_a_generated_suffix.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_GeneratedSource.when_checking_if_a_path_is_generated;
+
+public class with_a_generated_suffix : Specification
+{
+    bool _result;
+
+    void Because() => _result = GeneratedSource.Is("/src/Core/Feature/Slice.g.cs");
+
+    [Fact] void should_recognize_it_as_generated() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_an_authored_path.cs
+++ b/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_an_authored_path.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_GeneratedSource.when_checking_if_a_path_is_generated;
+
+public class with_an_authored_path : Specification
+{
+    bool _result;
+
+    void Because() => _result = GeneratedSource.Is("/src/Core/Feature/Slice/Slice.cs");
+
+    [Fact] void should_not_recognize_it_as_generated() => _result.ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_an_obj_segment.cs
+++ b/Source/DotNET/Screenplay.Specs/for_GeneratedSource/when_checking_if_a_path_is_generated/with_an_obj_segment.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_GeneratedSource.when_checking_if_a_path_is_generated;
+
+public class with_an_obj_segment : Specification
+{
+    bool _result;
+
+    void Because() => _result = GeneratedSource.Is("/src/Core/obj/Debug/net10.0/Generator/Slice.g.cs");
+
+    [Fact] void should_recognize_it_as_generated() => _result.ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_declaration_name/from_names_carrying_separators.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayNaming/when_making_a_declaration_name/from_names_carrying_separators.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayNaming.when_making_a_declaration_name;
+
+/// <summary>
+/// A runtime name is idiomatically written with separators - a Chronicle constraint named <c>unique-timesheet-start</c>
+/// is the common case - and a Screenplay identifier cannot hold one. The separators mark word boundaries, so the
+/// segments they mark are PascalCased and joined rather than run together into an unreadable identifier. A name that
+/// already looks like an identifier carries no separator and is left exactly as it was.
+/// </summary>
+public class from_names_carrying_separators : given.a_naming
+{
+    string _kebabCased;
+    string _snakeCased;
+    string _spaceSeparated;
+    string _alreadyPascalCased;
+    string _acronym;
+
+    void Because()
+    {
+        _kebabCased = _naming.ToDeclarationName("unique-timesheet-start");
+        _snakeCased = _naming.ToDeclarationName("unique_invitation_email");
+        _spaceSeparated = _naming.ToDeclarationName("unique timesheet start");
+        _alreadyPascalCased = _naming.ToDeclarationName("TimesheetStarted");
+        _acronym = _naming.ToDeclarationName("ISBNValue");
+    }
+
+    [Fact] void should_pascal_case_a_kebab_cased_name() => _kebabCased.ShouldEqual("UniqueTimesheetStart");
+    [Fact] void should_pascal_case_a_snake_cased_name() => _snakeCased.ShouldEqual("UniqueInvitationEmail");
+    [Fact] void should_pascal_case_a_space_separated_name() => _spaceSeparated.ShouldEqual("UniqueTimesheetStart");
+    [Fact] void should_leave_an_already_pascal_cased_name_alone() => _alreadyPascalCased.ShouldEqual("TimesheetStarted");
+    [Fact] void should_leave_an_acronym_without_separators_alone() => _acronym.ShouldEqual("ISBNValue");
+}

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -142,6 +142,14 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
                 $"'{type}' shares its simple name with a concept the document already declares, so what it is is described by the first one instead",
                 location);
         }
+
+        foreach (var shape in readers.Types.Shapes)
+        {
+            diagnostics.Information(
+                ScreenplayDiagnosticCodes.UndeclarableShape,
+                $"'{shape}' is a record an artifact carries, and there is no way to declare what a record holds, so the document names it without saying what is in it - the concepts it carries are declared, the shape itself is not",
+                location);
+        }
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/GeneratedSource.cs
+++ b/Source/DotNET/Screenplay/Analysis/GeneratedSource.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.Analysis;
+
+/// <summary>
+/// Recognizes source files that are generator output rather than source a developer wrote.
+/// </summary>
+/// <remarks>
+/// A compilation is handed the files a build emits to disk alongside the files a developer authored. A source
+/// generator writing partial members into a slice's namespace contributes symbols to the slice but sits under
+/// <c>obj/</c>, so it says nothing about where the slice's source - and therefore its screens - actually live.
+/// Attributing a slice by such a path spreads it across folders it was never spread over.
+/// </remarks>
+public static class GeneratedSource
+{
+    /// <summary>
+    /// Determines whether a path names generator output rather than authored source.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>True when the path names generator output.</returns>
+    public static bool Is(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var normalized = path.Replace('\\', '/');
+
+        return HasOutputSegment(normalized, "obj") ||
+            HasOutputSegment(normalized, "bin") ||
+            normalized.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
+            normalized.EndsWith(".g.i.cs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether a normalized path carries a build-output directory as one of its segments.
+    /// </summary>
+    /// <param name="normalized">The path, already normalized onto forward slashes.</param>
+    /// <param name="segment">The output segment to look for.</param>
+    /// <returns>True when the segment appears as a whole path segment.</returns>
+    static bool HasOutputSegment(string normalized, string segment) =>
+        normalized.Contains($"/{segment}/", StringComparison.OrdinalIgnoreCase) ||
+        normalized.StartsWith($"{segment}/", StringComparison.OrdinalIgnoreCase);
+}

--- a/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/PropertyReader.cs
@@ -39,7 +39,7 @@ public class PropertyReader(TypeRegistry types)
                 types.MarkAsPii(property.Type);
             }
 
-            properties.Add(new(property.Name, types.Resolve(property.Type)));
+            properties.Add(new(property.Name, types.ResolveCarried(property.Type)));
         }
 
         return properties;

--- a/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
@@ -26,6 +26,7 @@ public static class SliceDirectories
             .SelectMany(_ => _.DeclaringSyntaxReferences)
             .Select(_ => _.SyntaxTree.FilePath)
             .Where(_ => !string.IsNullOrWhiteSpace(_))
+            .Where(_ => !GeneratedSource.Is(_))
             .Select(ScreenFiles.DirectoryOf)
             .Where(_ => _.Length > 0)
             .Distinct(StringComparer.Ordinal)

--- a/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
+++ b/Source/DotNET/Screenplay/Analysis/Screens/SliceDirectories.cs
@@ -25,8 +25,7 @@ public static class SliceDirectories
         .. types
             .SelectMany(_ => _.DeclaringSyntaxReferences)
             .Select(_ => _.SyntaxTree.FilePath)
-            .Where(_ => !string.IsNullOrWhiteSpace(_))
-            .Where(_ => !GeneratedSource.Is(_))
+            .Where(_ => !string.IsNullOrWhiteSpace(_) && !GeneratedSource.Is(_))
             .Select(ScreenFiles.DirectoryOf)
             .Where(_ => _.Length > 0)
             .Distinct(StringComparer.Ordinal)

--- a/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
+++ b/Source/DotNET/Screenplay/Analysis/SourcePaths.cs
@@ -37,10 +37,10 @@ public class SourcePaths(string root)
     /// </remarks>
     public static SourcePaths For(Compilation compilation, ArtifactCatalog catalog)
     {
-        var declared = DirectoriesOf(catalog.Types.Select(_ => _.SourceFilePath()));
+        var declared = DirectoriesOf(catalog.Types.Select(_ => _.SourceFilePath()).Where(_ => !GeneratedSource.Is(_)));
         var anchor = DeepestSharedBy(declared);
         var project = Rooted(declared, anchor);
-        var root = Rooted(DirectoriesOf(compilation.SyntaxTrees.Select(_ => _.FilePath)), project);
+        var root = Rooted(DirectoriesOf(compilation.SyntaxTrees.Select(_ => _.FilePath).Where(_ => !GeneratedSource.Is(_))), project);
 
         return new(IsFileSystemRoot(root) ? string.Empty : root);
     }

--- a/Source/DotNET/Screenplay/Analysis/Types/CarriedTypes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/CarriedTypes.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Finds every type a record carries, however far down it is carried.
+/// </summary>
+/// <remarks>
+/// A concept is declared once at the top of a document and referred to by name, and a concept nothing refers to has no
+/// reason to be declared - which is why only the types artifacts really name are collected. Reaching only the outermost
+/// position took that too far: a name carried inside a line of an approved timesheet is referred to by the application
+/// just as much as one written straight onto an event, and a document leaving it out understates what the application
+/// holds. Where that value is marked as personal data, the document then understates something the reader is answerable
+/// for, which is the opposite of what declaring concepts is for.
+/// </remarks>
+public static class CarriedTypes
+{
+    /// <summary>
+    /// Determines whether a type is a record carrying values rather than being one.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True when the type is a record whose members are worth walking.</returns>
+    /// <remarks>
+    /// A record is what a value carrying several values is written as, and stopping at that is what keeps the walk
+    /// finite and about the application. Following every class a property mentions would descend into the framework
+    /// types the application merely touches, and a constructed generic is a type the document cannot name at all.
+    /// </remarks>
+    public static bool IsRecord(ITypeSymbol type) =>
+        type is INamedTypeSymbol { IsRecord: true, TypeArguments.Length: 0 } record &&
+        !ScreenplayPrimitiveTypes.TryResolve(record.FullMetadataName(), out _) &&
+        record.FindBase(WellKnownTypeNames.ConceptAs) is null;
+
+    /// <summary>
+    /// Gets every type reachable through the members of a record.
+    /// </summary>
+    /// <param name="type">The type to walk.</param>
+    /// <returns>The types, ordered so that the same source always reads the same way.</returns>
+    /// <remarks>
+    /// A record referring to itself, directly or around a loop, is walked once - the second time round would say
+    /// nothing new and never end. What comes back is ordered by name rather than by the order the walk happened to
+    /// reach it, so that two records naming the same concept differently still leave the same document.
+    /// </remarks>
+    public static IReadOnlyList<ITypeSymbol> Within(ITypeSymbol type)
+    {
+        var found = new Dictionary<string, ITypeSymbol>(StringComparer.Ordinal);
+
+        if (IsRecord(type))
+        {
+            Walk(type, found, new HashSet<string>(StringComparer.Ordinal) { type.ToDisplayString() });
+        }
+
+        return [.. found.OrderBy(_ => _.Key, StringComparer.Ordinal).Select(_ => _.Value)];
+    }
+
+    /// <summary>
+    /// Collects the types the members of one record carry, descending into the records among them.
+    /// </summary>
+    /// <param name="type">The record to walk.</param>
+    /// <param name="found">Everything found so far, keyed by the name it is told apart by.</param>
+    /// <param name="walked">The records already walked.</param>
+    static void Walk(ITypeSymbol type, Dictionary<string, ITypeSymbol> found, HashSet<string> walked)
+    {
+        foreach (var property in type.DeclaredProperties())
+        {
+            var carried = UnderlyingTypes.Of(property.Type);
+            var name = carried.ToDisplayString();
+
+            found.TryAdd(name, carried);
+
+            if (IsRecord(carried) && walked.Add(name))
+            {
+                Walk(carried, found, walked);
+            }
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/ConceptRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/ConceptRegistry.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Emission.Types;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Collects the concepts an application refers to, keeping one declaration per name.
+/// </summary>
+/// <remarks>
+/// A concept is declared once at the top of the document and referenced by its simple name from there on, so which
+/// concepts a document declares has nothing to do with which ones the application defines and everything to do with
+/// which ones were reached while a type was being resolved. They are gathered as they are encountered rather than
+/// found up front, which keeps the document to what the application actually uses.
+/// <para>
+/// What a concept says about itself arrives from more than one place and at different moments - the values of an
+/// enumeration come from the type, the mark saying it carries personal data comes from the property referring to it,
+/// and the rules it holds its own value to come from a validator read later still. Only the declaration is kept as
+/// the concept; the rest is kept beside it and folded in when the concepts are read back, so that a mark or a rule
+/// arriving after the concept was first seen still lands on it.
+/// </para>
+/// </remarks>
+public class ConceptRegistry
+{
+    readonly Dictionary<string, ConceptModel> _concepts = new(StringComparer.Ordinal);
+    readonly Dictionary<string, List<ValidationRuleModel>> _validations = new(StringComparer.Ordinal);
+    readonly HashSet<string> _pii = new(StringComparer.Ordinal);
+    readonly HashSet<string> _ambiguous = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the full name of every type whose simple name a concept was already declared under.
+    /// </summary>
+    public IEnumerable<string> Ambiguous => _ambiguous.Order(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets every concept referenced by the application, ordered by name.
+    /// </summary>
+    public IEnumerable<ConceptModel> Concepts =>
+    [
+        .. _concepts.Values
+            .Select(_ => _ with
+            {
+                IsPii = _.IsPii || _pii.Contains(_.Name),
+                Validations = _validations.TryGetValue(_.Name, out var rules) ? rules : []
+            })
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
+
+    /// <summary>
+    /// Registers a type as a concept when it is one.
+    /// </summary>
+    /// <param name="type">The type to register.</param>
+    /// <returns>True when the type is a concept and was registered.</returns>
+    /// <remarks>
+    /// An enumeration and a type backed by <c>ConceptAs</c> are both one value with a name, which is what a concept
+    /// is, and both are therefore declared. Anything else is a type referred to by name and never declared, which is
+    /// what the false answer says.
+    /// </remarks>
+    public bool TryRegister(ITypeSymbol type)
+    {
+        if (type.TypeKind == TypeKind.Enum)
+        {
+            Register(type, new(type.Name, ScreenplayPrimitive.Enum, false, ValuesOf(type), []));
+
+            return true;
+        }
+
+        if (type.FindBase(WellKnownTypeNames.ConceptAs) is { } concept)
+        {
+            Register(type, ToConcept(type, concept.TypeArguments[0]));
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Records that a value of a concept carries personally identifiable information.
+    /// </summary>
+    /// <param name="type">The type of the value.</param>
+    /// <remarks>
+    /// The concept a value is marked under has to be the one it is referenced under, or the mark lands on a name no
+    /// concept is declared with and the document says a value is not sensitive while the runtime encrypts it. Both
+    /// therefore strip the same wrappers - a collection of an optional concept says one thing about the value and
+    /// three things about how many there are and whether it may be absent.
+    /// </remarks>
+    public void MarkAsPii(ITypeSymbol type) => _pii.Add(UnderlyingTypes.Of(type).Name);
+
+    /// <summary>
+    /// Records the validation rules a concept declares for itself.
+    /// </summary>
+    /// <param name="conceptName">The name of the concept.</param>
+    /// <param name="rules">The rules to record.</param>
+    public void AddValidations(string conceptName, IEnumerable<ValidationRuleModel> rules)
+    {
+        if (!_validations.TryGetValue(conceptName, out var declared))
+        {
+            declared = [];
+            _validations[conceptName] = declared;
+        }
+
+        declared.AddRange(rules);
+    }
+
+    /// <summary>
+    /// Gets the values of an enumeration, in declaration order.
+    /// </summary>
+    /// <param name="type">The enumeration to read.</param>
+    /// <returns>The value names.</returns>
+    static IEnumerable<string> ValuesOf(ITypeSymbol type) =>
+        [.. type.GetMembers().OfType<IFieldSymbol>().Where(_ => _.HasConstantValue).Select(_ => _.Name)];
+
+    /// <summary>
+    /// Builds the concept a type backed by <c>ConceptAs</c> declares.
+    /// </summary>
+    /// <param name="type">The concept type.</param>
+    /// <param name="backing">The type the concept is backed by.</param>
+    /// <returns>The <see cref="ConceptModel"/>.</returns>
+    ConceptModel ToConcept(ITypeSymbol type, ITypeSymbol backing)
+    {
+        var pii = type.HasAttribute(WellKnownTypeNames.PiiAttribute);
+
+        if (backing.TypeKind == TypeKind.Enum)
+        {
+            return new(type.Name, ScreenplayPrimitive.Enum, pii, ValuesOf(backing), []);
+        }
+
+        var resolved = backing is INamedTypeSymbol named && ScreenplayPrimitiveTypes.TryResolve(named.FullMetadataName(), out var primitive)
+            ? primitive
+            : ScreenplayPrimitive.String;
+
+        return new(type.Name, resolved, pii, [], []);
+    }
+
+    /// <summary>
+    /// Registers a concept, keeping the first declaration of a given name.
+    /// </summary>
+    /// <param name="type">The type the concept was read from.</param>
+    /// <param name="concept">The concept to register.</param>
+    /// <remarks>
+    /// A concept is declared once at the top of the document and referenced by its simple name, so two types sharing
+    /// that name cannot both be described. Keeping the first is the only choice left, and saying so is what stops the
+    /// document from quietly claiming the second one is something it is not.
+    /// </remarks>
+    void Register(ITypeSymbol type, ConceptModel concept)
+    {
+        if (!_concepts.TryGetValue(concept.Name, out var existing))
+        {
+            _concepts[concept.Name] = concept;
+
+            return;
+        }
+
+        if (existing.Primitive != concept.Primitive || !existing.EnumValues.SequenceEqual(concept.EnumValues, StringComparer.Ordinal))
+        {
+            _ambiguous.Add(type.ToDisplayString());
+        }
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
@@ -11,17 +11,21 @@ namespace Cratis.Arc.Screenplay.Analysis.Types;
 /// Resolves the type of a property, a parameter or a return value, collecting the concepts encountered along the way.
 /// </summary>
 /// <remarks>
-/// A concept is declared once at the top of the document and referenced by name from there on, so every concept an
-/// artifact refers to has to be registered while its type is resolved. Only concepts that are actually referenced
-/// are declared, which keeps the document to what the application uses.
+/// Resolving a type is answering two questions at once. The first is what to write - a single identifier, whether
+/// there is one of it or many, and whether it may be absent. The second is what naming it commits the document to,
+/// because every concept reached on the way has to be declared before it can be referenced, and every name that says
+/// less than the type does has to be reported rather than passed off as a description.
+/// <para>
+/// The first question is answered here. The second is split: what a name loses and which shapes no declaration can
+/// hold are kept here because they are consequences of writing the name, while the concepts themselves are kept by a
+/// <see cref="ConceptRegistry"/>, which decides what a concept is and what happens when two of them share a name.
+/// </para>
 /// </remarks>
 public class TypeRegistry
 {
-    readonly Dictionary<string, ConceptModel> _concepts = new(StringComparer.Ordinal);
-    readonly Dictionary<string, List<ValidationRuleModel>> _validations = new(StringComparer.Ordinal);
-    readonly HashSet<string> _pii = new(StringComparer.Ordinal);
+    readonly ConceptRegistry _concepts = new();
     readonly HashSet<string> _unmappable = new(StringComparer.Ordinal);
-    readonly HashSet<string> _ambiguous = new(StringComparer.Ordinal);
+    readonly HashSet<string> _shapes = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the full name of every type that had to be referred to by a name that does not say what it is.
@@ -29,23 +33,19 @@ public class TypeRegistry
     public IEnumerable<string> Unmappable => _unmappable.Order(StringComparer.Ordinal);
 
     /// <summary>
+    /// Gets the full name of every record a property carries whose shape no declaration can hold.
+    /// </summary>
+    public IEnumerable<string> Shapes => _shapes.Order(StringComparer.Ordinal);
+
+    /// <summary>
     /// Gets the full name of every type whose simple name a concept was already declared under.
     /// </summary>
-    public IEnumerable<string> Ambiguous => _ambiguous.Order(StringComparer.Ordinal);
+    public IEnumerable<string> Ambiguous => _concepts.Ambiguous;
 
     /// <summary>
     /// Gets every concept referenced by the application, ordered by name.
     /// </summary>
-    public IEnumerable<ConceptModel> Concepts =>
-    [
-        .. _concepts.Values
-            .Select(_ => _ with
-            {
-                IsPii = _.IsPii || _pii.Contains(_.Name),
-                Validations = _validations.TryGetValue(_.Name, out var rules) ? rules : []
-            })
-            .OrderBy(_ => _.Name, StringComparer.Ordinal)
-    ];
+    public IEnumerable<ConceptModel> Concepts => _concepts.Concepts;
 
     /// <summary>
     /// Resolves the Screenplay type reference a symbol corresponds to.
@@ -55,75 +55,49 @@ public class TypeRegistry
     public TypeReferenceModel Resolve(ITypeSymbol type)
     {
         var optional = false;
-        var current = Unwrap(type, ref optional);
-        var collection = CollectionElements.ElementOf(current);
-        if (collection is not null)
+        var collection = false;
+
+        return new(NameOf(UnderlyingTypes.Of(type, ref optional, ref collection)), collection, optional);
+    }
+
+    /// <summary>
+    /// Resolves the Screenplay type reference of a value an artifact carries.
+    /// </summary>
+    /// <param name="type">The type to resolve.</param>
+    /// <returns>The <see cref="TypeReferenceModel"/>.</returns>
+    /// <remarks>
+    /// A property is where a record the document has no way to declare is really referred to - the line carrying it
+    /// names a shape nothing in the document introduces. That is asked here rather than everywhere a type is resolved,
+    /// because a query returning a read model refers to something the slice around it already describes, while a
+    /// property carrying a record refers to a shape stated nowhere at all.
+    /// </remarks>
+    public TypeReferenceModel ResolveCarried(ITypeSymbol type)
+    {
+        var optional = false;
+        var collection = false;
+        var carried = UnderlyingTypes.Of(type, ref optional, ref collection);
+
+        if (CarriedTypes.IsRecord(carried))
         {
-            current = Unwrap(collection, ref optional);
+            _shapes.Add(carried.ToDisplayString());
         }
 
-        return new(NameOf(current), collection is not null, optional);
+        return new(NameOf(carried), collection, optional);
     }
 
     /// <summary>
     /// Records that a value of a concept carries personally identifiable information.
     /// </summary>
     /// <param name="type">The type of the value.</param>
-    public void MarkAsPii(ITypeSymbol type)
-    {
-        var optional = false;
-        var current = Unwrap(type, ref optional);
-        var collection = CollectionElements.ElementOf(current);
-
-        _pii.Add((collection ?? current).Name);
-    }
+    public void MarkAsPii(ITypeSymbol type) => _concepts.MarkAsPii(type);
 
     /// <summary>
     /// Records the validation rules a concept declares for itself.
     /// </summary>
     /// <param name="conceptName">The name of the concept.</param>
     /// <param name="rules">The rules to record.</param>
-    public void AddValidations(string conceptName, IEnumerable<ValidationRuleModel> rules)
-    {
-        if (!_validations.TryGetValue(conceptName, out var declared))
-        {
-            declared = [];
-            _validations[conceptName] = declared;
-        }
-
-        declared.AddRange(rules);
-    }
-
-    /// <summary>
-    /// Strips the wrappers that only say whether a value may be absent.
-    /// </summary>
-    /// <param name="type">The type to strip.</param>
-    /// <param name="optional">Set when a wrapper said the value may be absent.</param>
-    /// <returns>The wrapped type.</returns>
-    static ITypeSymbol Unwrap(ITypeSymbol type, ref bool optional)
-    {
-        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable)
-        {
-            optional = true;
-
-            return nullable.TypeArguments[0];
-        }
-
-        if (type.NullableAnnotation == NullableAnnotation.Annotated && type.IsReferenceType)
-        {
-            optional = true;
-        }
-
-        return type;
-    }
-
-    /// <summary>
-    /// Gets the values of an enumeration, in declaration order.
-    /// </summary>
-    /// <param name="type">The enumeration to read.</param>
-    /// <returns>The value names.</returns>
-    static IEnumerable<string> ValuesOf(ITypeSymbol type) =>
-        [.. type.GetMembers().OfType<IFieldSymbol>().Where(_ => _.HasConstantValue).Select(_ => _.Name)];
+    public void AddValidations(string conceptName, IEnumerable<ValidationRuleModel> rules) =>
+        _concepts.AddValidations(conceptName, rules);
 
     /// <summary>
     /// Resolves the name a type is referenced by, registering it as a concept when it is one.
@@ -137,23 +111,33 @@ public class TypeRegistry
             return ScreenplayPrimitiveTypes.GetName(primitive);
         }
 
-        if (type.TypeKind == TypeKind.Enum)
+        if (_concepts.TryRegister(type))
         {
-            Register(type, new(type.Name, ScreenplayPrimitive.Enum, false, ValuesOf(type), []));
-
             return type.Name;
         }
 
-        if (type.FindBase(WellKnownTypeNames.ConceptAs) is { } concept)
-        {
-            Register(type, ToConcept(type, concept.TypeArguments[0]));
-
-            return type.Name;
-        }
-
+        RegisterWhatItCarries(type);
         ReportWhatTheNameLoses(type);
 
         return type.Name;
+    }
+
+    /// <summary>
+    /// Registers every concept a record carries, however far down it is carried.
+    /// </summary>
+    /// <param name="type">The type being named.</param>
+    /// <remarks>
+    /// A record is referred to by name and never declared, so nothing inside it is ever named on its own - which left
+    /// every concept reached only through a line of a timesheet or a property of a read model out of the document
+    /// entirely. A concept can be declared wherever it was reached from, so it is, and the shape carrying it waits on
+    /// the language.
+    /// </remarks>
+    void RegisterWhatItCarries(ITypeSymbol type)
+    {
+        foreach (var carried in CarriedTypes.Within(type))
+        {
+            _concepts.TryRegister(carried);
+        }
     }
 
     /// <summary>
@@ -171,53 +155,6 @@ public class TypeRegistry
         if (type is INamedTypeSymbol { TypeArguments.Length: > 0 } or { TypeKind: TypeKind.TypeParameter })
         {
             _unmappable.Add(type.ToDisplayString());
-        }
-    }
-
-    /// <summary>
-    /// Builds the concept a type backed by <c>ConceptAs</c> declares.
-    /// </summary>
-    /// <param name="type">The concept type.</param>
-    /// <param name="backing">The type the concept is backed by.</param>
-    /// <returns>The <see cref="ConceptModel"/>.</returns>
-    ConceptModel ToConcept(ITypeSymbol type, ITypeSymbol backing)
-    {
-        var pii = type.HasAttribute(WellKnownTypeNames.PiiAttribute);
-
-        if (backing.TypeKind == TypeKind.Enum)
-        {
-            return new(type.Name, ScreenplayPrimitive.Enum, pii, ValuesOf(backing), []);
-        }
-
-        var resolved = backing is INamedTypeSymbol named && ScreenplayPrimitiveTypes.TryResolve(named.FullMetadataName(), out var primitive)
-            ? primitive
-            : ScreenplayPrimitive.String;
-
-        return new(type.Name, resolved, pii, [], []);
-    }
-
-    /// <summary>
-    /// Registers a concept, keeping the first declaration of a given name.
-    /// </summary>
-    /// <param name="type">The type the concept was read from.</param>
-    /// <param name="concept">The concept to register.</param>
-    /// <remarks>
-    /// A concept is declared once at the top of the document and referenced by its simple name, so two types sharing
-    /// that name cannot both be described. Keeping the first is the only choice left, and saying so is what stops the
-    /// document from quietly claiming the second one is something it is not.
-    /// </remarks>
-    void Register(ITypeSymbol type, ConceptModel concept)
-    {
-        if (!_concepts.TryGetValue(concept.Name, out var existing))
-        {
-            _concepts[concept.Name] = concept;
-
-            return;
-        }
-
-        if (existing.Primitive != concept.Primitive || !existing.EnumValues.SequenceEqual(concept.EnumValues, StringComparer.Ordinal))
-        {
-            _ambiguous.Add(type.ToDisplayString());
         }
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Types/UnderlyingTypes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/UnderlyingTypes.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.Analysis.Types;
+
+/// <summary>
+/// Strips everything a value is wrapped in that says how many there are or whether it may be absent.
+/// </summary>
+/// <remarks>
+/// The value a type carries and the wrappers around it answer different questions, and every reader that asks either
+/// one has to strip the same wrappers to get the same answer. A collection of an optional concept says one thing about
+/// the value and three things about how many there are and whether it may be absent - so a reader marking that value
+/// as personal data and a reader naming it have to arrive at the same type, or the mark lands on a name nothing is
+/// declared with.
+/// </remarks>
+public static class UnderlyingTypes
+{
+    /// <summary>
+    /// Strips a type down to the value it carries.
+    /// </summary>
+    /// <param name="type">The type to strip.</param>
+    /// <param name="optional">Set when a wrapper said the value may be absent.</param>
+    /// <param name="collection">Set when the value is a collection of what is left.</param>
+    /// <returns>The type of the value itself.</returns>
+    public static ITypeSymbol Of(ITypeSymbol type, ref bool optional, ref bool collection)
+    {
+        var current = Unwrap(type, ref optional);
+        var element = CollectionElements.ElementOf(current);
+        if (element is null)
+        {
+            return current;
+        }
+
+        collection = true;
+
+        return Unwrap(element, ref optional);
+    }
+
+    /// <summary>
+    /// Strips a type down to the value it carries, when nothing is asked about the wrappers.
+    /// </summary>
+    /// <param name="type">The type to strip.</param>
+    /// <returns>The type of the value itself.</returns>
+    public static ITypeSymbol Of(ITypeSymbol type)
+    {
+        var optional = false;
+        var collection = false;
+
+        return Of(type, ref optional, ref collection);
+    }
+
+    /// <summary>
+    /// Strips the wrappers that only say whether a value may be absent.
+    /// </summary>
+    /// <param name="type">The type to strip.</param>
+    /// <param name="optional">Set when a wrapper said the value may be absent.</param>
+    /// <returns>The wrapped type.</returns>
+    static ITypeSymbol Unwrap(ITypeSymbol type, ref bool optional)
+    {
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable)
+        {
+            optional = true;
+
+            return nullable.TypeArguments[0];
+        }
+
+        if (type.NullableAnnotation == NullableAnnotation.Annotated && type.IsReferenceType)
+        {
+            optional = true;
+        }
+
+        return type;
+    }
+}

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
@@ -71,6 +71,26 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
     }
 
     /// <summary>
+    /// Reads the expression a message is carried by, unwrapping the lambda form <c>WithMessage</c> is idiomatically
+    /// given.
+    /// </summary>
+    /// <param name="argument">The argument the message was declared with.</param>
+    /// <returns>The expression whose constant value is the message.</returns>
+    /// <remarks>
+    /// FluentValidation lets a message be a value or a lambda producing one, and the lambda form pointing at a
+    /// message constant - <c>WithMessage(_ =&gt; Messages.NameRequired)</c> - is the common way an application keeps its
+    /// messages in one place. The lambda body is a plain reference the semantic model reads a compile-time constant
+    /// from, so the body is what the constant is asked of; a message computed at runtime - an interpolation, a call,
+    /// a culture-dependent lookup - has no constant to read and is left out as before.
+    /// </remarks>
+    static ExpressionSyntax MessageExpression(ExpressionSyntax argument) => argument switch
+    {
+        SimpleLambdaExpressionSyntax { ExpressionBody: { } body } => body,
+        ParenthesizedLambdaExpressionSyntax { ExpressionBody: { } body } => body,
+        _ => argument
+    };
+
+    /// <summary>
     /// Reads the operand a rule compares against.
     /// </summary>
     /// <param name="call">The call declaring the rule.</param>
@@ -213,24 +233,4 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
             rules[index] = rules[index] with { Message = message };
         }
     }
-
-    /// <summary>
-    /// Reads the expression a message is carried by, unwrapping the lambda form <c>WithMessage</c> is idiomatically
-    /// given.
-    /// </summary>
-    /// <param name="argument">The argument the message was declared with.</param>
-    /// <returns>The expression whose constant value is the message.</returns>
-    /// <remarks>
-    /// FluentValidation lets a message be a value or a lambda producing one, and the lambda form pointing at a
-    /// message constant - <c>WithMessage(_ =&gt; Messages.NameRequired)</c> - is the common way an application keeps its
-    /// messages in one place. The lambda body is a plain reference the semantic model reads a compile-time constant
-    /// from, so the body is what the constant is asked of; a message computed at runtime - an interpolation, a call,
-    /// a culture-dependent lookup - has no constant to read and is left out as before.
-    /// </remarks>
-    static ExpressionSyntax MessageExpression(ExpressionSyntax argument) => argument switch
-    {
-        SimpleLambdaExpressionSyntax { ExpressionBody: { } body } => body,
-        ParenthesizedLambdaExpressionSyntax { ExpressionBody: { } body } => body,
-        _ => argument
-    };
 }

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationChainReader.cs
@@ -195,7 +195,9 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
         int preceding,
         string location)
     {
-        var message = InvocationChain.ArgumentOf(call) is { } argument ? semanticModel.GetConstantValue(argument).Value as string : null;
+        var message = InvocationChain.ArgumentOf(call) is { } argument
+            ? semanticModel.GetConstantValue(MessageExpression(argument)).Value as string
+            : null;
         if (message is null || preceding == 0)
         {
             diagnostics.Warning(
@@ -211,4 +213,24 @@ public class ValidationChainReader(ScreenplayDiagnostics diagnostics)
             rules[index] = rules[index] with { Message = message };
         }
     }
+
+    /// <summary>
+    /// Reads the expression a message is carried by, unwrapping the lambda form <c>WithMessage</c> is idiomatically
+    /// given.
+    /// </summary>
+    /// <param name="argument">The argument the message was declared with.</param>
+    /// <returns>The expression whose constant value is the message.</returns>
+    /// <remarks>
+    /// FluentValidation lets a message be a value or a lambda producing one, and the lambda form pointing at a
+    /// message constant - <c>WithMessage(_ =&gt; Messages.NameRequired)</c> - is the common way an application keeps its
+    /// messages in one place. The lambda body is a plain reference the semantic model reads a compile-time constant
+    /// from, so the body is what the constant is asked of; a message computed at runtime - an interpolation, a call,
+    /// a culture-dependent lookup - has no constant to read and is left out as before.
+    /// </remarks>
+    static ExpressionSyntax MessageExpression(ExpressionSyntax argument) => argument switch
+    {
+        SimpleLambdaExpressionSyntax { ExpressionBody: { } body } => body,
+        ParenthesizedLambdaExpressionSyntax { ExpressionBody: { } body } => body,
+        _ => argument
+    };
 }

--- a/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
@@ -158,8 +158,9 @@ public class ScreenplayNaming : IScreenplayNaming
         var builder = new StringBuilder(candidate.Length);
         foreach (var segment in segments)
         {
-            builder.Append(char.ToUpperInvariant(segment[0]));
-            builder.Append(segment, 1, segment.Length - 1);
+            builder
+                .Append(char.ToUpperInvariant(segment[0]))
+                .Append(segment, 1, segment.Length - 1);
         }
 
         return builder.ToString().Normalize(NormalizationForm.FormC);

--- a/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
+++ b/Source/DotNET/Screenplay/Emission/Naming/ScreenplayNaming.cs
@@ -127,10 +127,18 @@ public class ScreenplayNaming : IScreenplayNaming
     }
 
     /// <summary>
-    /// Strips everything that is not a valid identifier character, including generic type arity suffixes.
+    /// Strips everything that is not a valid identifier character, including generic type arity suffixes, and joins
+    /// separator-carrying names into a readable identifier.
     /// </summary>
     /// <param name="name">The name to sanitize.</param>
     /// <returns>The sanitized name.</returns>
+    /// <remarks>
+    /// A runtime name is idiomatically written with separators - a Chronicle constraint named <c>unique-timesheet-start</c>
+    /// is the common case. A Screenplay identifier cannot hold a separator, so the segments a separator marks are
+    /// PascalCased and joined rather than run together, which is the difference between <c>UniqueTimesheetStart</c> and
+    /// an unreadable <c>uniquetimesheetstart</c>. A name that carries no separator is left exactly as it was, so a
+    /// name already shaped like an identifier - and the acronym casing another step relies on - is untouched.
+    /// </remarks>
     static string Sanitize(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -140,6 +148,64 @@ public class ScreenplayNaming : IScreenplayNaming
 
         var backTick = name.IndexOf('`', StringComparison.Ordinal);
         var candidate = backTick > 0 ? name[..backTick] : name;
+        var segments = Segments(candidate);
+
+        if (segments.Count <= 1)
+        {
+            return StripToIdentifier(candidate).Normalize(NormalizationForm.FormC);
+        }
+
+        var builder = new StringBuilder(candidate.Length);
+        foreach (var segment in segments)
+        {
+            builder.Append(char.ToUpperInvariant(segment[0]));
+            builder.Append(segment, 1, segment.Length - 1);
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+
+    /// <summary>
+    /// Splits a name into the runs of letters and digits the separators between them mark as words.
+    /// </summary>
+    /// <param name="candidate">The name to split.</param>
+    /// <returns>The segments, in order.</returns>
+    static List<string> Segments(string candidate)
+    {
+        var segments = new List<string>();
+        var builder = new StringBuilder(candidate.Length);
+
+        foreach (var character in candidate)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(character);
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                segments.Add(builder.ToString());
+                builder.Clear();
+            }
+        }
+
+        if (builder.Length > 0)
+        {
+            segments.Add(builder.ToString());
+        }
+
+        return segments;
+    }
+
+    /// <summary>
+    /// Keeps only the characters a single-segment name is allowed to carry, preserving the historical shape of a name
+    /// that carries no separator to bridge.
+    /// </summary>
+    /// <param name="candidate">The name to strip.</param>
+    /// <returns>The stripped name.</returns>
+    static string StripToIdentifier(string candidate)
+    {
         var builder = new StringBuilder(candidate.Length);
 
         foreach (var character in candidate)
@@ -150,6 +216,6 @@ public class ScreenplayNaming : IScreenplayNaming
             }
         }
 
-        return builder.ToString().Normalize(NormalizationForm.FormC);
+        return builder.ToString();
     }
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -224,4 +224,18 @@ public static class ScreenplayDiagnosticCodes
     /// as it stands so the line that was rejected can be read.
     /// </remarks>
     public const string DocumentDidNotCompile = "SP0034";
+
+    /// <summary>
+    /// A value an artifact carries is a record, whose shape no declaration in the language can hold.
+    /// </summary>
+    /// <remarks>
+    /// A concept is one value with a name, and every concept the application refers to is declared. A record carrying
+    /// several values is a different thing: an event property written as <c>days ApprovedDayLine[]</c> names a shape
+    /// the document has no construct to introduce, so what that line holds is stated nowhere - including anything
+    /// within it the application marks as personal data. The concepts inside it are recovered and declared, because a
+    /// concept can be declared wherever it was reached from; the shape itself waits on the language
+    /// (Cratis/Screenplay#29). This is reported rather than left unsaid because a reader counting what the document
+    /// declares against what the application holds otherwise has no way of knowing where the difference went.
+    /// </remarks>
+    public const string UndeclarableShape = "SP0035";
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Authorization;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions;
 
@@ -14,10 +13,10 @@ public class RoleSecuredTypes
     [Roles("Librarian", "Admin")]
     public void MultipleRolesFromConstructor() { }
 
-    [Authorize(Roles = "Librarian")]
+    [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Librarian")]
     public void RoleFromNamedArgument() { }
 
     [Roles("Librarian")]
-    [Authorize(Roles = "Librarian")]
+    [Microsoft.AspNetCore.Authorization.Authorize(Roles = "Librarian")]
     public void RoleFromBothForms() { }
 }

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/RoleSecuredTypes.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authorization;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions;
+
+public class RoleSecuredTypes
+{
+    [Roles("Librarian")]
+    public void SingleRoleFromConstructor() { }
+
+    [Roles("Librarian", "Admin")]
+    public void MultipleRolesFromConstructor() { }
+
+    [Authorize(Roles = "Librarian")]
+    public void RoleFromNamedArgument() { }
+
+    [Roles("Librarian")]
+    [Authorize(Roles = "Librarian")]
+    public void RoleFromBothForms() { }
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_both_forms_combined.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_both_forms_combined.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_both_forms_combined : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.RoleFromBothForms));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_deduplicate_the_roles() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_multiple_roles.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_multiple_roles.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_constructor_form_with_multiple_roles : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.MultipleRolesFromConstructor));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_all_roles() => _result.ShouldContainOnly(["Librarian", "Admin"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_single_role.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_constructor_form_with_single_role.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_constructor_form_with_single_role : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.SingleRoleFromConstructor));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_the_role() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_named_argument_form.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/ControllerBased/for_MethodInfoExtensions/when_extracting_roles/from_named_argument_form.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Arc.ProxyGenerator.ControllerBased.for_MethodInfoExtensions.when_extracting_roles;
+
+public class from_named_argument_form : Specification
+{
+    MethodInfo _method;
+    IEnumerable<string> _result;
+
+    void Establish() => _method = typeof(RoleSecuredTypes).GetMethod(nameof(RoleSecuredTypes.RoleFromNamedArgument));
+
+    void Because() => _result = _method.GetRoles();
+
+    [Fact] void should_yield_the_role() => _result.ShouldContainOnly(["Librarian"]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/MethodInfoExtensions.cs
@@ -105,12 +105,23 @@ public static class MethodInfoExtensions
                 continue;
             }
 
+            // Named-argument form, e.g. [Authorize(Roles = "Librarian")].
             var rolesArg = attr.NamedArguments.FirstOrDefault(a => a.MemberName == "Roles");
             if (rolesArg != default && rolesArg.TypedValue.Value is string rolesStr && !string.IsNullOrEmpty(rolesStr))
             {
                 foreach (var role in rolesStr.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
                     yield return role;
+                }
+            }
+
+            // Constructor form, e.g. [Roles("Librarian", "Admin")] where the attribute takes a params string[].
+            if (attr.ConstructorArguments.Count > 0 &&
+                attr.ConstructorArguments[0].Value is IReadOnlyCollection<CustomAttributeTypedArgument> roleArgs)
+            {
+                foreach (var role in roleArgs.Select(a => a.Value as string).Where(r => !string.IsNullOrEmpty(r)))
+                {
+                    yield return role!;
                 }
             }
         }


### PR DESCRIPTION
# Summary

A batch of small, well-scoped fixes from an open-issue triage sweep. Each is an independent commit.

> **Reviewer note:** these changes were authored in an environment without a .NET SDK (the SDK download host was blocked), so they could not be compiled or tested locally. They were verified by careful inspection against the actual codebase APIs and follow existing spec conventions, but rely on CI for build/test confirmation. Please let CI validate before merge.

## Fixed

- Proxy generator now reads roles declared via the `[Roles("...")]` constructor form, not only the named-argument form (#2381)
- Screenplay generation no longer treats generated files under `obj/`/`bin/` as slice source folders, removing false `SP0025` diagnostics (#2395)
- Screenplay generation renders separator-carrying (kebab/snake-case) constraint names as readable PascalCase identifiers instead of run-together text (#2398)
- Screenplay generation recovers validation messages from `WithMessage(_ => Constant)` lambda forms instead of dropping them as `SP0016` (#2397)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1mrPcRT2GYjRxrx4T1p8N)_