### PR TITLE
Fix observable queries over primitive collections losing every value

### DIFF
--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeStringObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/FakeStringObservableQuery.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ObservableQueryFor, QueryResult, ObservableQuerySubscription, OnNextResult } from '@cratis/arc/queries';
+import { ParameterDescriptor } from '@cratis/arc/reflection';
+import { Constructor } from '@cratis/fundamentals';
+
+export type SubscribeCallback = OnNextResult<QueryResult<string[]>>;
+
+/**
+ * A fake for the shape a backend `ISubject<IEnumerable<string>>` generates: an observable query
+ * over a primitive collection, whose model type is the `String` wrapper.
+ */
+export class FakeStringObservableQuery extends ObservableQueryFor<string[]> {
+    readonly route = '/api/fake-string-observable-query';
+    readonly parameterDescriptors: ParameterDescriptor[] = [];
+
+    get requiredRequestParameters(): string[] {
+        return [];
+    }
+
+    defaultValue: string[] = [];
+
+    constructor() {
+        super(String as Constructor, true);
+    }
+
+    static subscribeCallbacks: SubscribeCallback[] = [];
+    static subscriptionReturned: ObservableQuerySubscription<string[]>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    subscribe(callback: SubscribeCallback, args?: object): ObservableQuerySubscription<string[]> {
+        FakeStringObservableQuery.subscribeCallbacks.push(callback);
+        FakeStringObservableQuery.subscriptionReturned = {
+            unsubscribe: () => {}
+        } as unknown as ObservableQuerySubscription<string[]>;
+        return FakeStringObservableQuery.subscriptionReturned;
+    }
+
+    static reset() {
+        FakeStringObservableQuery.subscribeCallbacks = [];
+    }
+}

--- a/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_the_model_type_is_a_primitive_collection.ts
+++ b/Source/JavaScript/Arc.React/queries/for_useObservableQuery/when_the_model_type_is_a_primitive_collection.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useObservableQuery } from '../useObservableQuery';
+import { FakeStringObservableQuery } from './FakeStringObservableQuery';
+import { ArcContext, ArcConfiguration } from '../../ArcContext';
+import { QueryResult, QueryResultWithState, QueryInstanceCache } from '@cratis/arc/queries';
+import { QueryInstanceCacheContext } from '../QueryInstanceCacheContext';
+
+describe('when the model type is a primitive collection', () => {
+    let capturedResult: QueryResultWithState<string[]> | undefined;
+
+    beforeEach(() => {
+        FakeStringObservableQuery.reset();
+        capturedResult = undefined;
+    });
+
+    const config: ArcConfiguration = {
+        microservice: 'test-microservice',
+        apiBasePath: '/api',
+        origin: 'https://example.com',
+    };
+
+    const render_and_get_callback = () => {
+        const TestComponent = () => {
+            const [result] = useObservableQuery<string[], FakeStringObservableQuery>(FakeStringObservableQuery);
+            capturedResult = result;
+            return React.createElement('div', null, 'Test');
+        };
+
+        render(
+            React.createElement(
+                QueryInstanceCacheContext.Provider,
+                { value: new QueryInstanceCache() },
+                React.createElement(
+                    ArcContext.Provider,
+                    { value: config },
+                    React.createElement(TestComponent)
+                )
+            )
+        );
+
+        return FakeStringObservableQuery.subscribeCallbacks[0];
+    };
+
+    const resultFor = (data: string[], changeSet?: object) => ({
+        data,
+        isSuccess: true,
+        isAuthorized: true,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: data.length, totalPages: 1 },
+        ...(changeSet ? { changeSet } : {})
+    } as unknown as QueryResult<string[]>);
+
+    it('should keep the values of the initial payload', async () => {
+        const callback = render_and_get_callback();
+
+        await act(async () => {
+            callback(resultFor(['first', 'second']));
+        });
+
+        capturedResult!.data.should.deep.equal(['first', 'second']);
+    });
+
+    it('should keep every item a primitive string', async () => {
+        const callback = render_and_get_callback();
+
+        await act(async () => {
+            callback(resultFor(['first', 'second']));
+        });
+
+        capturedResult!.data.every(_ => typeof _ === 'string').should.be.true;
+    });
+
+    it('should keep the values of items added through a change set', async () => {
+        const callback = render_and_get_callback();
+
+        await act(async () => {
+            callback(resultFor(['first']));
+        });
+
+        await act(async () => {
+            callback(resultFor([], { added: ['second'], replaced: [], removed: [] }));
+        });
+
+        capturedResult!.data.should.deep.equal(['first', 'second']);
+    });
+
+    it('should remove an item removed through a change set', async () => {
+        const callback = render_and_get_callback();
+
+        await act(async () => {
+            callback(resultFor(['first', 'second']));
+        });
+
+        await act(async () => {
+            callback(resultFor([], { added: [], replaced: [], removed: ['first'] }));
+        });
+
+        capturedResult!.data.should.deep.equal(['second']);
+    });
+});

--- a/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
+++ b/Source/JavaScript/Arc.React/queries/useObservableQuery.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { QueryResultWithState, IObservableQueryFor, Sorting, Paging, ChangeSet } from '@cratis/arc/queries';
+import { QueryResultWithState, IObservableQueryFor, Sorting, Paging, ChangeSet, isPrimitiveModelType } from '@cratis/arc/queries';
 import { Constructor, JsonSerializer } from '@cratis/fundamentals';
 import { useState, useEffect, useContext, useRef, useMemo } from 'react';
 import { SetSorting } from './SetSorting';
@@ -80,21 +80,45 @@ function applyChangeSet<T>(previous: T[], changeSet: ChangeSet<unknown>): T[] {
     return [...result, ...changeSet.added] as T[];
 }
 
+/**
+ * Deserializes a payload collection into its model type, passing primitives through untouched.
+ *
+ * A query whose backend returns a primitive collection - `IEnumerable<string>`, `IEnumerable<int>` -
+ * generates a proxy with `String`, `Number` or `Boolean` as its model type, and
+ * {@link JsonSerializer.deserializeArrayFromInstance} is destructive for those: it constructs
+ * `new String()` per item and copies declared fields onto it, discarding the value and leaving an
+ * empty wrapper object behind.
+ *
+ * Only the primitive check itself is shared with `@cratis/arc` - the deserialization must run
+ * through this package's own {@link JsonSerializer}, whose converter registry is module state and
+ * therefore only knows the `Guid`, `Date` and concept types registered in this package's copy.
+ * @param {Constructor} modelType The instance type of the items to deserialize into.
+ * @param {unknown[]} items The items to deserialize.
+ * @returns {unknown[]} The deserialized items, or the items unchanged for primitive model types.
+ */
+function deserializeItems(modelType: Constructor | null, items: unknown[]): unknown[] {
+    if (!modelType || modelType === Object || isPrimitiveModelType(modelType)) {
+        return Array.from(items);
+    }
+
+    return JsonSerializer.deserializeArrayFromInstance(modelType, items);
+}
+
 function deserializeChangeSet(changeSet: ChangeSet<unknown>, modelType: Constructor): ChangeSet<unknown> {
     return {
-        added: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.added ?? []),
-        replaced: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.replaced ?? []),
-        removed: JsonSerializer.deserializeArrayFromInstance(modelType, changeSet.removed ?? []),
+        added: deserializeItems(modelType, changeSet.added ?? []),
+        replaced: deserializeItems(modelType, changeSet.replaced ?? []),
+        removed: deserializeItems(modelType, changeSet.removed ?? []),
     };
 }
 
 function deserializeResponseData<TDataType>(data: unknown, modelType: Constructor | null): TDataType {
-    // If data is an array and we have a model type, deserialize each item
-    if (Array.isArray(data) && modelType && modelType !== Object) {
-        return JsonSerializer.deserializeArrayFromInstance(modelType, data) as TDataType;
+    // Non-array payloads (null, undefined, a single value) are passed through untouched.
+    if (!Array.isArray(data)) {
+        return data as TDataType;
     }
-    // Otherwise return data as-is (could be null, undefined, or non-array type)
-    return data as TDataType;
+
+    return deserializeItems(modelType, data) as TDataType;
 }
 
 function hasAllRequiredArguments(requiredRequestParameters: string[], args?: object): boolean {

--- a/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryFor.ts
@@ -9,7 +9,7 @@ import { IObservableQueryConnection } from './IObservableQueryConnection';
 import { NullObservableQueryConnection } from './NullObservableQueryConnection';
 import { createObservableQueryConnection } from './ObservableQueryConnectionFactory';
 import { Constructor } from '@cratis/fundamentals';
-import { JsonSerializer } from '@cratis/fundamentals';
+import { deserializeQueryModel, deserializeQueryModels } from './deserializeQueryModel';
 import { QueryResult } from './QueryResult';
 import { Sorting } from './Sorting';
 import { Paging } from './Paging';
@@ -219,13 +219,9 @@ export abstract class ObservableQueryFor<TDataType, TParameters = object> implem
 
     private deserializeResult(result: any): void {
         if (this.enumerable) {
-            if (Array.isArray(result.data)) {
-                result.data = JsonSerializer.deserializeArrayFromInstance(this.modelType, result.data);
-            } else {
-                result.data = [];
-            }
+            result.data = deserializeQueryModels(this.modelType, result.data);
         } else if (result.data) {
-            result.data = JsonSerializer.deserializeFromInstance(this.modelType, result.data);
+            result.data = deserializeQueryModel(this.modelType, result.data);
         }
     }
 }

--- a/Source/JavaScript/Arc/queries/QueryResult.ts
+++ b/Source/JavaScript/Arc/queries/QueryResult.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Constructor, JsonSerializer } from '@cratis/fundamentals';
+import { Constructor } from '@cratis/fundamentals';
 import { ValidationResult } from '../validation/ValidationResult';
 import { IQueryResult } from './IQueryResult';
 import { PagingInfo } from './PagingInfo';
 import { ChangeSet } from './ChangeSet';
+import { deserializeQueryModel, deserializeQueryModels } from './deserializeQueryModel';
 
 type ServerQueryResult = {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -162,37 +163,18 @@ export class QueryResult<TDataType = object> implements IQueryResult<TDataType> 
         this.paging.totalPages = result.paging.totalPages;
 
         if (result.data) {
-            let data: object = result.data;
-            const isPrimitive = instanceType === String || instanceType === Number || instanceType === Boolean;
-            if (enumerable) {
-                if (Array.isArray(result.data)) {
-                    data = isPrimitive
-                        ? Array.from(result.data)
-                        : JsonSerializer.deserializeArrayFromInstance(instanceType, data);
-                } else {
-                    data = [];
-                }
-            } else {
-                data = isPrimitive ? data : JsonSerializer.deserializeFromInstance(instanceType, data);
-            }
-
-            this.data = data as TDataType;
+            this.data = (enumerable
+                ? deserializeQueryModels(instanceType, result.data)
+                : deserializeQueryModel(instanceType, result.data)) as TDataType;
         } else {
             this.data = (enumerable ? [] : null) as TDataType;
         }
 
         if (enumerable && result.changeSet) {
-            const isPrimitive = instanceType === String || instanceType === Number || instanceType === Boolean;
             this.changeSet = {
-                added: isPrimitive
-                    ? Array.from(result.changeSet.added ?? [])
-                    : JsonSerializer.deserializeArrayFromInstance(instanceType, result.changeSet.added ?? []),
-                replaced: isPrimitive
-                    ? Array.from(result.changeSet.replaced ?? [])
-                    : JsonSerializer.deserializeArrayFromInstance(instanceType, result.changeSet.replaced ?? []),
-                removed: isPrimitive
-                    ? Array.from(result.changeSet.removed ?? [])
-                    : JsonSerializer.deserializeArrayFromInstance(instanceType, result.changeSet.removed ?? []),
+                added: deserializeQueryModels(instanceType, result.changeSet.added ?? []),
+                replaced: deserializeQueryModels(instanceType, result.changeSet.replaced ?? []),
+                removed: deserializeQueryModels(instanceType, result.changeSet.removed ?? []),
             } as ChangeSet<unknown>;
         }
     }

--- a/Source/JavaScript/Arc/queries/deserializeQueryModel.ts
+++ b/Source/JavaScript/Arc/queries/deserializeQueryModel.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor, JsonSerializer } from '@cratis/fundamentals';
+
+/*
+ * ⚠️ deserializeQueryModel / deserializeQueryModels are for use WITHIN this package only.
+ *
+ * JsonSerializer's converter registry is module state, and a consumer package can easily resolve a
+ * different physical copy of @cratis/fundamentals than this one. Calling these from another package
+ * therefore looks up Guid/Date/concept converters in the wrong registry and silently degrades those
+ * values to plain deserialization. Other packages should use isPrimitiveModelType - which compares
+ * against the JavaScript globals and is safe across copies - and deserialize through their own
+ * JsonSerializer.
+ */
+
+/**
+ * Determines whether a model type is a JavaScript primitive wrapper rather than a real model.
+ *
+ * A query whose backend returns a primitive collection - `IEnumerable<string>`, `IEnumerable<int>` -
+ * generates a proxy with `String`, `Number` or `Boolean` as its model type.
+ * @param {Constructor} modelType The model type the query describes itself with.
+ * @returns {boolean} True when the type is a primitive wrapper.
+ */
+export function isPrimitiveModelType(modelType: Constructor | null | undefined): boolean {
+    return modelType === String || modelType === Number || modelType === Boolean;
+}
+
+/**
+ * Deserializes a single query payload into its model type, passing primitives through untouched.
+ *
+ * {@link JsonSerializer.deserializeFromInstance} is destructive for primitive wrapper types: it
+ * constructs `new String()` and copies declared fields onto it, which for a primitive means the
+ * value is discarded and an empty wrapper object is produced. Primitives therefore need to bypass
+ * deserialization entirely - they already arrive in their final shape.
+ * @param {Constructor} modelType The model type to deserialize into.
+ * @param {unknown} data The payload to deserialize.
+ * @returns {TDataType} The deserialized instance, or the payload unchanged for primitive types.
+ */
+export function deserializeQueryModel<TDataType>(modelType: Constructor | null | undefined, data: unknown): TDataType {
+    if (!modelType || modelType === Object || isPrimitiveModelType(modelType)) {
+        return data as TDataType;
+    }
+
+    return JsonSerializer.deserializeFromInstance(modelType, data) as TDataType;
+}
+
+/**
+ * Deserializes a query payload collection into its model type, passing primitives through untouched.
+ *
+ * See {@link deserializeQueryModel} for why primitive model types must bypass deserialization.
+ * @param {Constructor} modelType The instance type of the items to deserialize into.
+ * @param {unknown} data The payload to deserialize. A non-array payload yields an empty collection.
+ * @returns {TDataType[]} The deserialized items, or the items unchanged for primitive types.
+ */
+export function deserializeQueryModels<TDataType>(modelType: Constructor | null | undefined, data: unknown): TDataType[] {
+    if (!Array.isArray(data)) {
+        return [];
+    }
+
+    if (!modelType || modelType === Object || isPrimitiveModelType(modelType)) {
+        return Array.from(data) as TDataType[];
+    }
+
+    return JsonSerializer.deserializeArrayFromInstance(modelType, data) as TDataType[];
+}

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_receiving_a_result/and_the_model_type_is_a_primitive_collection.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryFor/when_receiving_a_result/and_the_model_type_is_a_primitive_collection.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as sinon from 'sinon';
+import { an_observable_query_for } from '../given/an_observable_query_for';
+import { given } from '../../../given';
+import { Globals } from '../../../Globals';
+import { EventSourceFactory } from '../../../EventSourceFactory';
+import { QueryResult } from '../../QueryResult';
+import { QueryTransportMethod } from '../../QueryTransportMethod';
+import { ObservableQuerySubscription } from '../../ObservableQuerySubscription';
+
+interface FakeEventSource {
+    onmessage: ((event: MessageEvent) => void) | null;
+    onerror: (() => void) | null;
+    close: sinon.SinonStub;
+}
+
+describe('and the model type is a primitive collection', given(an_observable_query_for, context => {
+    let subscription: ObservableQuerySubscription<string[]>;
+    let fakeEventSource: FakeEventSource;
+    let received: QueryResult<string[]>[];
+    let originalQueryDirectMode: boolean;
+    let originalTransportMethod: QueryTransportMethod;
+    let originalFactory: EventSourceFactory | undefined;
+
+    beforeEach(() => {
+        originalQueryDirectMode = Globals.queryDirectMode;
+        originalTransportMethod = Globals.queryTransportMethod;
+        originalFactory = Globals.eventSourceFactory;
+
+        Globals.queryDirectMode = true;
+        Globals.queryTransportMethod = QueryTransportMethod.ServerSentEvents;
+
+        fakeEventSource = { onmessage: null, onerror: null, close: sinon.stub() };
+        Globals.eventSourceFactory = (() => fakeEventSource) as unknown as EventSourceFactory;
+
+        context.enumerableQuery.setOrigin('https://example.com');
+
+        received = [];
+        subscription = context.enumerableQuery.subscribe(
+            result => received.push(result),
+            { category: 'test-category' });
+
+        fakeEventSource.onmessage!({
+            data: JSON.stringify({
+                data: ['first', 'second'],
+                isSuccess: true,
+                isAuthorized: true,
+                isValid: true,
+                hasExceptions: false,
+                validationResults: [],
+                exceptionMessages: [],
+                exceptionStackTrace: '',
+                paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+            })
+        } as MessageEvent);
+    });
+
+    afterEach(() => {
+        subscription?.unsubscribe();
+        Globals.queryDirectMode = originalQueryDirectMode;
+        Globals.queryTransportMethod = originalTransportMethod;
+        Globals.eventSourceFactory = originalFactory;
+        sinon.restore();
+    });
+
+    it('should deliver the result to the subscriber', () => received.length.should.equal(1));
+    it('should keep every item a primitive string', () => received[0].data.every(_ => typeof _ === 'string').should.be.true);
+    it('should keep the values intact', () => received[0].data.should.deep.equal(['first', 'second']));
+}));

--- a/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_models.ts
+++ b/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_models.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor, field } from '@cratis/fundamentals';
+import { deserializeQueryModels } from '../deserializeQueryModel';
+
+class Item {
+    @field(String)
+    name!: string;
+}
+
+describe('when deserializing a collection of models', () => {
+    const result = deserializeQueryModels<Item>(Item as Constructor, [{ name: 'first' }, { name: 'second' }]);
+
+    it('should produce instances of the model type', () => result.every(_ => _ instanceof Item).should.be.true);
+    it('should carry the values over', () => result.map(_ => _.name).should.deep.equal(['first', 'second']));
+});

--- a/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_numbers.ts
+++ b/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_numbers.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { deserializeQueryModels } from '../deserializeQueryModel';
+
+describe('when deserializing a collection of numbers', () => {
+    const result = deserializeQueryModels<number>(Number as Constructor, [42, 43]);
+
+    it('should keep every item a primitive number', () => result.every(_ => typeof _ === 'number').should.be.true);
+    it('should keep the values intact', () => result.should.deep.equal([42, 43]));
+});

--- a/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_strings.ts
+++ b/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_collection_of_strings.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { deserializeQueryModels } from '../deserializeQueryModel';
+
+describe('when deserializing a collection of strings', () => {
+    const result = deserializeQueryModels<string>(String as Constructor, ['first', 'second']);
+
+    it('should keep every item a primitive string', () => result.every(_ => typeof _ === 'string').should.be.true);
+    it('should keep the values intact', () => result.should.deep.equal(['first', 'second']));
+});

--- a/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_non_array_as_a_collection.ts
+++ b/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_non_array_as_a_collection.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { deserializeQueryModels } from '../deserializeQueryModel';
+
+describe('when deserializing a non array as a collection', () => {
+    const result = deserializeQueryModels<string>(String as Constructor, null);
+
+    it('should produce an empty collection', () => result.should.be.empty);
+});

--- a/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_single_string.ts
+++ b/Source/JavaScript/Arc/queries/for_deserializeQueryModel/when_deserializing_a_single_string.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Constructor } from '@cratis/fundamentals';
+import { deserializeQueryModel } from '../deserializeQueryModel';
+
+describe('when deserializing a single string', () => {
+    const result = deserializeQueryModel<string>(String as Constructor, 'the value');
+
+    it('should keep it a primitive string', () => (typeof result).should.equal('string'));
+    it('should keep the value intact', () => result.should.equal('the value'));
+});

--- a/Source/JavaScript/Arc/queries/index.ts
+++ b/Source/JavaScript/Arc/queries/index.ts
@@ -36,6 +36,7 @@ export * from './WebSocketMessage';
 export * from './QueryTransportMethod';
 export * from './QueryInstanceCache';
 export * from './reconcileQueryData';
+export * from './deserializeQueryModel';
 export * from './IQueryProvider';
 export * from './QueryProvider';
 export * from './QueryValidator';


### PR DESCRIPTION
# Summary

An observable query whose backend returns a primitive collection — for example `ISubject<IEnumerable<string>>` — delivered a collection of empty values to the client instead of the actual data. Names rendered blank, comparisons failed, and string interpolation produced an empty string. One-shot queries were unaffected, so this only surfaced on live/observable queries.

## Fixed

- Observable queries returning a collection of primitives (`string`, numeric, `bool`) now deliver the actual values instead of empty ones, both for the initial payload and for change-set deltas
- Observable queries returning a single primitive value now deliver that value instead of an empty one
- Observable queries that describe themselves with `Object` now pass their payload through instead of losing it