### PR TITLE
Take Screenplay modules from the namespaces when no project names the application

### DIFF
--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/SeparateRootsSource.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/SeparateRootsSource.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating.from_projects_in_separate_namespace_roots;
+
+/// <summary>
+/// The source of a solution holding two applications that share nothing, the way a samples or a monorepo solution
+/// really is arranged.
+/// </summary>
+/// <remarks>
+/// The layered source is two projects of one application, so every namespace in it begins with the same segment and
+/// the question of what the modules are never arises. Here the two do not: each names itself, and a document that
+/// gathered both under one module named after the solution would say the solution is the application and that the
+/// two applications are features of it.
+/// </remarks>
+public static class SeparateRootsSource
+{
+    const string Ordering = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Ordering.Placing;
+
+        /// <summary>
+        /// An order was placed.
+        /// </summary>
+        [EventType]
+        public record OrderPlaced(string Reference);
+
+        /// <summary>
+        /// Places an order.
+        /// </summary>
+        [Command]
+        public record PlaceOrder(string Reference)
+        {
+            public OrderPlaced Handle() => new(Reference);
+        }
+        """;
+
+    const string Onboarding = """
+        using Cratis.Arc.Commands.ModelBound;
+        using Cratis.Chronicle.Events;
+
+        namespace Quickstart.Users.Onboarding;
+
+        /// <summary>
+        /// A user was onboarded.
+        /// </summary>
+        [EventType]
+        public record UserOnboarded(string Name);
+
+        /// <summary>
+        /// Onboards a user.
+        /// </summary>
+        [Command]
+        public record OnboardUser(string Name)
+        {
+            public UserOnboarded Handle() => new(Name);
+        }
+        """;
+
+    /// <summary>
+    /// Builds the project of the first application.
+    /// </summary>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    public static Compilation LibraryProject() =>
+        Analyzed.Project(
+            "Library",
+            [],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Ordering/Placing/Placing.cs", Ordering));
+
+    /// <summary>
+    /// Builds the project of the second application, which shares no namespace with the first.
+    /// </summary>
+    /// <returns>The <see cref="Compilation"/>.</returns>
+    public static Compilation QuickstartProject() =>
+        Analyzed.Project(
+            "Quickstart",
+            [],
+            ("Source/Quickstart/Program.cs", "namespace Quickstart;"),
+            ("Source/Quickstart/Users/Onboarding/Onboarding.cs", Onboarding));
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/and_a_module_is_named.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/and_a_module_is_named.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating.from_projects_in_separate_namespace_roots;
+
+/// <summary>
+/// Taking the modules from the namespaces is what happens when nobody says otherwise, not what happens regardless.
+/// A caller that names a module has said the whole document is that module, and gathering the applications beneath
+/// it is then the answer rather than the accident.
+/// </summary>
+public class and_a_module_is_named : Specification
+{
+    string _source;
+
+    void Because() =>
+        _source = new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(
+                [SeparateRootsSource.LibraryProject(), SeparateRootsSource.QuickstartProject()],
+                new ScreenplayOptions { Domain = "Samples", Module = "Everything" })
+            .Source;
+
+    [Fact] void should_declare_the_module_that_was_named() => _source.Contains("module Everything", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_not_take_a_module_from_the_namespaces() => _source.Contains("module Library", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_gather_the_applications_beneath_it() => _source.Contains("feature Library", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/and_nothing_names_a_module.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/when_generating/from_projects_in_separate_namespace_roots/and_nothing_names_a_module.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Emission;
+
+namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.when_generating.from_projects_in_separate_namespace_roots;
+
+/// <summary>
+/// None of several projects is the application, which is why nothing names the domain after one of them. The same
+/// holds for the module: a single one would carry a name that belongs to nobody - the solution file, or the neutral
+/// default - and would gather every application in the solution beneath it as a feature. The namespaces already say
+/// what the modules are.
+/// </summary>
+public class and_nothing_names_a_module : Specification
+{
+    string _source;
+
+    void Because() =>
+        _source = new ScreenplayGenerator(
+                new ApplicationModelAnalyzer(DeclaredUserInterfaceFiles.None),
+                new ScreenplayEmitter())
+            .Generate(
+                [SeparateRootsSource.LibraryProject(), SeparateRootsSource.QuickstartProject()],
+                new ScreenplayOptions { Domain = "Samples" })
+            .Source;
+
+    [Fact] void should_declare_the_first_namespace_root_as_a_module() => _source.Contains("module Library", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_declare_the_second_namespace_root_as_a_module() => _source.Contains("module Quickstart", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_not_gather_them_under_the_name_the_solution_goes_by() => _source.Contains("module Samples", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_not_turn_either_application_into_a_feature() => _source.Contains("feature Library", StringComparison.Ordinal).ShouldBeFalse();
+    [Fact] void should_still_name_the_domain_the_caller_asked_for() => _source.Contains("domain Samples", StringComparison.Ordinal).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/ApplicationSyntaxBuilder.cs
@@ -53,9 +53,7 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
     public ApplicationSyntax Build(ApplicationModel model, ScreenplayOptions options)
     {
         var domain = ToName(model.Domain, options.Domain);
-        var module = ToName(model.Module, options.Module);
-
-        var modules = BuildModules(model, module, options.SegmentsToSkip ?? 0);
+        var modules = BuildModules(model, options, domain);
         var concepts = new ConceptSyntaxBuilder(naming, _validations, diagnostics, _names).Build(model.Concepts);
         var policies = new PolicySyntaxBuilder(naming).Build(model.Policies, _authorize.Referenced);
 
@@ -98,13 +96,14 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
     /// Builds the modules holding every slice that declares something.
     /// </summary>
     /// <param name="model">The model to build from.</param>
-    /// <param name="module">The name of the module.</param>
-    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <param name="options">The options to build with, already resolved.</param>
+    /// <param name="domain">The name of the domain, which a slice with no namespace left is gathered under.</param>
     /// <returns>The modules.</returns>
-    IEnumerable<ModuleSyntax> BuildModules(ApplicationModel model, string module, int segmentsToSkip)
+    IEnumerable<ModuleSyntax> BuildModules(ApplicationModel model, ScreenplayOptions options, string domain)
     {
         var sliceBuilder = CreateSliceBuilder();
         var placed = new List<PlacedSlice>();
+        var segmentsToSkip = options.SegmentsToSkip ?? 0;
 
         foreach (var slice in model.Slices
             .OrderBy(_ => _.Namespace, StringComparer.Ordinal)
@@ -123,7 +122,11 @@ public class ApplicationSyntaxBuilder(IScreenplayNaming naming, ScreenplayDiagno
             placed.Add(new(slice.Namespace, built));
         }
 
-        return new SliceTreeBuilder(naming).Build(placed, module, segmentsToSkip);
+        var builder = new SliceTreeBuilder(naming);
+
+        return options.ModulesFromNamespaceRoots
+            ? builder.BuildPerNamespaceRoot(placed, domain, segmentsToSkip)
+            : builder.Build(placed, ToName(model.Module, options.Module), segmentsToSkip);
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceTreeBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceTreeBuilder.cs
@@ -36,6 +36,44 @@ public class SliceTreeBuilder(IScreenplayNaming naming)
     }
 
     /// <summary>
+    /// Builds one module per outermost namespace segment, nesting features after the segments below it.
+    /// </summary>
+    /// <param name="slices">The slices to arrange, keyed on the namespace they live in.</param>
+    /// <param name="fallbackName">The name a slice with nothing left of its namespace is gathered under.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <returns>The modules of the document, ordered by name.</returns>
+    /// <remarks>
+    /// A slice belongs to a namespace rather than to a project - the same namespace is deliberately joined across
+    /// every project declaring a part of it - so the outermost segment is what an application written as several
+    /// projects is actually divided by, and the assembly names are not. It is also the division a reader already
+    /// sees, because the segment every namespace of one bounded context begins with is the name that context goes by.
+    /// </remarks>
+    public IEnumerable<ModuleSyntax> BuildPerNamespaceRoot(IEnumerable<PlacedSlice> slices, string fallbackName, int segmentsToSkip) =>
+    [
+        .. slices
+            .GroupBy(_ => RootOf(_.Namespace, fallbackName, segmentsToSkip), StringComparer.Ordinal)
+            .OrderBy(_ => _.Key, StringComparer.Ordinal)
+            .SelectMany(group => Build([.. group], group.Key, segmentsToSkip))
+    ];
+
+    /// <summary>
+    /// Resolves the module a slice is gathered under.
+    /// </summary>
+    /// <param name="namespace">The namespace of the slice.</param>
+    /// <param name="fallbackName">The name to use when the namespace has no segment left.</param>
+    /// <param name="segmentsToSkip">The number of leading namespace segments to skip.</param>
+    /// <returns>The name of the module.</returns>
+    string RootOf(string @namespace, string fallbackName, int segmentsToSkip)
+    {
+        var segments = @namespace
+            .Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Skip(segmentsToSkip)
+            .ToArray();
+
+        return segments.Length == 0 ? fallbackName : naming.ToDeclarationName(segments[0]);
+    }
+
+    /// <summary>
     /// Resolves the feature path a slice is placed under, excluding the slice itself.
     /// </summary>
     /// <param name="namespace">The namespace of the slice.</param>

--- a/Source/DotNET/Screenplay/ScreenplayOptions.cs
+++ b/Source/DotNET/Screenplay/ScreenplayOptions.cs
@@ -39,6 +39,24 @@ public record ScreenplayOptions
     public int? SegmentsToSkip { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the modules of the document are taken from the outermost namespace segment of
+    /// each slice rather than from one name.
+    /// </summary>
+    /// <remarks>
+    /// Resolved rather than configured. It is reached when nothing named a module and no single assembly names the
+    /// application, which is how an application written as several projects arrives. The reasoning that leaves the
+    /// domain unnamed there holds for the module too: none of the projects is the application, so one module would
+    /// carry a name that belongs to nobody and would gather every project under it. The namespaces already say what
+    /// the modules are. Naming a module still collapses the document into that one, which is the way to ask for it.
+    /// <para>
+    /// Once resolved it stays resolved. Emission resolves a second time against the domain of the model, which by
+    /// then is known, and without this the module would quietly be filled in from it and the document would come
+    /// back as one module after all.
+    /// </para>
+    /// </remarks>
+    public bool ModulesFromNamespaceRoots { get; init; }
+
+    /// <summary>
     /// Resolves the options with every value filled in.
     /// </summary>
     /// <param name="fallbackName">The name to use for the domain when none is configured.</param>
@@ -46,12 +64,15 @@ public record ScreenplayOptions
     public ScreenplayOptions WithDefaults(string? fallbackName)
     {
         var domain = Coalesce(Domain, Coalesce(fallbackName, DefaultName));
+        var fromNamespaceRoots = ModulesFromNamespaceRoots ||
+            (string.IsNullOrWhiteSpace(Module) && string.IsNullOrWhiteSpace(fallbackName));
 
         return this with
         {
             Domain = domain,
-            Module = Coalesce(Module, domain),
-            SegmentsToSkip = SegmentsToSkip ?? 0
+            Module = fromNamespaceRoots ? null : Coalesce(Module, domain),
+            SegmentsToSkip = SegmentsToSkip ?? 0,
+            ModulesFromNamespaceRoots = fromNamespaceRoots
         };
     }
 


### PR DESCRIPTION
# Summary

A solution holding several applications was described as one module named after the solution, with each application a feature of it.

## Changed

- A Screenplay document generated from several projects now declares one module per outermost namespace segment, instead of gathering every project into a single module named after the solution. Naming a module still produces that one module, and generating from a single project is unchanged. (#2399)
