### PR TITLE
Stop pull requests cancelling each other's builds

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,7 +1,13 @@
 name: .NET Build
 
+# The build runs on pull_request_target, where github.ref is the branch being merged into rather than the pull
+# request - refs/heads/main for every one of them. Grouping on it therefore put every open pull request in one
+# group, and cancel-in-progress made each new one cancel the build of whichever was already running. The pull
+# request that lost was left with a cancelled run and no failing job, which reads as though it is still going
+# rather than as though anything is wrong. So the group is the pull request when there is one, and the ref only
+# for the manual runs that have no pull request to name.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,7 +1,9 @@
 name: PR Prerelase
 
+# This only ever runs on pull_request_target, where github.ref names the branch being merged into rather than the
+# pull request, so grouping on it made every open pull request share one group and cancel each other's prerelease.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
# Summary

Build infrastructure only, with no user-facing change and so nothing for the release notes: open pull requests shared one concurrency group and cancelled each other's builds.
