### PR TITLE
Let a consumer declare how a type crosses the wire

### DIFF
--- a/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
+++ b/Source/DotNET/Tools/ProxyGenerator.Build/build/Cratis.Arc.ProxyGenerator.Build.targets
@@ -37,10 +37,11 @@
             <ExcludeTypes>@(ExcludeType -> '--exclude-type=%(TypeName)', ' ')</ExcludeTypes>
             <ExcludeNamespaces>@(ExcludeNamespace -> '--exclude-namespace=%(Namespace)', ' ')</ExcludeNamespaces>
             <NamespaceRoots>@(NamespaceRoot -> '--namespace-root=%(Namespace)=%(Folder)', ' ')</NamespaceRoots>
+            <TypeMappings>@(TypeToTsType -> '--type-to-ts=%(TypeName)=%(TsType)=%(Package)', ' ')</TypeMappings>
         </PropertyGroup>
 
         <Exec ConsoleToMsBuild="true"
-            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots)"
+            Command="dotnet $(CratisProxyGeneratorAssembly) &quot;$(MSBuildProjectDirectory)/$(OutputPath)$(AssemblyName).dll&quot; &quot;$(CratisProxiesOutputPath)&quot; $(CratisProxiesSegmentsToSkip) $(LibraryMode) $(SkipOutputDeletion) $(SkipCommandNameInRoute) $(SkipQueryNameInRoute) $(ApiPrefix) --project-directory=&quot;$(MSBuildProjectDirectory)&quot; $(SkipFileIndexTracking) $(SkipIndexGeneration) $(UseSourceFileAsOutputFile) $(AssemblyPackageMappings) $(ExcludeTypes) $(ExcludeNamespaces) $(NamespaceRoots) $(TypeMappings)"
             WorkingDirectory="$(CratisProxyGeneratorAssemblyDirectory)" />
     </Target>
 </Project>

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/given/no_type_mappings.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/given/no_type_mappings.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions.given;
+
+/// <summary>
+/// Leaves the mapping table empty after each spec.
+/// </summary>
+/// <remarks>
+/// The table is static, so a spec that configures one and walks away changes what every later spec
+/// generates - and the guarantee worth protecting here is that a build configuring nothing generates
+/// exactly what it generated before.
+/// </remarks>
+public class no_type_mappings : Specification
+{
+    void Destroy() => TypeExtensions.SetTypeMappings([]);
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_is_configured.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_is_configured.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+public class when_a_type_mapping_is_configured : given.no_type_mappings
+{
+    TargetType _result = null!;
+
+    void Establish() => TypeExtensions.SetTypeMappings([(typeof(Version).FullName!, "SemanticVersion", "@acme/versions")]);
+
+    void Because() => _result = typeof(Version).GetTargetType();
+
+    [Fact] void should_generate_the_declared_type() => _result.Type.ShouldEqual("SemanticVersion");
+    [Fact] void should_construct_with_the_declared_type() => _result.Constructor.ShouldEqual("SemanticVersion");
+    [Fact] void should_import_from_the_declared_package() => _result.Module.ShouldEqual("@acme/versions");
+    [Fact] void should_import_it_as_a_bare_specifier() => _result.FromPackage.ShouldBeTrue();
+    [Fact] void should_keep_the_original_type() => _result.OriginalType.ShouldEqual(typeof(Version));
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_is_configured_without_a_package.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_is_configured_without_a_package.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+public class when_a_type_mapping_is_configured_without_a_package : given.no_type_mappings
+{
+    TargetType _result = null!;
+
+    void Establish() => TypeExtensions.SetTypeMappings([(typeof(Version).FullName!, "string", string.Empty)]);
+
+    void Because() => _result = typeof(Version).GetTargetType();
+
+    [Fact] void should_generate_the_declared_type() => _result.Type.ShouldEqual("string");
+    [Fact] void should_not_import_anything() => _result.Module.ShouldBeEmpty();
+    [Fact] void should_not_be_from_a_package() => _result.FromPackage.ShouldBeFalse();
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_overrides_a_built_in_one.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_a_type_mapping_overrides_a_built_in_one.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+/// <summary>
+/// The mapping is consulted ahead of the built-in map, which is what lets a consumer correct how an
+/// existing type crosses the wire rather than only declare one the generator has never seen. Without
+/// that ordering the seam could only ever add.
+/// </summary>
+public class when_a_type_mapping_overrides_a_built_in_one : given.no_type_mappings
+{
+    TargetType _before = null!;
+    TargetType _after = null!;
+
+    void Establish()
+    {
+        _before = typeof(DateTime).GetTargetType();
+        TypeExtensions.SetTypeMappings([(typeof(DateTime).FullName!, "Instant", "@acme/time")]);
+    }
+
+    void Because() => _after = typeof(DateTime).GetTargetType();
+
+    [Fact] void should_have_used_the_built_in_mapping_before() => _before.Type.ShouldEqual("Date");
+    [Fact] void should_take_the_place_of_the_built_in_mapping() => _after.Type.ShouldEqual("Instant");
+    [Fact] void should_import_from_the_declared_package() => _after.Module.ShouldEqual("@acme/time");
+}

--- a/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_no_type_mappings_are_configured.cs
+++ b/Source/DotNET/Tools/ProxyGenerator.Specs/for_TypeExtensions/when_no_type_mappings_are_configured.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Geospatial;
+
+namespace Cratis.Arc.ProxyGenerator.for_TypeExtensions;
+
+/// <summary>
+/// The guarantee that matters most for this seam. Generated proxies are committed in consumer repos, so
+/// a build that configures no mappings has to generate exactly what it generated before - anything else
+/// lands as a large silent diff in somebody else's repository.
+/// </summary>
+/// <remarks>
+/// Asserts that configuring a mapping and clearing it leaves nothing behind, rather than restating the
+/// built-in mappings themselves. The built-in map is what the rest of this suite already covers, and
+/// pinning individual values here would cement whichever ones happen to be under discussion.
+/// </remarks>
+public class when_no_type_mappings_are_configured : given.no_type_mappings
+{
+    TargetType _beforeAnyMapping = null!;
+    TargetType _afterClearingMappings = null!;
+    TargetType _guid = null!;
+    TargetType _point = null!;
+    TargetType _unmapped = null!;
+
+    void Establish()
+    {
+        _beforeAnyMapping = typeof(DateTime).GetTargetType();
+        TypeExtensions.SetTypeMappings([(typeof(DateTime).FullName!, "Instant", "@acme/time")]);
+    }
+
+    void Because()
+    {
+        TypeExtensions.SetTypeMappings([]);
+        _afterClearingMappings = typeof(DateTime).GetTargetType();
+        _guid = typeof(Guid).GetTargetType();
+        _point = typeof(Point).GetTargetType();
+        _unmapped = typeof(Version).GetTargetType();
+    }
+
+    [Fact] void should_leave_nothing_behind_when_mappings_are_cleared() => _afterClearingMappings.ShouldEqual(_beforeAnyMapping);
+    [Fact] void should_still_map_guid_from_the_fundamentals_package() => _guid.Module.ShouldEqual("@cratis/fundamentals");
+    [Fact] void should_still_map_point_from_the_fundamentals_package() => _point.Module.ShouldEqual("@cratis/fundamentals");
+    [Fact] void should_leave_an_unmapped_type_alone() => _unmapped.Type.ShouldEqual(nameof(Version));
+    [Fact] void should_not_import_an_unmapped_type() => _unmapped.Module.ShouldBeEmpty();
+}

--- a/Source/DotNET/Tools/ProxyGenerator/Generator.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Generator.cs
@@ -32,6 +32,7 @@ public static class Generator
     /// <param name="excludedTypeNames">Fully qualified type names that should be excluded from proxy generation.</param>
     /// <param name="excludedNamespacePatterns">Namespace glob patterns (supports <c>*</c> as wildcard) whose matching types are excluded from generation.</param>
     /// <param name="namespaceRoots">Pairs of (namespace, base folder) used as roots. When a type's namespace begins with a root the root is stripped and the remainder is placed under the base folder.</param>
+    /// <param name="typeMappings">Triples of (fully qualified type name, TypeScript type, package) declaring how a type crosses the wire. Consulted ahead of the built-in map, so it can correct an existing mapping as well as add an unknown one.</param>
     /// <returns>True if successful, false if not.</returns>
     public static async Task<bool> Generate(
         string assemblyFile,
@@ -49,7 +50,8 @@ public static class Generator
         IReadOnlyDictionary<string, string>? assemblyPackageMappings = null,
         IReadOnlyCollection<string>? excludedTypeNames = null,
         IReadOnlyCollection<string>? excludedNamespacePatterns = null,
-        IReadOnlyCollection<(string Namespace, string Folder)>? namespaceRoots = null)
+        IReadOnlyCollection<(string Namespace, string Folder)>? namespaceRoots = null,
+        IReadOnlyCollection<(string TypeName, string TsType, string Package)>? typeMappings = null)
     {
         assemblyFile = Path.GetFullPath(assemblyFile);
         if (!File.Exists(assemblyFile))
@@ -68,6 +70,7 @@ public static class Generator
         TypeExtensions.SetAssemblyPackageMappings(assemblyPackageMappings ?? new Dictionary<string, string>());
         TypeExtensions.SetExcludedTypes(excludedTypeNames ?? [], excludedNamespacePatterns ?? []);
         TypeExtensions.SetNamespaceRoots(namespaceRoots ?? []);
+        TypeExtensions.SetTypeMappings(typeMappings ?? []);
         TypeExtensions.InitializeProjectAssemblies(assemblyFile, message, errorMessage);
 
         var commands = new List<CommandDescriptor>();

--- a/Source/DotNET/Tools/ProxyGenerator/Program.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/Program.cs
@@ -9,7 +9,7 @@ Console.WriteLine("Cratis Proxy Generator\n");
 if (args.Length < 2)
 {
     Console.WriteLine("Usage: ");
-    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--library-mode] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file] [--assembly-to-package=<Assembly>=<Package>]... [--exclude-type=<FullyQualifiedTypeName>]... [--exclude-namespace=<Pattern>]... [--namespace-root=<Namespace>=<Folder>]...");
+    Console.WriteLine("  Cratis.ProxyGenerator <assembly> <output-path> [segments-to-skip] [--library-mode] [--skip-output-deletion] [--skip-command-name-in-route] [--skip-query-name-in-route] [--api-prefix=<prefix>] [--skip-index-generation] [--use-source-file-as-output-file] [--assembly-to-package=<Assembly>=<Package>]... [--exclude-type=<FullyQualifiedTypeName>]... [--exclude-namespace=<Pattern>]... [--namespace-root=<Namespace>=<Folder>]... [--type-to-ts=<FullyQualifiedTypeName>=<TsType>[=<Package>]]...");
     return 1;
 }
 var assemblyFile = Normalize(Path.GetFullPath(args[0]));
@@ -43,6 +43,19 @@ var excludedNamespacePatterns = args
     .Where(_ => _.StartsWith("--exclude-namespace="))
     .Select(_ => _["--exclude-namespace=".Length..])
     .ToList();
+
+// A repeatable mapping of a .NET type to the TypeScript type it should cross the wire as, fed from a
+// TypeToTsType MSBuild item. Consulted ahead of the generator's built-in map, so it can correct an
+// existing mapping as well as declare one the generator has never seen.
+var typeMappings = new List<(string TypeName, string TsType, string Package)>();
+foreach (var entry in args.Where(_ => _.StartsWith("--type-to-ts=")).Select(_ => _["--type-to-ts=".Length..]))
+{
+    var parts = entry.Split('=');
+    if (parts.Length >= 2 && !string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1]))
+    {
+        typeMappings.Add((parts[0], parts[1], parts.Length > 2 ? parts[2] : string.Empty));
+    }
+}
 
 var namespaceRoots = new List<(string Namespace, string Folder)>();
 foreach (var entry in args.Where(_ => _.StartsWith("--namespace-root=")).Select(_ => _["--namespace-root=".Length..]))
@@ -115,5 +128,6 @@ var result = await Generator.Generate(
     assemblyPackageMappings,
     excludedTypeNames,
     excludedNamespacePatterns,
-    namespaceRoots);
+    namespaceRoots,
+    typeMappings);
 return result ? 0 : 1;

--- a/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
+++ b/Source/DotNET/Tools/ProxyGenerator/TypeExtensions.cs
@@ -83,6 +83,7 @@ public static class TypeExtensions
     ];
 
     static Dictionary<string, string> _assemblyPackageMappings = [];
+    static Dictionary<string, TargetType> _typeMappings = [];
     static HashSet<string> _excludedTypeNames = [];
     static List<string> _excludedNamespacePatterns = [];
     static List<(string Namespace, string Folder)> _namespaceRoots = [];
@@ -102,6 +103,36 @@ public static class TypeExtensions
     public static void SetAssemblyPackageMappings(IReadOnlyDictionary<string, string> mappings)
     {
         _assemblyPackageMappings = new Dictionary<string, string>(mappings);
+    }
+
+    /// <summary>
+    /// Sets explicit mappings from a .NET type to the TypeScript type it should cross the wire as.
+    /// </summary>
+    /// <param name="mappings">Triples of (fully qualified type name, TypeScript type, package the type is imported from).</param>
+    /// <remarks>
+    /// <para>
+    /// Consulted ahead of the built-in map, so a consumer can correct how an existing type is generated
+    /// as well as declare one the generator has never seen. Nothing is mapped unless asked for, so a
+    /// build that passes no mappings generates exactly what it generated before.
+    /// </para>
+    /// <para>
+    /// A mapping with no package generates a bare TypeScript type and emits no import; one with a
+    /// package emits the package as a bare specifier, the way <c>Guid</c> and <c>TimeSpan</c> are
+    /// imported from <c>@cratis/fundamentals</c>.
+    /// </para>
+    /// </remarks>
+    public static void SetTypeMappings(IReadOnlyCollection<(string TypeName, string TsType, string Package)> mappings)
+    {
+        _typeMappings = mappings.ToDictionary(
+            static mapping => mapping.TypeName,
+            static mapping => new TargetType(
+                typeof(object),
+                mapping.TsType,
+                mapping.TsType,
+                mapping.Package,
+                Final: true,
+                FromPackage: !string.IsNullOrEmpty(mapping.Package)),
+            StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -506,6 +537,13 @@ public static class TypeExtensions
         {
             var underlyingType = type.GetGenericArguments()[0];
             return underlyingType.GetTargetType();
+        }
+
+        // Ahead of the built-in map, which is what lets a mapping correct an existing type rather than
+        // only add an unknown one. The built-in map is still what answers when nothing was configured.
+        if (type.FullName is not null && _typeMappings.TryGetValue(type.FullName, out var mapped))
+        {
+            return mapped with { OriginalType = type };
         }
 
         if (type.FullName is not null && _primitiveTypeMap.TryGetValue(type.FullName, out var value))

--- a/Source/JavaScript/Arc/package.json
+++ b/Source/JavaScript/Arc/package.json
@@ -69,7 +69,12 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "^7.16.0",
         "rxjs": "^7.8.2"
+    },
+    "peerDependencies": {
+        "@cratis/fundamentals": "^7"
+    },
+    "devDependencies": {
+        "@cratis/fundamentals": "7.16.0"
     }
 }


### PR DESCRIPTION
## Added

- `--type-to-ts` argument and matching `TypeToTsType` MSBuild item declare how a .NET type crosses the wire to TypeScript, and take the place of the built-in mapping for that type.

## Changed

- `@cratis/arc` declares `@cratis/fundamentals` as a peer dependency instead of a versioned dependency. Consumers whose package manager does not install peers automatically must now declare it themselves.
