### PR TITLE
Identify command form fields and columns by a tamper-resistant marker

### DIFF
--- a/Documentation/frontend/react/command-form/custom-fields.md
+++ b/Documentation/frontend/react/command-form/custom-fields.md
@@ -72,6 +72,24 @@ The second parameter to `asCommandFormField` is a configuration object:
 | `defaultValue` | `TValue` | Yes | Default value when the field is empty/undefined |
 | `extractValue` | `(event: unknown) => TValue` | No | Function to extract the value from change events. If omitted, the event itself is used as the value. |
 
+## How a field is recognized
+
+`asCommandFormField` marks the component it returns so `CommandForm` can pick its fields out of its children. The marker is a static `isCommandFormField` property, and the component's `displayName` is set to `CommandFormField` as well, which is what a version of `@cratis/components` that predates the marker still reads.
+
+:::caution
+**Do not overwrite `displayName` on a command form field**, and do not strip static properties from one. A build transform that does either can unbind the field from its command — the form renders, the input accepts typing, and nothing reaches the command. There is no error and no warning.
+
+The most likely source is Storybook's `reactDocgen: 'react-docgen-typescript'` setting, whose plugin rewrites `displayName` by default. The `isCommandFormField` marker is there to survive exactly that, so a field keeps working under it — but a transform that removes both loses the binding.
+:::
+
+If you build a field by hand rather than through `asCommandFormField`, mark it with `markAsCommandFormField` rather than assigning `displayName` yourself:
+
+```tsx
+import { markAsCommandFormField } from '@cratis/arc.react/commands';
+
+markAsCommandFormField(MyHandRolledField);
+```
+
 ## Example: PrimeReact InputText
 
 Here's a complete example of creating a custom field using PrimeReact's `InputText` component:

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandForm.tsx
@@ -14,6 +14,7 @@ import { getPropertyNameFromAccessor } from './getPropertyNameFromAccessor';
 import { memberMatchesField } from './memberMatchesField';
 import { runCommandValidation } from './runCommandValidation';
 import { useIdentity } from '../../identity';
+import { isCommandFormColumn, isCommandFormField, markAsCommandFormColumn } from './commandFormMarkers';
 
 // Re-export for backwards compatibility
 export { useCommandFormContext } from './CommandFormContext';
@@ -98,13 +99,13 @@ const getCommandFormFields = <TCommand,>(props: { children?: React.ReactNode }):
         const component = child.type as React.ComponentType<unknown>;
 
         // Check if child is a CommandFormColumn
-        if (component.displayName === 'CommandFormColumn') {
+        if (isCommandFormColumn(component)) {
             hasColumns = true;
             const childProps = child.props as { children?: React.ReactNode };
             const columnFields = React.Children.toArray(childProps.children).filter(child => {
                 if (React.isValidElement(child)) {
                     const comp = child.type as React.ComponentType<unknown>;
-                    if (comp.displayName === 'CommandFormField') {
+                    if (isCommandFormField(comp)) {
                         extractInitialValue(child as React.ReactElement);
                         return true;
                     }
@@ -114,7 +115,7 @@ const getCommandFormFields = <TCommand,>(props: { children?: React.ReactNode }):
             columns.push({ fields: columnFields as React.ReactElement<CommandFormFieldProps>[] });
         }
         // Check if child is a CommandFormField (direct child)
-        else if (component.displayName === 'CommandFormField') {
+        else if (isCommandFormField(component)) {
             extractInitialValue(child as React.ReactElement);
             fields.push(child as React.ReactElement<CommandFormFieldProps>);
             orderedChildren.push({ type: 'field', content: child, index: fieldIndex++ });
@@ -421,7 +422,7 @@ const CommandFormColumnComponent = (props: CommandFormColumnProps) => {
             {children.map((child, index) => {
                 if (React.isValidElement(child)) {
                     const component = child.type as React.ComponentType<unknown>;
-                    if (component.displayName === 'CommandFormField') {
+                    if (isCommandFormField(component)) {
                         return (
                             <CommandFormFieldWrapper
                                 key={`column-field-${index}`}
@@ -437,7 +438,7 @@ const CommandFormColumnComponent = (props: CommandFormColumnProps) => {
     );
 };
 
-CommandFormColumnComponent.displayName = 'CommandFormColumn';
+markAsCommandFormColumn(CommandFormColumnComponent);
 
 // Export as function to enable proper type inference from command prop
 export function CommandForm<TCommand extends object = object, TResponse = object>(

--- a/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/CommandFormField.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+import { markAsCommandFormField } from './commandFormMarkers';
+
 /**
  * Props for the CommandFormField marker component.
  *
@@ -32,4 +34,4 @@ export const CommandFormField = <TCommand = unknown,>(_props: CommandFormFieldPr
     return <></>;
 };
 
-CommandFormField.displayName = 'CommandFormField';
+markAsCommandFormField(CommandFormField);

--- a/Source/JavaScript/Arc.React/commands/CommandForm/asCommandFormField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/asCommandFormField.tsx
@@ -4,6 +4,7 @@
 import { PropertyDescriptor } from '@cratis/arc/reflection';
 import React, { ComponentType } from 'react';
 import { useCommandFormContext } from './CommandForm';
+import { markAsCommandFormField } from './commandFormMarkers';
 
 /**
  * Props that will be injected by CommandFormFields into your wrapped component
@@ -159,7 +160,7 @@ export function asCommandFormField<TComponentProps extends WrappedFieldProps<unk
         return <Component {...wrappedProps} />;
     };
 
-    WrappedField.displayName = 'CommandFormField';
+    markAsCommandFormField(WrappedField);
 
     return WrappedField;
 }

--- a/Source/JavaScript/Arc.React/commands/CommandForm/commandFormMarkers.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/commandFormMarkers.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The `displayName` a command form field carries.
+ * @remarks
+ * Exported so a consumer recognising a field has a constant to compare against rather than a duplicated string
+ * literal, and so the two values below have one definition between them.
+ */
+export const CommandFormFieldDisplayName = 'CommandFormField';
+
+/**
+ * The `displayName` a command form column carries.
+ */
+export const CommandFormColumnDisplayName = 'CommandFormColumn';
+
+/**
+ * The shape a component carries to say what it is to a {@link CommandForm}.
+ */
+export type CommandFormMarked = {
+    /** Set on a field component. */
+    isCommandFormField?: boolean;
+
+    /** Set on a column component. */
+    isCommandFormColumn?: boolean;
+
+    /** The React display name, kept as the compatibility fallback. */
+    displayName?: string;
+};
+
+/**
+ * Marks a component as a command form field.
+ * @param component The component to mark.
+ * @returns The same component, typed as marked.
+ * @remarks
+ * Sets both the marker and the `displayName`. The `displayName` is not redundant and is not on a deprecation path:
+ * it is what lets a version of this package interoperate with a version of a consuming package that only knows the
+ * string, in both directions. Removing it would silently unbind every field across that version boundary - the very
+ * failure the marker exists to prevent.
+ */
+export function markAsCommandFormField<T>(component: T): T & CommandFormMarked {
+    const marked = component as T & CommandFormMarked;
+    marked.isCommandFormField = true;
+    marked.displayName = CommandFormFieldDisplayName;
+    return marked;
+}
+
+/**
+ * Marks a component as a command form column.
+ * @param component The component to mark.
+ * @returns The same component, typed as marked.
+ */
+export function markAsCommandFormColumn<T>(component: T): T & CommandFormMarked {
+    const marked = component as T & CommandFormMarked;
+    marked.isCommandFormColumn = true;
+    marked.displayName = CommandFormColumnDisplayName;
+    return marked;
+}
+
+/**
+ * Whether a component is a command form field.
+ * @param component The component to check.
+ * @returns True when it is.
+ * @remarks
+ * The marker is checked first and the `displayName` second. A build transform that rewrites `displayName` - which
+ * `react-docgen-typescript` does by default, and Storybook selects it through a documented option - leaves the
+ * marker alone, so a field survives where it used to unbind silently. The fallback keeps a hand-marked component,
+ * and a component from a package that predates the marker, working exactly as before.
+ */
+export function isCommandFormField(component: CommandFormMarked | undefined): boolean {
+    return component?.isCommandFormField === true || component?.displayName === CommandFormFieldDisplayName;
+}
+
+/**
+ * Whether a component is a command form column.
+ * @param component The component to check.
+ * @returns True when it is.
+ */
+export function isCommandFormColumn(component: CommandFormMarked | undefined): boolean {
+    return component?.isCommandFormColumn === true || component?.displayName === CommandFormColumnDisplayName;
+}

--- a/Source/JavaScript/Arc.React/commands/CommandForm/commandFormMarkers.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/commandFormMarkers.ts
@@ -4,7 +4,7 @@
 /**
  * The `displayName` a command form field carries.
  * @remarks
- * Exported so a consumer recognising a field has a constant to compare against rather than a duplicated string
+ * Exported so a consumer recognizing a field has a constant to compare against rather than a duplicated string
  * literal, and so the two values below have one definition between them.
  */
 export const CommandFormFieldDisplayName = 'CommandFormField';

--- a/Source/JavaScript/Arc.React/commands/CommandForm/fields/RadioButtonField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/fields/RadioButtonField.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { BaseCommandFormFieldProps, InjectedCommandFormFieldProps } from '../asCommandFormField';
+import { markAsCommandFormField } from '../commandFormMarkers';
 
 type RadioValueAccessor = (instance: never) => unknown;
 type CommandType<TAccessor extends RadioValueAccessor> = Parameters<TAccessor>[0];
@@ -64,4 +65,4 @@ export function RadioButtonField<TAccessor extends RadioValueAccessor>(props: Ra
     );
 }
 
-RadioButtonField.displayName = 'CommandFormField';
+markAsCommandFormField(RadioButtonField);

--- a/Source/JavaScript/Arc.React/commands/CommandForm/fields/RadioGroupField.tsx
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/fields/RadioGroupField.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { BaseCommandFormFieldProps, InjectedCommandFormFieldProps } from '../asCommandFormField';
+import { markAsCommandFormField } from '../commandFormMarkers';
 
 type RadioValueAccessor = (instance: never) => unknown;
 type CommandType<TAccessor extends RadioValueAccessor> = Parameters<TAccessor>[0];
@@ -76,4 +77,4 @@ export function RadioGroupField<TAccessor extends RadioValueAccessor>(props: Rad
     );
 }
 
-RadioGroupField.displayName = 'CommandFormField';
+markAsCommandFormField(RadioGroupField);

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_a_transform_has_rewritten_displayName.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_a_transform_has_rewritten_displayName.ts
@@ -11,7 +11,7 @@ import {
 } from '../commandFormMarkers';
 
 /**
- * A field used to be recognised only by `component.displayName === 'CommandFormField'`, so any transform that set
+ * A field used to be recognized only by `component.displayName === 'CommandFormField'`, so any transform that set
  * `displayName` unbound every field with no error and no warning - react-docgen-typescript does exactly that, by
  * default, through a documented Storybook option.
  */
@@ -22,17 +22,17 @@ describe('when a transform has rewritten displayName', () => {
     field.displayName = 'MyStorybookName';
     column.displayName = 'MyStorybookName';
 
-    it('should still recognise the field', () => isCommandFormField(field).should.be.true);
-    it('should still recognise the column', () => isCommandFormColumn(column).should.be.true);
+    it('should still recognize the field', () => isCommandFormField(field).should.be.true);
+    it('should still recognize the column', () => isCommandFormColumn(column).should.be.true);
 
     // The compatibility half, and why displayName is not on a deprecation path: a component from a package that
     // predates the marker, or one a consumer marked by hand, has only the string.
-    it('should still recognise a component carrying only the field displayName', () =>
+    it('should still recognize a component carrying only the field displayName', () =>
         isCommandFormField({ displayName: CommandFormFieldDisplayName }).should.be.true);
-    it('should still recognise a component carrying only the column displayName', () =>
+    it('should still recognize a component carrying only the column displayName', () =>
         isCommandFormColumn({ displayName: CommandFormColumnDisplayName }).should.be.true);
 
-    it('should not recognise an unrelated component', () => isCommandFormField({ displayName: 'Something' }).should.be.false);
+    it('should not recognize an unrelated component', () => isCommandFormField({ displayName: 'Something' }).should.be.false);
     it('should not mistake a column for a field', () => isCommandFormField(column).should.be.false);
     it('should not mistake a field for a column', () => isCommandFormColumn(field).should.be.false);
     it('should tolerate no component at all', () => isCommandFormField(undefined).should.be.false);

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_a_transform_has_rewritten_displayName.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_a_transform_has_rewritten_displayName.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {
+    CommandFormColumnDisplayName,
+    CommandFormFieldDisplayName,
+    isCommandFormColumn,
+    isCommandFormField,
+    markAsCommandFormColumn,
+    markAsCommandFormField
+} from '../commandFormMarkers';
+
+/**
+ * A field used to be recognised only by `component.displayName === 'CommandFormField'`, so any transform that set
+ * `displayName` unbound every field with no error and no warning - react-docgen-typescript does exactly that, by
+ * default, through a documented Storybook option.
+ */
+describe('when a transform has rewritten displayName', () => {
+    const field = markAsCommandFormField(function Field() { return null; });
+    const column = markAsCommandFormColumn(function Column() { return null; });
+
+    field.displayName = 'MyStorybookName';
+    column.displayName = 'MyStorybookName';
+
+    it('should still recognise the field', () => isCommandFormField(field).should.be.true);
+    it('should still recognise the column', () => isCommandFormColumn(column).should.be.true);
+
+    // The compatibility half, and why displayName is not on a deprecation path: a component from a package that
+    // predates the marker, or one a consumer marked by hand, has only the string.
+    it('should still recognise a component carrying only the field displayName', () =>
+        isCommandFormField({ displayName: CommandFormFieldDisplayName }).should.be.true);
+    it('should still recognise a component carrying only the column displayName', () =>
+        isCommandFormColumn({ displayName: CommandFormColumnDisplayName }).should.be.true);
+
+    it('should not recognise an unrelated component', () => isCommandFormField({ displayName: 'Something' }).should.be.false);
+    it('should not mistake a column for a field', () => isCommandFormField(column).should.be.false);
+    it('should not mistake a field for a column', () => isCommandFormColumn(field).should.be.false);
+    it('should tolerate no component at all', () => isCommandFormField(undefined).should.be.false);
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_exchanging_marked_components_with_a_consuming_package.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/for_commandFormMarkers/when_exchanging_marked_components_with_a_consuming_package.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {
+    CommandFormColumnDisplayName,
+    CommandFormFieldDisplayName,
+    CommandFormMarked,
+    isCommandFormColumn,
+    isCommandFormField,
+    markAsCommandFormColumn,
+    markAsCommandFormField
+} from '../commandFormMarkers';
+
+/**
+ * The cross-package contract, and the only spec that can catch this package and a consuming one
+ * drifting apart.
+ *
+ * `@cratis/components` reads the field marker written here, and writes the column marker read here.
+ * Neither imports the other's helper — a consuming package declares this one as a version range, so
+ * a named import would be a hard module-link error against any version in that range predating the
+ * marker — so the contract is carried entirely by the property names below being identical on both
+ * sides. Nothing about that is enforced by the compiler.
+ *
+ * That is not hypothetical. The two packages were briefly implemented with different shapes, one a
+ * static property and the other a `Symbol`, and every spec in both repositories passed: both kept
+ * the `displayName` fallback, so nothing threw, and the marker simply stopped crossing the
+ * boundary. A field whose `displayName` a build transform had rewritten bound in a bare
+ * `CommandForm` and silently unbound inside a `CommandDialog` — the exact failure the marker was
+ * added to prevent, surviving the fix.
+ *
+ * The literals here are therefore deliberate rather than lazy: they restate what a consuming
+ * package writes and reads, so this reds if either side moves.
+ */
+describe('when exchanging marked components with a consuming package', () => {
+    const markedElsewhere = (marker: 'isCommandFormField' | 'isCommandFormColumn', displayName: string): CommandFormMarked => {
+        const component = function Component() { return null; };
+        return Object.assign(component, { [marker]: true, displayName }) as CommandFormMarked;
+    };
+
+    // A component another package marked, whose displayName a build transform then rewrote, so only
+    // the marker is left to recognize it by.
+    const field = markedElsewhere('isCommandFormField', CommandFormFieldDisplayName);
+    const column = markedElsewhere('isCommandFormColumn', CommandFormColumnDisplayName);
+    field.displayName = 'RenamedByABuildTransform';
+    column.displayName = 'RenamedByABuildTransform';
+
+    it('should recognize a field another package marked', () => isCommandFormField(field).should.be.true);
+    it('should recognize a column another package marked', () => isCommandFormColumn(column).should.be.true);
+
+    // The other half: what this package writes has to be what the consuming package reads. Asserted
+    // as raw property access rather than through the helpers, because that is the half performed by
+    // code this package does not run.
+    const ownField = markAsCommandFormField(function Field() { return null; });
+    const ownColumn = markAsCommandFormColumn(function Column() { return null; });
+
+    it('should expose the field marker under the property name a consuming package reads', () =>
+        (ownField as unknown as Record<string, unknown>).isCommandFormField!.should.equal(true));
+    it('should expose the column marker under the property name a consuming package reads', () =>
+        (ownColumn as unknown as Record<string, unknown>).isCommandFormColumn!.should.equal(true));
+
+    it('should keep the legacy field displayName for a consumer predating the marker', () =>
+        (ownField as unknown as Record<string, unknown>).displayName!.should.equal('CommandFormField'));
+    it('should keep the legacy column displayName for a consumer predating the marker', () =>
+        (ownColumn as unknown as Record<string, unknown>).displayName!.should.equal('CommandFormColumn'));
+});

--- a/Source/JavaScript/Arc.React/commands/CommandForm/index.ts
+++ b/Source/JavaScript/Arc.React/commands/CommandForm/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './asCommandFormField';
+export * from './commandFormMarkers';
 export * from './CommandForm';
 export * from './CommandFormContext';
 export * from './CommandFormField';


### PR DESCRIPTION
# Summary

A command form field or column is now identified by a marker a build transform does not touch, with the legacy `displayName` kept as a permanent fallback.

## Added

- `markAsCommandFormField` and `markAsCommandFormColumn` for marking a hand-rolled field or column, and `isCommandFormField` and `isCommandFormColumn` for identifying one, exported from `@cratis/arc.react/commands`
- `CommandFormMarked`, the marker shape, and the `CommandFormFieldDisplayName` and `CommandFormColumnDisplayName` constants
- Documentation on how a field is recognized, on marking a hand-rolled field, and on the Storybook setting that breaks it

## Changed

- `CommandForm` identifies field and column children through the marker, falling back to `displayName`, so consumers marking a field by hand are unaffected
- `asCommandFormField`, `CommandFormField`, `RadioButtonField`, `RadioGroupField` and the column component set the marker alongside the `displayName` they already set

## Fixed

- A command form field whose `displayName` is rewritten by a build transform — such as Storybook's `reactDocgen: 'react-docgen-typescript'`, which rewrites it by default — is no longer silently unbound from its command, rendering an input that accepts typing while nothing reaches the command
