### PR TITLE
Depend on @cratis/fundamentals as a peer

### DIFF
--- a/Source/JavaScript/Arc/package.json
+++ b/Source/JavaScript/Arc/package.json
@@ -69,7 +69,12 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@cratis/fundamentals": "^7.16.0",
         "rxjs": "^7.8.2"
+    },
+    "peerDependencies": {
+        "@cratis/fundamentals": "^7"
+    },
+    "devDependencies": {
+        "@cratis/fundamentals": "7.16.0"
     }
 }


### PR DESCRIPTION
## Changed

- `@cratis/arc` declares `@cratis/fundamentals` as a peer dependency instead of a versioned dependency. Consumers whose package manager does not install peers automatically must now declare it themselves.
