### PR TITLE
Update Cratis.Screenplay to 1.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Cratis.Chronicle.Testing" Version="16.16.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
-    <PackageVersion Include="Cratis.Screenplay" Version="1.5.2" />
+    <PackageVersion Include="Cratis.Screenplay" Version="1.8.0" />
     <!-- MAUI -->
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />

--- a/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ConceptSyntaxBuilder/when_building/a_concept_carrying_personal_data.cs
@@ -28,6 +28,6 @@ public class a_concept_carrying_personal_data : given.a_concept_syntax_builder
         _unmarked = concepts.First(_ => _.Name == "BookTitle");
     }
 
-    [Fact] void should_mark_the_concept_carrying_personal_data() => _marked.Attributes.ShouldContainOnly([ConceptSyntaxBuilder.PersonallyIdentifiableInformation]);
+    [Fact] void should_mark_the_concept_carrying_personal_data() => _marked.AttributeNames.ShouldContainOnly([ConceptSyntaxBuilder.PersonallyIdentifiableInformation]);
     [Fact] void should_not_mark_a_concept_that_carries_none() => _unmarked.Attributes.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_document_the_language_rejects.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayGenerator/given/a_document_the_language_rejects.cs
@@ -16,8 +16,11 @@ namespace Cratis.Arc.Screenplay.for_ScreenplayGenerator.given;
 /// Every way of emitting a rejected document that anyone has found has since been fixed, which is exactly why the
 /// check exists - it has to hold for the one nobody has found yet. Replacing the printed text is the smallest seam
 /// that produces one: the analysis, the emitter, the syntax tree the emitter builds and the compiler reading the
-/// text back are all the real ones, and nothing on the path a host takes is substituted. The text is the defect that
-/// shipped, which is a command property called <c>Description</c> written out as the directive of the same name.
+/// text back are all the real ones, and nothing on the path a host takes is substituted. The text is the shape the
+/// defect that shipped took - a name written where the grammar holds a quoted description - moved to a body that
+/// reads <c>description</c> as nothing but the directive. The command body it was written in no longer rejects it:
+/// the language now reads a directive-shaped property line as the property, so the exact text that shipped is
+/// something it holds rather than something it turns away.
 /// </remarks>
 public class a_document_the_language_rejects : Specification
 {
@@ -28,8 +31,8 @@ public class a_document_the_language_rejects : Specification
         domain Library
         module Library
           feature Authors
-            slice StateChange Registration
-              command RegisterAuthor
+            slice StateView Registration
+              query AuthorById => Author
                 description RequestDescription
         """;
 

--- a/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Concepts/ConceptSyntaxBuilder.cs
@@ -26,7 +26,7 @@ public class ConceptSyntaxBuilder(
     /// <summary>
     /// The Screenplay attribute marking a concept as personally identifiable information.
     /// </summary>
-    public const string PersonallyIdentifiableInformation = "pii";
+    public const string PersonallyIdentifiableInformation = ConceptAttributeSyntax.Pii;
 
     /// <summary>
     /// Builds every concept the document declares.
@@ -59,7 +59,7 @@ public class ConceptSyntaxBuilder(
             declared[name] = new(
                 name,
                 ScreenplayPrimitiveTypes.GetName(concept.Primitive),
-                concept.IsPii ? [PersonallyIdentifiableInformation] : [],
+                concept.IsPii ? [new ConceptAttributeSyntax(PersonallyIdentifiableInformation, SourceLocation.Start)] : [],
                 values,
                 SourceLocation.Start,
                 [.. validations.Build(concept.Validations, concept.Name, impliedSubject: true)]);


### PR DESCRIPTION
# Summary

Moves the Screenplay language package to the current release, so the end-to-end check verifies generated documents against the language they will actually be read with.

## Changed

- `Cratis.Screenplay` 1.5.2 to 1.8.0
