### PR TITLE
Fix observable queries releasing PII against the wrong tenant namespace

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/given/a_client_enumerable_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/given/a_client_enumerable_observable.cs
@@ -9,7 +9,6 @@ public class a_client_enumerable_observable : Specification
 {
     protected TestAsyncEnumerable _enumerable;
     protected IReadModelInterceptors _readModelInterceptors;
-    protected IServiceProvider _serviceProvider;
     protected IWebSocketConnectionHandler _webSocketConnectionHandler;
     protected ILogger<IClientObservable> _logger;
     protected ClientEnumerableObservable<TestData> _clientEnumerableObservable;
@@ -18,14 +17,12 @@ public class a_client_enumerable_observable : Specification
     {
         _enumerable = new TestAsyncEnumerable();
         _readModelInterceptors = Substitute.For<IReadModelInterceptors>();
-        _serviceProvider = Substitute.For<IServiceProvider>();
         _webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
         _logger = Substitute.For<ILogger<IClientObservable>>();
 
         _clientEnumerableObservable = new ClientEnumerableObservable<TestData>(
             _enumerable,
             _readModelInterceptors,
-            _serviceProvider,
             _webSocketConnectionHandler,
             _logger);
     }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/given/a_client_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/given/a_client_observable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Subjects;
+using Cratis.Arc.Http;
 using Cratis.Execution;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,7 @@ public class a_client_observable : Specification
     protected QueryContext _queryContext;
     protected BehaviorSubject<TestData> _subject;
     protected IReadModelInterceptors _readModelInterceptors;
-    protected IServiceProvider _serviceProvider;
+    protected IHttpRequestContextAccessor _httpRequestContextAccessor;
     protected IWebSocketConnectionHandler _webSocketConnectionHandler;
     protected IHostApplicationLifetime _hostApplicationLifetime;
     protected ILogger<ClientObservable<TestData>> _logger;
@@ -24,7 +25,7 @@ public class a_client_observable : Specification
         _queryContext = new QueryContext("TestQuery", CorrelationId.New(), Paging.NotPaged, Sorting.None);
         _subject = new BehaviorSubject<TestData>(new TestData("Initial"));
         _readModelInterceptors = Substitute.For<IReadModelInterceptors>();
-        _serviceProvider = Substitute.For<IServiceProvider>();
+        _httpRequestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
         _webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
         _hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
         _logger = Substitute.For<ILogger<ClientObservable<TestData>>>();
@@ -33,7 +34,7 @@ public class a_client_observable : Specification
             _queryContext,
             _subject,
             _readModelInterceptors,
-            _serviceProvider,
+            _httpRequestContextAccessor,
             _webSocketConnectionHandler,
             _hostApplicationLifetime,
             _logger);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
@@ -22,6 +22,7 @@ public class and_complete_and_next_race
 
         var httpContext = Substitute.For<IHttpRequestContext>();
         httpContext.WebSockets.Returns(webSocketContext);
+        httpContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
 
         var hostLifetime = Substitute.For<IHostApplicationLifetime>();
         hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
@@ -56,7 +57,7 @@ public class and_complete_and_next_race
             queryContext,
             subject,
             Substitute.For<IReadModelInterceptors>(),
-            Substitute.For<IServiceProvider>(),
+            Substitute.For<IHttpRequestContextAccessor>(),
             webSocketConnectionHandler,
             hostLifetime,
             logger);
@@ -97,6 +98,7 @@ public class and_complete_and_next_race
 
         var httpContext = Substitute.For<IHttpRequestContext>();
         httpContext.WebSockets.Returns(webSocketContext);
+        httpContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
 
         var hostLifetime = Substitute.For<IHostApplicationLifetime>();
         hostLifetime.ApplicationStopping.Returns(CancellationToken.None);
@@ -130,7 +132,7 @@ public class and_complete_and_next_race
             queryContext,
             subject,
             Substitute.For<IReadModelInterceptors>(),
-            Substitute.For<IServiceProvider>(),
+            Substitute.For<IHttpRequestContextAccessor>(),
             webSocketConnectionHandler,
             hostLifetime,
             logger);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
@@ -18,6 +18,7 @@ public class and_concurrent_emissions_and_disposal_occur
         // Arrange
         var subject = new Subject<int>();
         var httpContext = Substitute.For<IHttpRequestContext>();
+        httpContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
         var arcOptions = Substitute.For<IOptions<ArcOptions>>();
         var options = new ArcOptions();
         arcOptions.Value.Returns(options);
@@ -40,7 +41,7 @@ public class and_concurrent_emissions_and_disposal_occur
             queryContext,
             subject,
             Substitute.For<IReadModelInterceptors>(),
-            Substitute.For<IServiceProvider>(),
+            Substitute.For<IHttpRequestContextAccessor>(),
             arcOptions,
             hostLifetime,
             logger);
@@ -79,6 +80,7 @@ public class and_concurrent_emissions_and_disposal_occur
         // Arrange
         var subject = new Subject<int>();
         var httpContext = Substitute.For<IHttpRequestContext>();
+        httpContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
         var arcOptions = Substitute.For<IOptions<ArcOptions>>();
         var options = new ArcOptions();
         arcOptions.Value.Returns(options);
@@ -101,7 +103,7 @@ public class and_concurrent_emissions_and_disposal_occur
             queryContext,
             subject,
             Substitute.For<IReadModelInterceptors>(),
-            Substitute.For<IServiceProvider>(),
+            Substitute.For<IHttpRequestContextAccessor>(),
             arcOptions,
             hostLifetime,
             logger);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,7 +34,10 @@ public class an_observable_query_demultiplexer : Specification
         _readModelInterceptors = Substitute.For<IReadModelInterceptors>();
         _readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
             .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
-        _serviceProvider = Substitute.For<IServiceProvider>();
+
+        // A real container — the hub creates a per-subscription IServiceScope from this, which a bare
+        // NSubstitute mock cannot satisfy (it has no working IServiceScopeFactory to resolve).
+        _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
         _arcOptions = Options.Create(new ArcOptions());
         _logger = Substitute.For<ILogger<ObservableQueryDemultiplexer>>();

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_connection_is_known_and_read_models_are_intercepted_per_emission.cs
@@ -86,7 +86,15 @@ public class and_connection_is_known_and_read_models_are_intercepted_per_emissio
     }
 
     [Fact] void should_intercept_each_emission_with_the_read_model_element_type() =>
-        _readModelInterceptors.Received().Intercept(typeof(string), Arg.Any<IEnumerable<object>>(), _serviceProvider);
+        _readModelInterceptors.Received().Intercept(typeof(string), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>());
+
+    /// <summary>
+    /// Regression guard for the bug this fixes: interception must run against a scope created for this
+    /// subscription, never the root container directly — resolving scoped Chronicle services from root would
+    /// cache whichever tenant subscribed first and reuse it for every subscription thereafter.
+    /// </summary>
+    [Fact] void should_not_intercept_with_the_root_service_provider() =>
+        _readModelInterceptors.Received().Intercept(typeof(string), Arg.Any<IEnumerable<object>>(), Arg.Is<IServiceProvider>(sp => sp != _serviceProvider));
 
     [Fact] void should_send_the_released_value_to_the_client() =>
         string.Concat(_messages).Contains("item-a-released", StringComparison.Ordinal).ShouldBeTrue();

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_subscribing_to_an_async_enumerable_stream.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_subscribing_to_an_async_enumerable_stream.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using Cratis.Arc.Http;
 using Cratis.Execution;
 
 namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer;
@@ -26,6 +27,7 @@ public class when_subscribing_to_an_async_enumerable_stream : given.an_observabl
     async Task Because()
     {
         _subscription = _hub.SubscribeToStreamingData(
+            Substitute.For<IHttpRequestContext>(),
             Stream(),
             "q1",
             new PagingInfo(0, 0, 0),

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
@@ -12,13 +12,11 @@ namespace Cratis.Arc.Queries;
 /// <typeparam name="T">Type of data being observed.</typeparam>
 /// <param name="enumerable">The <see cref="IAsyncEnumerable{T}"/> to use for streaming.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors.</param>
 /// <param name="webSocketConnectionHandler">The <see cref="IWebSocketConnectionHandler"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientEnumerableObservable<T>(
     IAsyncEnumerable<T> enumerable,
     IReadModelInterceptors readModelInterceptors,
-    IServiceProvider serviceProvider,
     IWebSocketConnectionHandler webSocketConnectionHandler,
     ILogger<IClientObservable> logger)
     : IClientEnumerableObservable
@@ -44,7 +42,10 @@ public class ClientEnumerableObservable<T>(
                         continue;
                     }
 
-                    queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, serviceProvider);
+                    // Resolve through the connection's own request-scoped provider — captured here via closure —
+                    // rather than the root, so the interceptor releases compliance/PII data under this
+                    // subscription's tenant instead of whichever tenant happened to resolve first.
+                    queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, context.RequestServices);
                     var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                     if (error is null)
                     {

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
@@ -17,13 +17,11 @@ namespace Cratis.Arc.Queries;
 /// </remarks>
 /// <param name="enumerable">The <see cref="IAsyncEnumerable{T}"/> to use for streaming.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientEnumerableObservableSSE<T>(
     IAsyncEnumerable<T> enumerable,
     IReadModelInterceptors readModelInterceptors,
-    IServiceProvider serviceProvider,
     IOptions<ArcOptions> arcOptions,
     ILogger<IClientObservable> logger)
     : IClientEnumerableObservable
@@ -48,7 +46,10 @@ public class ClientEnumerableObservableSSE<T>(
                     continue;
                 }
 
-                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, serviceProvider);
+                // Resolve through the connection's own request-scoped provider rather than the root, so the
+                // interceptor releases compliance/PII data under this subscription's tenant instead of
+                // whichever tenant happened to resolve first.
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, context.RequestServices);
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";
 

--- a/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
@@ -18,7 +18,7 @@ namespace Cratis.Arc.Queries;
 /// <param name="queryContext">The <see cref="QueryContext"/> the observable is for.</param>
 /// <param name="subject">The <see cref="ISubject{T}"/> the observable wraps.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors.</param>
+/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> restored around each emission so tenant resolution sees the subscribing connection, not whatever ambient context the emitting thread happens to carry.</param>
 /// <param name="webSocketConnectionHandler">The <see cref="IWebSocketConnectionHandler"/>.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
@@ -26,7 +26,7 @@ public class ClientObservable<T>(
     QueryContext queryContext,
     ISubject<T> subject,
     IReadModelInterceptors readModelInterceptors,
-    IServiceProvider serviceProvider,
+    IHttpRequestContextAccessor httpRequestContextAccessor,
     IWebSocketConnectionHandler webSocketConnectionHandler,
     IHostApplicationLifetime hostApplicationLifetime,
     ILogger<ClientObservable<T>> logger) : ClientObservableBase<T>(subject)
@@ -81,7 +81,14 @@ public class ClientObservable<T>(
                 }
 
                 queryResult.Paging = new(queryContext.Paging.Page, queryContext.Paging.Size, queryContext.TotalItems);
-                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
+
+                // Next() is invoked by the subject's producer on its own thread, where the AsyncLocal tenant
+                // context set up for this connection does not flow. Restoring it here — and resolving through
+                // the connection's own request-scoped provider rather than the root — ensures the interceptor
+                // releases compliance/PII data under this subscription's tenant, not whichever tenant happened
+                // to resolve first.
+                httpRequestContextAccessor.Current = context;
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, context.RequestServices);
 
                 var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                 if (error is not null && !cts.IsCancellationRequested)

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
@@ -20,7 +20,7 @@ namespace Cratis.Arc.Queries;
 /// <param name="queryContext">The <see cref="QueryContext"/> the observable is for.</param>
 /// <param name="subject">The <see cref="ISubject{T}"/> the observable wraps.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors.</param>
+/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> restored around each emission so tenant resolution sees the subscribing connection, not whatever ambient context the emitting thread happens to carry.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/>.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
@@ -28,7 +28,7 @@ public class ClientObservableSSE<T>(
     QueryContext queryContext,
     ISubject<T> subject,
     IReadModelInterceptors readModelInterceptors,
-    IServiceProvider serviceProvider,
+    IHttpRequestContextAccessor httpRequestContextAccessor,
     IOptions<ArcOptions> arcOptions,
     IHostApplicationLifetime hostApplicationLifetime,
     ILogger<ClientObservableSSE<T>> logger) : ClientObservableBase<T>(subject)
@@ -79,7 +79,14 @@ public class ClientObservableSSE<T>(
                 }
 
                 queryResult.Paging = new(queryContext.Paging.Page, queryContext.Paging.Size, queryContext.TotalItems);
-                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
+
+                // Next() is invoked by the subject's producer on its own thread, where the AsyncLocal tenant
+                // context set up for this connection does not flow. Restoring it here — and resolving through
+                // the connection's own request-scoped provider rather than the root — ensures the interceptor
+                // releases compliance/PII data under this subscription's tenant, not whichever tenant happened
+                // to resolve first.
+                httpRequestContextAccessor.Current = context;
+                queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, context.RequestServices);
 
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -13,6 +13,7 @@ using Cratis.DependencyInjection;
 using Cratis.Execution;
 using Cratis.Reflection;
 using Cratis.Strings;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -35,13 +36,22 @@ namespace Cratis.Arc.Queries;
 /// The WebSocket transport uses bidirectional frames; the SSE transport uses separate POST
 /// endpoints for subscribe/unsubscribe, correlated via a server-assigned connection identifier.
 /// </para>
+/// <para>
+/// Each subject-backed subscription gets its own <see cref="IServiceScope"/>, created at subscribe time from
+/// <paramref name="serviceProvider"/> and disposed when the subscription ends. Chronicle's client services are
+/// registered scoped, resolving the current tenant's namespace the first time they are used within a scope and
+/// caching it for the scope's lifetime — resolving them from the root container instead would cache whichever
+/// tenant asked first and reuse it for every subscription thereafter. Emissions arrive on the subject's own
+/// producer thread, where the AsyncLocal tenant context does not flow, so <see cref="IHttpRequestContextAccessor.Current"/>
+/// is restored to the subscribing connection immediately before each interception call.
+/// </para>
 /// </remarks>
 /// <param name="queryPipeline">The <see cref="IQueryPipeline"/> used to perform and authorize queries.</param>
 /// <param name="queryContextManager">The <see cref="IQueryContextManager"/> for managing query contexts.</param>
-/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> used to propagate the caller's identity into the authorization pipeline.</param>
+/// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> used to propagate the caller's identity into the authorization pipeline, and restored around each emission so tenant resolution sees the subscribing connection.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/> used to cancel connections on shutdown.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> used to intercept (e.g. decrypt compliance/PII properties on) each emitted read model before it is sent to the client.</param>
-/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve interceptors. The root provider is used because subscriptions outlive the short-lived subscribe request scope.</param>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to create a per-subscription <see cref="IServiceScope"/> for resolving interceptors — see remarks.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/> used for JSON serialization.</param>
 /// <param name="healthTracker">The <see cref="IQueryHealthTracker"/> used to track subscription health.</param>
 /// <param name="logger">The logger.</param>
@@ -287,6 +297,7 @@ public class ObservableQueryDemultiplexer(
     /// Subscribes to a streaming query result — an <see cref="ISubject{T}"/> or an <see cref="IAsyncEnumerable{T}"/>
     /// — and returns a disposable that tears the subscription down.
     /// </summary>
+    /// <param name="context">The subscribing connection's <see cref="IHttpRequestContext"/>.</param>
     /// <param name="streamingData">The streaming result to subscribe to.</param>
     /// <param name="queryId">The id of the query the subscription is for.</param>
     /// <param name="paging">The <see cref="PagingInfo"/> to report with each result.</param>
@@ -297,6 +308,7 @@ public class ObservableQueryDemultiplexer(
     /// <param name="token">The connection's <see cref="CancellationToken"/>.</param>
     /// <returns>An <see cref="IDisposable"/> that stops the subscription, or null when the data is not streamable.</returns>
     internal IDisposable? SubscribeToStreamingData(
+        IHttpRequestContext context,
         object streamingData,
         string queryId,
         PagingInfo paging,
@@ -310,7 +322,7 @@ public class ObservableQueryDemultiplexer(
 
         if (type.ImplementsOpenGeneric(typeof(ISubject<>)))
         {
-            return SubscribeToSubject(streamingData, type, queryId, paging, transferMode, correlationId, onNext, onError, token);
+            return SubscribeToSubject(context, streamingData, type, queryId, paging, transferMode, correlationId, onNext, onError, token);
         }
 
         if (type.ImplementsOpenGeneric(typeof(IAsyncEnumerable<>)))
@@ -555,10 +567,11 @@ public class ObservableQueryDemultiplexer(
             return null;
         }
 
-        return SubscribeToStreamingData(streamingData, queryId, queryResult.Paging, request.TransferMode, queryResult.CorrelationId, onNext, onError, token);
+        return SubscribeToStreamingData(context, streamingData, queryId, queryResult.Paging, request.TransferMode, queryResult.CorrelationId, onNext, onError, token);
     }
 
     IDisposable SubscribeToSubject(
+        IHttpRequestContext context,
         object subject,
         Type subjectType,
         string queryId,
@@ -577,10 +590,11 @@ public class ObservableQueryDemultiplexer(
             .GetMethod(nameof(SubscribeToSubjectOfType), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .MakeGenericMethod(elementType);
 
-        return (IDisposable)method.Invoke(this, [subject, queryId, paging, transferMode, correlationId, onNext, onError, token])!;
+        return (IDisposable)method.Invoke(this, [context, subject, queryId, paging, transferMode, correlationId, onNext, onError, token])!;
     }
 
     CompositeDisposable SubscribeToSubjectOfType<T>(
+        IHttpRequestContext context,
         ISubject<T> subject,
         string queryId,
         PagingInfo paging,
@@ -605,9 +619,13 @@ public class ObservableQueryDemultiplexer(
         // inside the callback would return QueryContext.NotSet and overwrite the real paging info.
         var subscriptionQueryContext = queryContextManager.Current;
 
+        // A scope of its own per subscription — see the class remarks — so this subscription's Chronicle
+        // namespace resolution is never shared with (or overwritten by) another subscription's tenant.
+        var interceptionScope = serviceProvider.CreateScope();
+
         var subscription = subject.Subscribe(OnEmission, OnSubscriptionError);
 
-        return new CompositeDisposable(subscription, emissionGate);
+        return new CompositeDisposable(subscription, emissionGate, interceptionScope);
 
         // This is an async void callback invoked by the subject on a background (ThreadPool) thread. Any
         // exception that escapes it is unobserved and terminates the whole process. The connection's
@@ -630,7 +648,11 @@ public class ObservableQueryDemultiplexer(
                 await emissionGate.WaitAsync(token);
                 gateAcquired = true;
 
-                var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, serviceProvider);
+                // Restore the subscribing connection's context — this callback runs on the subject's own
+                // producer thread, where the AsyncLocal tenant context set up when the subscription was
+                // created does not flow (see the class remarks).
+                httpRequestContextAccessor.Current = context;
+                var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, interceptionScope.ServiceProvider);
 
                 var isFirstEmission = previousItems is null;
 

--- a/Source/DotNET/Arc.Specs/Queries/for_ObservableQueryExtensions/given/all_dependencies.cs
+++ b/Source/DotNET/Arc.Specs/Queries/for_ObservableQueryExtensions/given/all_dependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -22,6 +23,7 @@ public class all_dependencies : Specification
         services.AddSingleton(_logger);
         services.AddSingleton(Substitute.For<Microsoft.Extensions.Hosting.IHostApplicationLifetime>());
         services.AddSingleton(Substitute.For<IReadModelInterceptors>());
+        services.AddSingleton(Substitute.For<IHttpRequestContextAccessor>());
         services.AddLogging();
 
         _serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
# Summary

Every observable-query transport (WebSocket, SSE, and the multiplexed hub) resolved the read-model interceptor from the root `IServiceProvider`. Chronicle's client services are registered scoped, resolving the current tenant's namespace once per scope and caching it — so resolving them from root cached whichever tenant subscribed first and reused that namespace for every subscription thereafter. In a multi-tenant app this meant `[PII]` properties on observable-query results came back empty for every tenant but the first.

## Security

- Fix observable queries decrypting/releasing compliance and PII data under the wrong tenant's Chronicle namespace, which caused `[PII]` properties to come back empty for every subscriber but whichever tenant's subscription resolved the namespace first (#2463)