### PR TITLE
Depend on the latest listed SharpCompress

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,11 @@
     <!-- Third Party -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
-    <PackageVersion Include="SharpCompress" Version="1.0.0" />
+    <!-- 0.50.4 is the newest version listed on nuget.org. 1.0.0 exists in the flat container but is
+         unlisted, so it is invisible to search and to anyone auditing the dependency - and because
+         NuGet still orders it above 0.50.4, depending on it forces every consumer that also pulls a
+         package targeting the listed line into an NU1605 downgrade error. -->
+    <PackageVersion Include="SharpCompress" Version="0.50.4" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />
     <PackageVersion Include="castle.core" Version="5.2.1" />


### PR DESCRIPTION
## Fixed

- The MongoDB integration no longer depends on a SharpCompress version that is unlisted on NuGet. Because that version still sorted above the latest listed one, any project combining Arc with a package targeting the listed line failed to restore with a package downgrade error.