### PR TITLE
Do not hand back a response a failed command produced, and let a stream be re-authorized

### DIFF
--- a/Documentation/backend/queries/index.md
+++ b/Documentation/backend/queries/index.md
@@ -63,6 +63,7 @@ Every query runs through a pipeline where Arc applies the cross-cutting concerns
 | Authorize by role or policy | [Authorization](../core/authorization.md) |
 | Transform read models before they're served (mask, decrypt, enrich) | [Read Model Interception](./read-model-interception.md) |
 | Stream many live queries over one connection | [Observable Query Hub](./observable-query-demultiplexer.md) |
+| Re-check authorization while a live stream is running | [Observable Query Emission Guards](./observable-query-emission-guards.md) |
 | Debug a live query from the terminal | [Use Observable Queries with cURL](./using-observable-queries-with-curl.md) |
 
 ## The payoff: typed reads in React

--- a/Documentation/backend/queries/observable-query-demultiplexer.md
+++ b/Documentation/backend/queries/observable-query-demultiplexer.md
@@ -166,6 +166,8 @@ Authorization is enforced for every subscription through the standard query pipe
 - If the query allows anonymous access (`[AllowAnonymous]`), the subscription is accepted regardless of authentication state.
 - Authorization is re-evaluated on every new subscription, not cached for the lifetime of the connection.
 
+That verdict gates *obtaining* the stream. A subscription can then stay open indefinitely, and nothing ends it when a token expires or a role is revoked. To re-check the verdict while a stream is running, implement an [emission guard](./observable-query-emission-guards.md).
+
 ## Keep-alive
 
 Both WebSocket and SSE transports send automatic keep-alive messages to prevent idle connections from being closed by proxies or firewalls.

--- a/Documentation/backend/queries/observable-query-emission-guards.md
+++ b/Documentation/backend/queries/observable-query-emission-guards.md
@@ -38,7 +38,7 @@ That is the whole opt-in. Guards are discovered by convention — no registratio
 
 `Suppress` does **not** move the delta baseline. The client never saw the withheld emission, so the next delivered `ChangeSet` is still computed against the last state it actually received — nothing goes missing.
 
-`DenyAndTerminate` ends only the subscription it was given. Every sibling subscription on the same multiplexed connection keeps streaming. On the hub the client receives an `unauthorized` message for that query id; on a direct connection it receives a final `QueryResult` with `IsAuthorized` false and the stream closes. The client does not reconnect after that — a reconnect would only be denied again.
+`DenyAndTerminate` ends only the subscription it was given. Every sibling subscription on the same multiplexed connection keeps streaming. On the hub the client receives an `unauthorized` message for that query id and the subscription is deleted; on a direct connection it receives a final `QueryResult` with `IsAuthorized` false and the stream closes. In both cases the Arc client latches the denial and stops reconnecting — a reconnect would only be denied again, and on a direct SSE connection the browser would otherwise re-establish the stream every few seconds and re-run the whole query for each attempt.
 
 ## What the guard is told
 
@@ -52,13 +52,19 @@ Every guard is asked, and the most restrictive verdict wins: `DenyAndTerminate` 
 
 ## Failing closed
 
-A guard that throws is treated as `DenyAndTerminate`. The failure is logged and never rethrown.
+A guard that throws is treated as `DenyAndTerminate`. The failure is logged at `Error` and never rethrown.
 
 This is deliberate. A guard that failed open would leave an application believing its stream is protected while it keeps flowing — which is worse than having no guard at all, because nobody goes looking.
+
+Know the blast radius before you write one. The aggregator is a process-wide singleton over every discovered guard type, so a single guard that cannot be constructed at all — an open generic, or one whose constructor takes something the subscription scope cannot resolve — denies **every** observable query in the application, on every transport, for as long as the process runs. The only symptom is the `Error` log; clients simply see their subscriptions end as unauthorized. Cover a new guard with a spec that exercises its real constructor.
+
+One exception is carved out: if the subscription's own `CancellationToken` is cancelled while the guard is running, the resulting `OperationCanceledException` is the client going away, not a guard failing. The emission is still withheld and the subscription still ends, but nothing is logged as a failure — otherwise every closed tab would produce an authorization error.
 
 ## Cost
 
 The guard runs on **every** emission of **every** subscription. Keep it fast: prefer cached state, a local revocation list, or a short-TTL lookup over a network round trip per emission.
+
+**The guard instance itself is constructed per emission.** Guards are resolved with `GetServiceOrCreateInstance`, and Arc's `IFoo → Foo` convention does not match a guard named for what it decides (`SessionMustStillBeActive` implements `IGuardObservableQueryEmission`, not `ISessionMustStillBeActive`), so unless the application registers the type explicitly it is newly constructed — constructor and all — for every emission, and never disposed. Keep the constructor trivial, and put any cache in an injected singleton rather than in a field on the guard, where it would be thrown away and rebuilt each time.
 
 Resolve collaborators through the constructor. They come from the subscription's own scope and are disposed with it, so a guard can safely hold a scoped session store or tenant-aware service.
 

--- a/Documentation/backend/queries/observable-query-emission-guards.md
+++ b/Documentation/backend/queries/observable-query-emission-guards.md
@@ -1,0 +1,75 @@
+# Observable Query Emission Guards
+
+Authorization for an observable query runs when the subscription is established. That verdict decides whether the caller may **obtain** the live stream — it says nothing about the minutes or hours the stream then stays open.
+
+That is fine for most applications. Subscriptions end when the user navigates away, the tab closes, or the server shuts down. But a subscription has no other reason to end: nothing terminates it when a token expires, a session is signed out, or a role is revoked. Keep-alive pings deliberately stop proxies from culling an idle connection, and the client reconnects and re-subscribes on its own.
+
+An **emission guard** closes that gap. Implement `IGuardObservableQueryEmission` and Arc consults it for every emission an observable query is about to write, on every transport — the multiplexed hub and the direct WebSocket/SSE connections alike.
+
+## Writing a guard
+
+```csharp
+public class SessionMustStillBeActive(ISessions sessions) : IGuardObservableQueryEmission
+{
+    public async Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+    {
+        var sessionId = context.Principal?.FindFirst("sid")?.Value;
+        if (sessionId is null)
+        {
+            return ObservableQueryEmissionVerdict.DenyAndTerminate;
+        }
+
+        return await sessions.IsActive(sessionId)
+            ? ObservableQueryEmissionVerdict.Allow
+            : ObservableQueryEmissionVerdict.DenyAndTerminate;
+    }
+}
+```
+
+That is the whole opt-in. Guards are discovered by convention — no registration, no configuration. An application with no guard pays nothing: no context is built and nothing is dispatched, and emissions take exactly the path they took before.
+
+## The three verdicts
+
+| Verdict | What happens |
+| --- | --- |
+| `Allow` | The emission is written unchanged. |
+| `Suppress` | This one emission is withheld. The subscription stays live and the next emission is evaluated again. |
+| `DenyAndTerminate` | Nothing is written, the client is told it is unauthorized, and this subscription is torn down. |
+
+`Suppress` does **not** move the delta baseline. The client never saw the withheld emission, so the next delivered `ChangeSet` is still computed against the last state it actually received — nothing goes missing.
+
+`DenyAndTerminate` ends only the subscription it was given. Every sibling subscription on the same multiplexed connection keeps streaming. On the hub the client receives an `unauthorized` message for that query id; on a direct connection it receives a final `QueryResult` with `IsAuthorized` false and the stream closes. The client does not reconnect after that — a reconnect would only be denied again.
+
+## What the guard is told
+
+`ObservableQueryEmissionContext` carries the fully qualified query name, the coerced query arguments, the caller's `ClaimsPrincipal`, the correlation id, whether this is the first emission on the subscription, the subscription's cancellation token, and the `IServiceProvider` to resolve from.
+
+The principal is handed over **explicitly**. Emissions arrive on the producing stream's own thread, where the request's `AsyncLocal` context does not flow, so a guard that reached for an ambient accessor would see the wrong identity — or none at all.
+
+## Several guards
+
+Every guard is asked, and the most restrictive verdict wins: `DenyAndTerminate` over `Suppress` over `Allow`. The first `DenyAndTerminate` short-circuits the rest.
+
+## Failing closed
+
+A guard that throws is treated as `DenyAndTerminate`. The failure is logged and never rethrown.
+
+This is deliberate. A guard that failed open would leave an application believing its stream is protected while it keeps flowing — which is worse than having no guard at all, because nobody goes looking.
+
+## Cost
+
+The guard runs on **every** emission of **every** subscription. Keep it fast: prefer cached state, a local revocation list, or a short-TTL lookup over a network round trip per emission.
+
+Resolve collaborators through the constructor. They come from the subscription's own scope and are disposed with it, so a guard can safely hold a scoped session store or tenant-aware service.
+
+## Where it does not help
+
+On a WebSocket the principal is frozen at the handshake — the protocol offers no way to present fresh credentials on an established connection. The identity a guard receives on a WebSocket subscription is the one captured when the socket was upgraded, and it does not change for the life of that connection.
+
+That does not make the guard useless there; it makes it a lookup rather than a re-read. Take the identity from the context and ask your own source of truth — a session store, a token introspection endpoint, a revocation list — whether that identity is still good.
+
+## See also
+
+- [Observable Query Hub](./observable-query-demultiplexer.md) — the multiplexed transport and its subscription lifecycle.
+- [Read Model Interception](./read-model-interception.md) — transforming each emitted read model before it is written.
+- [Authorization](../core/authorization.md) — the subscription-time verdict this builds on.

--- a/Documentation/backend/queries/toc.yml
+++ b/Documentation/backend/queries/toc.yml
@@ -4,6 +4,8 @@
   href: model-bound/toc.yml
 - name: Observable Query Demultiplexer
   href: observable-query-demultiplexer.md
+- name: Observable Query Emission Guards
+  href: observable-query-emission-guards.md
 - name: Query Health Endpoint
   href: query-health.md
 - name: Use the HTTP QUERY method

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_a_value_handler_fails.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_a_value_handler_fails.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+/// <summary>
+/// The handler returns a response alongside a value the pipeline hands to a response value handler - the shape of a
+/// command that returns a value and appends events. When that handler fails, the command failed.
+/// </summary>
+public class and_a_response_was_produced_and_a_value_handler_fails : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult<string> _result;
+    (string Response, int Value) _tuple;
+    string _errorMessage;
+
+    void Establish()
+    {
+        _tuple = ("Forty two", 42);
+        _errorMessage = Guid.NewGuid().ToString();
+        _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_tuple);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _tuple.Response).Returns(false);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _tuple.Value).Returns(true);
+        _commandResponseValueHandlers.Handle(Arg.Any<CommandContext>(), _tuple.Value).Returns(CommandResult.Error(_correlationId, _errorMessage));
+    }
+
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_carry_the_response() => _result.Response.ShouldBeNull();
+    [Fact] void should_keep_the_failure_from_the_value_handler() => _result.ExceptionMessages.ShouldContain(_errorMessage);
+    [Fact] void should_still_have_offered_the_response_to_the_value_handler() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Response)), _tuple.Value);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_an_execution_scope_fails_to_complete.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_an_execution_scope_fails_to_complete.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+public class and_a_response_was_produced_and_an_execution_scope_fails_to_complete : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult<string> _result;
+    string _response;
+    Exception _failure;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _failure = new Exception("Commit failed");
+        _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_response);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _response).Returns(false);
+        _executionScope.Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>()).Throws(_failure);
+    }
+
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_carry_the_response() => _result.Response.ShouldBeNull();
+    [Fact] void should_keep_the_exception_message() => _result.ExceptionMessages.ShouldContain(_failure.Message);
+    [Fact] void should_keep_the_exception_stack_trace() => _result.ExceptionStackTrace.ShouldNotBeEmpty();
+    [Fact] void should_keep_the_result_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_not_invent_validation_results() => _result.ValidationResults.ShouldBeEmpty();
+    [Fact] void should_keep_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+    [Fact] void should_complete_the_scope_exactly_once() => _executionScope.Received(1).Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_an_execution_scope_reports_a_validation_failure.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_an_execution_scope_reports_a_validation_failure.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+/// <summary>
+/// A commit-time constraint or concurrency violation is a validation failure, not an exception - the shape a
+/// transactional scope merges onto the result when the unit of work cannot commit.
+/// </summary>
+public class and_a_response_was_produced_and_an_execution_scope_reports_a_validation_failure : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult<string> _result;
+    string _response;
+    ValidationResult _constraintViolation;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _constraintViolation = ValidationResult.Error(
+            "The value is already claimed by another event source.",
+            reason: ValidationResultReason.ConstraintViolation);
+        _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_response);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _response).Returns(false);
+        _executionScope
+            .Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>())
+            .Returns(callInfo =>
+            {
+                callInfo.ArgAt<CommandResult>(1).MergeWith(new CommandResult { ValidationResults = [_constraintViolation] });
+                return Task.CompletedTask;
+            });
+    }
+
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider)) as CommandResult<string>;
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_have_exceptions() => _result.HasExceptions.ShouldBeFalse();
+    [Fact] void should_not_carry_the_response() => _result.Response.ShouldBeNull();
+    [Fact] void should_keep_the_validation_failure() => _result.ValidationResults.ShouldContain(_constraintViolation);
+    [Fact] void should_keep_the_result_authorized() => _result.IsAuthorized.ShouldBeTrue();
+    [Fact] void should_keep_the_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_the_command_succeeded_with_warnings.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_a_response_was_produced_and_the_command_succeeded_with_warnings.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+/// <summary>
+/// Removing the response is gated on the command not succeeding - never on validation results merely being present.
+/// A warning at or below the allowed severity does not block the command, so the response it produced is its own.
+/// </summary>
+public class and_a_response_was_produced_and_the_command_succeeded_with_warnings : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult<string> _result;
+    string _response;
+    ValidationResult _warning;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _warning = ValidationResult.Warning("The value is unusually large.");
+        _commandFilters
+            .OnExecution(Arg.Any<CommandContext>())
+            .Returns(new CommandResult { CorrelationId = _correlationId, ValidationResults = [_warning] });
+        _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_response);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _response).Returns(false);
+    }
+
+    async Task Because() => _result = (await _commandPipeline.Execute(_command, _serviceProvider, ValidationResultSeverity.Warning)) as CommandResult<string>;
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_carry_the_response() => _result.Response.ShouldEqual(_response);
+    [Fact] void should_have_run_the_handler() => _commandHandler.Received(1).Handle(Arg.Any<CommandContext>());
+    [Fact] void should_complete_the_scope() => _executionScope.Received(1).Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_response_and_handled_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_one_of_with_tuple_containing_response_and_handled_value.cs
@@ -29,7 +29,7 @@ public class and_handler_returns_a_one_of_with_tuple_containing_response_and_han
 
     [Fact] void should_call_value_handlers_for_handled_value() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), 3.14);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_responseValue)), 3.14);
-    [Fact] void should_return_response_in_command_result() => _result.Response.ShouldEqual(_responseValue);
+    [Fact] void should_not_carry_the_response_for_the_failed_command() => _result.Response.ShouldBeNull();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_one_of_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_one_of_value.cs
@@ -28,7 +28,7 @@ public class and_handler_returns_a_tuple_with_response_and_one_of_value : given.
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item2.Value);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2.Value);
-    [Fact] void should_return_response_in_command_result() => _result.Response.ShouldEqual(_tuple.Item1);
+    [Fact] void should_not_carry_the_response_for_the_failed_command() => _result.Response.ShouldBeNull();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_value.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_response_and_value.cs
@@ -27,7 +27,7 @@ public class and_handler_returns_a_tuple_with_response_and_value : given.a_comma
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item2);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item1)), _tuple.Item2);
-    [Fact] void should_return_response_in_command_result() => _result.Response.ShouldEqual(_tuple.Item1);
+    [Fact] void should_not_carry_the_response_for_the_failed_command() => _result.Response.ShouldBeNull();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_value_first_and_response_second.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_handler_returns_a_tuple_with_value_first_and_response_second.cs
@@ -27,7 +27,7 @@ public class and_handler_returns_a_tuple_with_value_first_and_response_second : 
 
     [Fact] void should_call_value_handlers() => _commandResponseValueHandlers.Received(1).Handle(Arg.Any<CommandContext>(), _tuple.Item1);
     [Fact] void should_set_response_on_command_context() => _commandResponseValueHandlers.Received(1).Handle(Arg.Is<CommandContext>(ctx => ctx.Response.Equals(_tuple.Item2)), _tuple.Item1);
-    [Fact] void should_return_response_in_command_result() => _result.Response.ShouldEqual(_tuple.Item2);
+    [Fact] void should_not_carry_the_response_for_the_failed_command() => _result.Response.ShouldBeNull();
     [Fact] void should_have_correlation_id() => _result.CorrelationId.ShouldEqual(_correlationId);
     [Fact] void should_return_error_from_value_handlers() => _result.ExceptionMessages.First().ShouldEqual(_errorMessage);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing_with_generic_result/and_a_response_was_produced_and_an_execution_scope_fails_to_complete.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing_with_generic_result/and_a_response_was_produced_and_an_execution_scope_fails_to_complete.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing_with_generic_result;
+
+/// <summary>
+/// Asking for a base type the response is assignable to re-wraps the result into CommandResult&lt;TResult&gt;. The
+/// re-wrap copies the response across, so it must not resurrect one the pipeline already took back from a failure.
+/// </summary>
+public class and_a_response_was_produced_and_an_execution_scope_fails_to_complete : given.a_command_pipeline_and_a_handler_for_command
+{
+    CommandResult<IAnimal> _result;
+    Dog _dog;
+    Exception _failure;
+
+    void Establish()
+    {
+        _dog = new Dog("Rex");
+        _failure = new Exception("Commit failed");
+        _commandHandler.Handle(Arg.Any<CommandContext>()).Returns(_dog);
+        _commandResponseValueHandlers.CanHandle(Arg.Any<CommandContext>(), _dog).Returns(false);
+        _executionScope.Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>()).Throws(_failure);
+    }
+
+    async Task Because() => _result = await _commandPipeline.Execute<IAnimal>(_command, _serviceProvider);
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_no_response() => _result.Response.ShouldBeNull();
+    [Fact] void should_keep_the_exception_message() => _result.ExceptionMessages.ShouldContain(_failure.Message);
+
+    interface IAnimal;
+
+    record Dog(string Name) : IAnimal;
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/given/a_client_enumerable_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/given/a_client_enumerable_observable.cs
@@ -1,29 +1,36 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Execution;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Arc.Queries.for_ClientEnumerableObservable.given;
 
 public class a_client_enumerable_observable : Specification
 {
+    protected QueryContext _queryContext;
     protected TestAsyncEnumerable _enumerable;
     protected IReadModelInterceptors _readModelInterceptors;
     protected IWebSocketConnectionHandler _webSocketConnectionHandler;
+    protected IObservableQueryEmissionGuards _emissionGuards;
     protected ILogger<IClientObservable> _logger;
     protected ClientEnumerableObservable<TestData> _clientEnumerableObservable;
 
     void Establish()
     {
+        _queryContext = new QueryContext("TestQuery", CorrelationId.New(), Paging.NotPaged, Sorting.None);
         _enumerable = new TestAsyncEnumerable();
         _readModelInterceptors = Substitute.For<IReadModelInterceptors>();
         _webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
         _logger = Substitute.For<ILogger<IClientObservable>>();
 
         _clientEnumerableObservable = new ClientEnumerableObservable<TestData>(
+            _queryContext,
             _enumerable,
             _readModelInterceptors,
             _webSocketConnectionHandler,
+            _emissionGuards,
             _logger);
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_guard_allows_an_emission.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservable.when_handling_connection;
+
+public class and_guard_allows_an_emission : given.a_guarded_client_enumerable_observable
+{
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_consult_the_guard_for_every_item() => _guardCalls.Count.ShouldEqual(2);
+    [Fact] void should_write_every_item() => _sent.Count.ShouldEqual(2);
+    [Fact] void should_write_the_first_item_unchanged() => _sent.First().Data.ShouldEqual("event-store-a");
+    [Fact] void should_write_them_all_as_authorized() => _sent.Count(_ => _.IsAuthorized).ShouldEqual(2);
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_guard_denies_an_emission.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservable.when_handling_connection;
+
+public class and_guard_denies_an_emission : given.a_guarded_client_enumerable_observable
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_not_write_the_emission() => _sent.Count(_ => _.IsAuthorized).ShouldEqual(0);
+    [Fact] void should_write_a_terminal_unauthorized_result() => _sent.Count(_ => !_.IsAuthorized).ShouldEqual(1);
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_no_guard_is_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/and_no_guard_is_registered.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservable.when_handling_connection;
+
+/// <summary>
+/// An application that never implements a guard must not pay for the seam. Nothing else pins that on this transport,
+/// so removing the <see cref="IObservableQueryEmissionGuards.HasGuards"/> gate would stay green while charging every
+/// existing consumer a dispatch on every streamed item.
+/// </summary>
+public class and_no_guard_is_registered : given.a_guarded_client_enumerable_observable
+{
+    void Establish() => _emissionGuards.HasGuards.Returns(false);
+
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_write_every_item() => _sent.Count.ShouldEqual(2);
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/given/a_guarded_client_enumerable_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservable/when_handling_connection/given/a_guarded_client_enumerable_observable.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservable.when_handling_connection.given;
+
+public class a_guarded_client_enumerable_observable : Specification
+{
+    protected const string QueryName = "MyApp.Queries.GuardedQuery";
+
+    protected IHttpRequestContext _context;
+    protected IObservableQueryEmissionGuards _emissionGuards;
+    protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
+    protected ConcurrentQueue<SentResult> _sent;
+    protected ClaimsPrincipal _principal;
+    protected QueryContext _queryContext;
+    protected ClientEnumerableObservable<string> _observable;
+
+    /// <summary>
+    /// The verdict for an emission. Assign in a spec's own Establish — it is read when the emission happens.
+    /// </summary>
+    protected Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> _verdict = _ => ObservableQueryEmissionVerdict.Allow;
+
+    TaskCompletionSource _incomingCompleted;
+
+    void Establish()
+    {
+        _guardCalls = [];
+        _sent = [];
+        _incomingCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+        _queryContext = new QueryContext(QueryName, CorrelationId.New(), Paging.NotPaged, Sorting.None, new QueryArguments { ["id"] = 42 });
+
+        var webSocket = Substitute.For<IWebSocket>();
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        webSocketContext.AcceptWebSocket().Returns(Task.FromResult(webSocket));
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.WebSockets.Returns(webSocketContext);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.User.Returns(_principal);
+
+        var webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        webSocketConnectionHandler
+            .HandleIncomingMessages(Arg.Any<IWebSocket>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<CancellationToken>().Register(() => _incomingCompleted.TrySetResult());
+                return _incomingCompleted.Task;
+            });
+        webSocketConnectionHandler
+            .SendMessage(Arg.Any<IWebSocket>(), Arg.Any<QueryResult>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var result = callInfo.Arg<QueryResult>();
+                _sent.Enqueue(new SentResult(result.IsAuthorized, result.Data));
+                return Task.FromResult<Exception?>(null);
+            });
+
+        var readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
+        _emissionGuards.HasGuards.Returns(true);
+        _emissionGuards.Guard(Arg.Any<ObservableQueryEmissionContext>())
+            .Returns(callInfo =>
+            {
+                var emissionContext = callInfo.Arg<ObservableQueryEmissionContext>();
+                _guardCalls.Enqueue(emissionContext);
+                return Task.FromResult(_verdict(emissionContext));
+            });
+
+        _observable = new ClientEnumerableObservable<string>(
+            _queryContext,
+            TwoItems(),
+            readModelInterceptors,
+            webSocketConnectionHandler,
+            _emissionGuards,
+            Substitute.For<ILogger<IClientObservable>>());
+    }
+
+    protected async Task RunConnection() =>
+        await _observable.HandleConnection(_context).WaitAsync(TimeSpan.FromSeconds(5));
+
+    static async IAsyncEnumerable<string> TwoItems([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in new[] { "event-store-a", "event-store-b" })
+        {
+            await Task.Delay(10, cancellationToken);
+            yield return item;
+        }
+    }
+
+    protected record SentResult(bool IsAuthorized, object Data);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_guard_allows_an_emission.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservableSSE.when_handling_connection;
+
+public class and_guard_allows_an_emission : given.a_guarded_client_enumerable_observable_sse
+{
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_consult_the_guard_for_every_item() => _guardCalls.Count.ShouldEqual(2);
+    [Fact] void should_write_every_item() => WrittenResults.Count().ShouldEqual(2);
+    [Fact] void should_write_the_first_item_unchanged() => WrittenResults.First().Data.ToString().ShouldEqual("event-store-a");
+    [Fact] void should_write_them_all_as_authorized() => WrittenResults.Count(_ => _.IsAuthorized).ShouldEqual(2);
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_guard_denies_an_emission.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservableSSE.when_handling_connection;
+
+public class and_guard_denies_an_emission : given.a_guarded_client_enumerable_observable_sse
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_not_write_the_emission() => WrittenResults.Count(_ => _.IsAuthorized).ShouldEqual(0);
+    [Fact] void should_write_a_terminal_unauthorized_result() => WrittenResults.Count(_ => !_.IsAuthorized).ShouldEqual(1);
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_no_guard_is_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/and_no_guard_is_registered.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservableSSE.when_handling_connection;
+
+/// <summary>
+/// An application that never implements a guard must not pay for the seam. Nothing else pins that on this transport,
+/// so removing the <see cref="IObservableQueryEmissionGuards.HasGuards"/> gate would stay green while charging every
+/// existing consumer a dispatch on every streamed item.
+/// </summary>
+public class and_no_guard_is_registered : given.a_guarded_client_enumerable_observable_sse
+{
+    void Establish() => _emissionGuards.HasGuards.Returns(false);
+
+    async Task Because() => await RunConnection();
+
+    [Fact] void should_write_every_item() => WrittenResults.Count().ShouldEqual(2);
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/given/a_guarded_client_enumerable_observable_sse.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientEnumerableObservableSSE/when_handling_connection/given/a_guarded_client_enumerable_observable_sse.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Queries.for_ClientEnumerableObservableSSE.when_handling_connection.given;
+
+public class a_guarded_client_enumerable_observable_sse : Specification
+{
+    protected const string QueryName = "MyApp.Queries.GuardedQuery";
+
+    protected IHttpRequestContext _context;
+    protected IObservableQueryEmissionGuards _emissionGuards;
+    protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
+    protected ConcurrentQueue<string> _messages;
+    protected ClaimsPrincipal _principal;
+    protected QueryContext _queryContext;
+    protected IOptions<ArcOptions> _arcOptions;
+    protected ClientEnumerableObservableSSE<string> _observable;
+
+    /// <summary>
+    /// The verdict for an emission. Assign in a spec's own Establish — it is read when the emission happens.
+    /// </summary>
+    protected Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> _verdict = _ => ObservableQueryEmissionVerdict.Allow;
+
+    void Establish()
+    {
+        _guardCalls = [];
+        _messages = [];
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+        _queryContext = new QueryContext(QueryName, CorrelationId.New(), Paging.NotPaged, Sorting.None, new QueryArguments { ["id"] = 42 });
+        _arcOptions = Options.Create(new ArcOptions());
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(CancellationToken.None);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.User.Returns(_principal);
+        _context.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        var readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
+        _emissionGuards.HasGuards.Returns(true);
+        _emissionGuards.Guard(Arg.Any<ObservableQueryEmissionContext>())
+            .Returns(callInfo =>
+            {
+                var emissionContext = callInfo.Arg<ObservableQueryEmissionContext>();
+                _guardCalls.Enqueue(emissionContext);
+                return Task.FromResult(_verdict(emissionContext));
+            });
+
+        _observable = new ClientEnumerableObservableSSE<string>(
+            _queryContext,
+            TwoItems(),
+            readModelInterceptors,
+            _arcOptions,
+            _emissionGuards,
+            Substitute.For<ILogger<IClientObservable>>());
+    }
+
+    protected IEnumerable<QueryResult> WrittenResults =>
+        _messages
+            .Where(_ => _.StartsWith("data: ", StringComparison.Ordinal))
+            .Select(_ => JsonSerializer.Deserialize<QueryResult>(_["data: ".Length..].Trim(), _arcOptions.Value.JsonSerializerOptions))
+            .Where(_ => _ is not null)
+            .Select(_ => _!);
+
+    protected async Task RunConnection() =>
+        await _observable.HandleConnection(_context).WaitAsync(TimeSpan.FromSeconds(5));
+
+    static async IAsyncEnumerable<string> TwoItems([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in new[] { "event-store-a", "event-store-b" })
+        {
+            await Task.Delay(10, cancellationToken);
+            yield return item;
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/given/a_client_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/given/a_client_observable.cs
@@ -17,6 +17,7 @@ public class a_client_observable : Specification
     protected IHttpRequestContextAccessor _httpRequestContextAccessor;
     protected IWebSocketConnectionHandler _webSocketConnectionHandler;
     protected IHostApplicationLifetime _hostApplicationLifetime;
+    protected IObservableQueryEmissionGuards _emissionGuards;
     protected ILogger<ClientObservable<TestData>> _logger;
     protected ClientObservable<TestData> _clientObservable;
 
@@ -28,6 +29,7 @@ public class a_client_observable : Specification
         _httpRequestContextAccessor = Substitute.For<IHttpRequestContextAccessor>();
         _webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
         _hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
         _logger = Substitute.For<ILogger<ClientObservable<TestData>>>();
 
         _clientObservable = new ClientObservable<TestData>(
@@ -37,6 +39,7 @@ public class a_client_observable : Specification
             _httpRequestContextAccessor,
             _webSocketConnectionHandler,
             _hostApplicationLifetime,
+            _emissionGuards,
             _logger);
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_complete_and_next_race.cs
@@ -60,6 +60,7 @@ public class and_complete_and_next_race
             Substitute.For<IHttpRequestContextAccessor>(),
             webSocketConnectionHandler,
             hostLifetime,
+            Substitute.For<IObservableQueryEmissionGuards>(),
             logger);
 
         // Act — run connection in background, then trigger the races
@@ -135,6 +136,7 @@ public class and_complete_and_next_race
             Substitute.For<IHttpRequestContextAccessor>(),
             webSocketConnectionHandler,
             hostLifetime,
+            Substitute.For<IObservableQueryEmissionGuards>(),
             logger);
 
         var connectionTask = Task.Run(() => observable.HandleConnection(httpContext));

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_guard_allows_an_emission.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservable.when_handling_connection;
+
+public class and_guard_allows_an_emission : given.a_guarded_client_observable
+{
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => _sent.Count == 1);
+    });
+
+    [Fact] void should_consult_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_write_the_emission_unchanged() => _sent.Single().Data.ShouldEqual("event-store-a");
+    [Fact] void should_write_it_as_authorized() => _sent.Single().IsAuthorized.ShouldBeTrue();
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.Single().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.Single().Principal.ShouldEqual(_principal);
+    [Fact] void should_tell_the_guard_the_coerced_arguments() => _guardCalls.Single().Arguments["id"].ShouldEqual(42);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_guard_denies_an_emission.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservable.when_handling_connection;
+
+public class and_guard_denies_an_emission : given.a_guarded_client_observable
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => ServerEndedTheConnection);
+
+        _subject.OnNext("event-store-b");
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => _sent.Count(_ => _.IsAuthorized).ShouldEqual(0);
+    [Fact] void should_write_a_terminal_unauthorized_result() => _sent.Count(_ => !_.IsAuthorized).ShouldEqual(1);
+    [Fact] void should_end_the_connection() => ServerEndedTheConnection.ShouldBeTrue();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_no_guard_is_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/and_no_guard_is_registered.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservable.when_handling_connection;
+
+/// <summary>
+/// An application that never implements a guard must not pay for the seam. Nothing else pins that on this transport,
+/// so removing the <see cref="IObservableQueryEmissionGuards.HasGuards"/> gate would stay green while charging every
+/// existing consumer a dispatch on every emission.
+/// </summary>
+public class and_no_guard_is_registered : given.a_guarded_client_observable
+{
+    void Establish() => _emissionGuards.HasGuards.Returns(false);
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => _sent.Count == 1);
+    });
+
+    [Fact] void should_write_the_emission() => _sent.Single().Data.ShouldEqual("event-store-a");
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/given/a_guarded_client_observable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservable/when_handling_connection/given/a_guarded_client_observable.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Security.Claims;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ClientObservable.when_handling_connection.given;
+
+public class a_guarded_client_observable : Specification
+{
+    protected const string QueryName = "MyApp.Queries.GuardedQuery";
+
+    protected Subject<string> _subject;
+    protected IHttpRequestContext _context;
+    protected IObservableQueryEmissionGuards _emissionGuards;
+    protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
+    protected ConcurrentQueue<SentResult> _sent;
+    protected ClaimsPrincipal _principal;
+    protected QueryContext _queryContext;
+    protected ClientObservable<string> _observable;
+
+    /// <summary>
+    /// The verdict for an emission. Assign in a spec's own Establish — it is read when the emission happens.
+    /// </summary>
+    protected Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> _verdict = _ => ObservableQueryEmissionVerdict.Allow;
+
+    TaskCompletionSource _incomingStarted;
+    TaskCompletionSource _incomingCompleted;
+
+    void Establish()
+    {
+        _subject = new Subject<string>();
+        _guardCalls = [];
+        _sent = [];
+        _incomingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _incomingCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+        _queryContext = new QueryContext(QueryName, CorrelationId.New(), Paging.NotPaged, Sorting.None, new QueryArguments { ["id"] = 42 });
+
+        var webSocket = Substitute.For<IWebSocket>();
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        webSocketContext.AcceptWebSocket().Returns(Task.FromResult(webSocket));
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.WebSockets.Returns(webSocketContext);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.User.Returns(_principal);
+
+        var webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        webSocketConnectionHandler
+            .HandleIncomingMessages(Arg.Any<IWebSocket>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<CancellationToken>().Register(() => _incomingCompleted.TrySetResult());
+                _incomingStarted.TrySetResult();
+                return _incomingCompleted.Task;
+            });
+        webSocketConnectionHandler
+            .SendMessage(Arg.Any<IWebSocket>(), Arg.Any<QueryResult>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var result = callInfo.Arg<QueryResult>();
+                _sent.Enqueue(new SentResult(result.IsAuthorized, result.Data));
+                return Task.FromResult<Exception?>(null);
+            });
+
+        var readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
+        _emissionGuards.HasGuards.Returns(true);
+        _emissionGuards.Guard(Arg.Any<ObservableQueryEmissionContext>())
+            .Returns(callInfo =>
+            {
+                var emissionContext = callInfo.Arg<ObservableQueryEmissionContext>();
+                _guardCalls.Enqueue(emissionContext);
+                return Task.FromResult(_verdict(emissionContext));
+            });
+
+        var hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostApplicationLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        _observable = new ClientObservable<string>(
+            _queryContext,
+            _subject,
+            readModelInterceptors,
+            Substitute.For<IHttpRequestContextAccessor>(),
+            webSocketConnectionHandler,
+            hostApplicationLifetime,
+            _emissionGuards,
+            Substitute.For<ILogger<ClientObservable<string>>>());
+    }
+
+    protected bool ServerEndedTheConnection => _incomingCompleted.Task.IsCompleted;
+
+    protected async Task RunConnection(Func<Task> script)
+    {
+        var connectionTask = _observable.HandleConnection(_context);
+        await _incomingStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await script();
+
+        // Stand in for the client going away, in case the server has not already ended the connection itself.
+        _incomingCompleted.TrySetResult();
+        await connectionTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    protected static async Task WaitFor(Func<bool> condition)
+    {
+        var timeout = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+    }
+
+    protected record SentResult(bool IsAuthorized, object Data);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_guard_allows_an_emission.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_handling_connection;
+
+public class and_guard_allows_an_emission : given.a_guarded_client_observable_sse
+{
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => _messages.Count == 1);
+    });
+
+    [Fact] void should_consult_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_write_the_emission_unchanged() => WrittenResults.Single().Data.ToString().ShouldEqual("event-store-a");
+    [Fact] void should_write_it_as_authorized() => WrittenResults.Single().IsAuthorized.ShouldBeTrue();
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.Single().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.Single().Principal.ShouldEqual(_principal);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_guard_denies_an_emission.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_handling_connection;
+
+public class and_guard_denies_an_emission : given.a_guarded_client_observable_sse
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => _messages.Count == 1);
+
+        _subject.OnNext("event-store-b");
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => WrittenResults.Count(_ => _.IsAuthorized).ShouldEqual(0);
+    [Fact] void should_write_a_terminal_unauthorized_result() => WrittenResults.Count(_ => !_.IsAuthorized).ShouldEqual(1);
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_no_guard_is_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/and_no_guard_is_registered.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_handling_connection;
+
+/// <summary>
+/// An application that never implements a guard must not pay for the seam. Nothing else pins that on this transport,
+/// so removing the <see cref="IObservableQueryEmissionGuards.HasGuards"/> gate would stay green while charging every
+/// existing consumer a dispatch on every emission.
+/// </summary>
+public class and_no_guard_is_registered : given.a_guarded_client_observable_sse
+{
+    void Establish() => _emissionGuards.HasGuards.Returns(false);
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext("event-store-a");
+        await WaitFor(() => _messages.Count == 1);
+    });
+
+    [Fact] void should_write_the_emission() => WrittenResults.Single().Data.ToString().ShouldEqual("event-store-a");
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/given/a_guarded_client_observable_sse.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_handling_connection/given/a_guarded_client_observable_sse.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Security.Claims;
+using System.Text.Json;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Queries.for_ClientObservableSSE.when_handling_connection.given;
+
+public class a_guarded_client_observable_sse : Specification
+{
+    protected const string QueryName = "MyApp.Queries.GuardedQuery";
+
+    protected Subject<string> _subject;
+    protected IHttpRequestContext _context;
+    protected IObservableQueryEmissionGuards _emissionGuards;
+    protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
+    protected ConcurrentQueue<string> _messages;
+    protected ClaimsPrincipal _principal;
+    protected QueryContext _queryContext;
+    protected IOptions<ArcOptions> _arcOptions;
+    protected ClientObservableSSE<string> _observable;
+
+    /// <summary>
+    /// The verdict for an emission. Assign in a spec's own Establish — it is read when the emission happens.
+    /// </summary>
+    protected Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> _verdict = _ => ObservableQueryEmissionVerdict.Allow;
+
+    void Establish()
+    {
+        _subject = new Subject<string>();
+        _guardCalls = [];
+        _messages = [];
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+        _queryContext = new QueryContext(QueryName, CorrelationId.New(), Paging.NotPaged, Sorting.None, new QueryArguments { ["id"] = 42 });
+        _arcOptions = Options.Create(new ArcOptions());
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(CancellationToken.None);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.User.Returns(_principal);
+        _context.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        var readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
+        _emissionGuards.HasGuards.Returns(true);
+        _emissionGuards.Guard(Arg.Any<ObservableQueryEmissionContext>())
+            .Returns(callInfo =>
+            {
+                var emissionContext = callInfo.Arg<ObservableQueryEmissionContext>();
+                _guardCalls.Enqueue(emissionContext);
+                return Task.FromResult(_verdict(emissionContext));
+            });
+
+        var hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostApplicationLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        _observable = new ClientObservableSSE<string>(
+            _queryContext,
+            _subject,
+            readModelInterceptors,
+            Substitute.For<IHttpRequestContextAccessor>(),
+            _arcOptions,
+            hostApplicationLifetime,
+            _emissionGuards,
+            Substitute.For<ILogger<ClientObservableSSE<string>>>());
+    }
+
+    protected IEnumerable<QueryResult> WrittenResults =>
+        _messages
+            .Where(_ => _.StartsWith("data: ", StringComparison.Ordinal))
+            .Select(_ => JsonSerializer.Deserialize<QueryResult>(_["data: ".Length..].Trim(), _arcOptions.Value.JsonSerializerOptions))
+            .Where(_ => _ is not null)
+            .Select(_ => _!);
+
+    protected async Task RunConnection(Func<Task> script)
+    {
+        var connectionTask = _observable.HandleConnection(_context);
+
+        await script();
+
+        // Stand in for the stream ending, in case the server has not already ended the connection itself.
+        _subject.OnCompleted();
+        await connectionTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    protected static async Task WaitFor(Func<bool> condition)
+    {
+        var timeout = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ClientObservableSSE/when_streaming/and_concurrent_emissions_and_disposal_occur.cs
@@ -44,6 +44,7 @@ public class and_concurrent_emissions_and_disposal_occur
             Substitute.For<IHttpRequestContextAccessor>(),
             arcOptions,
             hostLifetime,
+            Substitute.For<IObservableQueryEmissionGuards>(),
             logger);
 
         // Act & Assert: Rapid emissions followed by disposal should not throw
@@ -106,6 +107,7 @@ public class and_concurrent_emissions_and_disposal_occur
             Substitute.For<IHttpRequestContextAccessor>(),
             arcOptions,
             hostLifetime,
+            Substitute.For<IObservableQueryEmissionGuards>(),
             logger);
 
         // Act: Start connection

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_connection.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.given;
+
+/// <summary>
+/// A demultiplexer wired to a real <see cref="ObservableQueryEmissionGuards"/> over a single application guard, so the
+/// specs exercise discovery, per-subscription resolution and verdict aggregation the way an application would — not a
+/// stand-in for them.
+/// </summary>
+public class a_guarded_connection : an_observable_query_demultiplexer
+{
+    protected const string QueryName = "MyApp.Queries.GuardedQuery";
+    protected const string FirstQueryId = "query-1";
+    protected const string SecondQueryId = "query-2";
+
+    protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
+    protected ConcurrentQueue<CorrelationId> _correlationIds;
+    protected Subject<IEnumerable<string>> _subject;
+    protected IQueryHealthTracker _healthTracker;
+    protected ClaimsPrincipal _principal;
+    protected IServiceProvider _guardedServiceProvider;
+    protected object _streamingData;
+    protected string[] _queryIds = [FirstQueryId];
+
+    /// <summary>
+    /// The verdict the application guard gives for an emission. Assign in a spec's own Establish — it is read when
+    /// the emission happens, which is long after every Establish has run.
+    /// </summary>
+    protected Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> _verdict = _ => ObservableQueryEmissionVerdict.Allow;
+
+    void Establish()
+    {
+        _guardCalls = [];
+        _correlationIds = [];
+        _subject = new Subject<IEnumerable<string>>();
+        _streamingData = _subject;
+        _healthTracker = Substitute.For<IQueryHealthTracker>();
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(new TestEmissionGuard(Evaluate));
+        var guardTypes = new List<Type> { typeof(TestEmissionGuard) };
+        ConfigureGuards(services, guardTypes);
+        _guardedServiceProvider = services.BuildServiceProvider();
+
+        var types = Substitute.For<ITypes>();
+        types.FindMultiple<IGuardObservableQueryEmission>().Returns(guardTypes.ToArray());
+        var guards = new ObservableQueryEmissionGuards(types, Substitute.For<ILogger<ObservableQueryEmissionGuards>>());
+
+        _queryPipeline.Perform(
+                Arg.Any<FullyQualifiedQueryName>(),
+                Arg.Any<QueryArguments>(),
+                Arg.Any<Paging>(),
+                Arg.Any<Sorting>(),
+                Arg.Any<IServiceProvider>())
+            .Returns(_ =>
+            {
+                // Every subscription gets its own correlation id, which is what a spec uses to tell one
+                // subscription's emissions from another's when both run the same query on one connection.
+                var correlationId = CorrelationId.New();
+                _correlationIds.Enqueue(correlationId);
+                var queryResult = QueryResult.Success(correlationId);
+                queryResult.Data = _streamingData;
+                return Task.FromResult(queryResult);
+            });
+
+        // Rebuild the hub over the guarded container and the real guards — the base context wires a substitute that
+        // reports no guards, which is the fast path every other spec runs on.
+        _hub = new ObservableQueryDemultiplexer(
+            _queryPipeline,
+            _queryContextManager,
+            _httpRequestContextAccessor,
+            _hostApplicationLifetime,
+            _readModelInterceptors,
+            _guardedServiceProvider,
+            _arcOptions,
+            _healthTracker,
+            guards,
+            _logger);
+    }
+
+    /// <summary>
+    /// Lets a spec add its own guard — and the services that guard needs — to the application's container.
+    /// </summary>
+    /// <param name="services">The application's services.</param>
+    /// <param name="guardTypes">The guard types discovery yields, in order.</param>
+    protected virtual void ConfigureGuards(IServiceCollection services, List<Type> guardTypes)
+    {
+    }
+
+    /// <summary>
+    /// A batch every 10 ms until the subscription is torn down — the async-enumerable counterpart of the subject.
+    /// </summary>
+    /// <param name="cancellationToken">Cancelled when the subscription ends.</param>
+    /// <returns>The stream of batches.</returns>
+    protected static async IAsyncEnumerable<IEnumerable<string>> ABatchEvery10Milliseconds([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        for (var index = 0; index < 100; index++)
+        {
+            await Task.Delay(10, cancellationToken);
+            yield return [$"item-{index}"];
+        }
+    }
+
+    ObservableQueryEmissionVerdict Evaluate(ObservableQueryEmissionContext context)
+    {
+        _guardCalls.Enqueue(context);
+        return _verdict(context);
+    }
+
+    /// <summary>
+    /// The application's guard, delegating every decision to the spec so a verdict — or a failure — is expressed
+    /// where the scenario reads.
+    /// </summary>
+    /// <param name="evaluate">The decision the spec makes for an emission.</param>
+    public class TestEmissionGuard(Func<ObservableQueryEmissionContext, ObservableQueryEmissionVerdict> evaluate) : IGuardObservableQueryEmission
+    {
+        /// <inheritdoc/>
+        public Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context) =>
+            Task.FromResult(evaluate(context));
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_connection.cs
@@ -22,6 +22,17 @@ public class a_guarded_connection : an_observable_query_demultiplexer
     protected const string FirstQueryId = "query-1";
     protected const string SecondQueryId = "query-2";
 
+    /// <summary>
+    /// What the client actually puts on the wire — strings, because a query string cannot carry anything else.
+    /// </summary>
+    protected static readonly Dictionary<string, string?> RawArguments = new() { ["id"] = "42" };
+
+    /// <summary>
+    /// What the query pipeline publishes on the query context after coercing <see cref="RawArguments"/> to the
+    /// declared parameter types. A guard has to be told these, not the strings that came in over the wire.
+    /// </summary>
+    protected static readonly QueryArguments CoercedArguments = new() { ["id"] = 42 };
+
     protected ConcurrentQueue<ObservableQueryEmissionContext> _guardCalls;
     protected ConcurrentQueue<CorrelationId> _correlationIds;
     protected Subject<IEnumerable<string>> _subject;
@@ -56,6 +67,16 @@ public class a_guarded_connection : an_observable_query_demultiplexer
         types.FindMultiple<IGuardObservableQueryEmission>().Returns(guardTypes.ToArray());
         var guards = new ObservableQueryEmissionGuards(types, Substitute.For<ILogger<ObservableQueryEmissionGuards>>());
 
+        // Performing a query publishes the coerced arguments on the query context, which is where the demultiplexer
+        // reads them from. A bare substitute answers null here, and a null answer sends every spec down the fallback
+        // to the raw wire strings — leaving the coerced lookup, and the whole point of it, unexercised.
+        _queryContextManager.Current.Returns(new QueryContext(
+            QueryName,
+            CorrelationId.New(),
+            Paging.NotPaged,
+            Sorting.None,
+            CoercedArguments));
+
         _queryPipeline.Perform(
                 Arg.Any<FullyQualifiedQueryName>(),
                 Arg.Any<QueryArguments>(),
@@ -75,6 +96,15 @@ public class a_guarded_connection : an_observable_query_demultiplexer
 
         // Rebuild the hub over the guarded container and the real guards — the base context wires a substitute that
         // reports no guards, which is the fast path every other spec runs on.
+        UseGuards(guards);
+    }
+
+    /// <summary>
+    /// Rebuilds the hub over a different set of emission guards, so a spec can run the very same connection script
+    /// on the no-guard fast path.
+    /// </summary>
+    /// <param name="guards">The <see cref="IObservableQueryEmissionGuards"/> the hub consults.</param>
+    protected void UseGuards(IObservableQueryEmissionGuards guards) =>
         _hub = new ObservableQueryDemultiplexer(
             _queryPipeline,
             _queryContextManager,
@@ -86,7 +116,6 @@ public class a_guarded_connection : an_observable_query_demultiplexer
             _healthTracker,
             guards,
             _logger);
-    }
 
     /// <summary>
     /// Lets a spec add its own guard — and the services that guard needs — to the application's container.

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_sse_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_sse_connection.cs
@@ -84,7 +84,7 @@ public class a_guarded_sse_connection : a_guarded_connection
             .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
                 _connectionId,
                 queryId,
-                new ObservableQuerySubscriptionRequest(QueryName))));
+                new ObservableQuerySubscriptionRequest(QueryName, RawArguments))));
         subscribeContext.When(_ => _.SetStatusCode(Arg.Any<int>()))
             .Do(callInfo => _subscribeStatusCodes[queryId] = callInfo.Arg<int>());
         return subscribeContext;

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_sse_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_sse_connection.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.given;
+
+/// <summary>
+/// Drives a full SSE connection: every query id in <see cref="a_guarded_connection._queryIds"/> is subscribed through
+/// its own POST, the spec's script then runs against the live subscriptions, and the client disconnects.
+/// </summary>
+public class a_guarded_sse_connection : a_guarded_connection
+{
+    protected IHttpRequestContext _connectionContext;
+    protected ConcurrentQueue<string> _messages;
+    protected ConcurrentDictionary<string, int> _subscribeStatusCodes;
+
+    CancellationTokenSource _connectionCancellation;
+    string _connectionId;
+
+    void Establish()
+    {
+        _messages = [];
+        _subscribeStatusCodes = new();
+        _connectionId = string.Empty;
+        _connectionCancellation = new CancellationTokenSource();
+
+        _connectionContext = Substitute.For<IHttpRequestContext>();
+        _connectionContext.RequestAborted.Returns(_connectionCancellation.Token);
+        _connectionContext.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _connectionContext.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _messages.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+    }
+
+    protected async Task RunConnection(Func<Task> script)
+    {
+        var connectionTask = _hub.HandleSSEConnection(_connectionContext);
+        await WaitFor(() => TryExtractConnectionId(out _connectionId));
+
+        foreach (var queryId in _queryIds)
+        {
+            await _hub.HandleSSESubscribe(CreateSubscribeContext(queryId));
+        }
+
+        await script();
+
+        await _connectionCancellation.CancelAsync();
+        await connectionTask;
+    }
+
+    protected int CountQueryResultsFor(string queryId) =>
+        HubMessages.Count(_ => _.Type == ObservableQueryHubMessageType.QueryResult && _.QueryId == queryId);
+
+    protected bool HasUnauthorizedFor(string queryId) =>
+        HubMessages.Any(_ => _.Type == ObservableQueryHubMessageType.Unauthorized && _.QueryId == queryId);
+
+    protected bool HasErrorFor(string queryId) =>
+        HubMessages.Any(_ => _.Type == ObservableQueryHubMessageType.Error && _.QueryId == queryId);
+
+    protected List<QueryResult> QueryResultsFor(string queryId) =>
+        [.. HubMessages
+            .Where(_ => _.Type == ObservableQueryHubMessageType.QueryResult && _.QueryId == queryId && _.Payload is JsonElement)
+            .Select(_ => JsonSerializer.Deserialize<QueryResult>(((JsonElement)_.Payload!).GetRawText(), _arcOptions.Value.JsonSerializerOptions))
+            .Where(_ => _ is not null)
+            .Select(_ => _!)];
+
+    IEnumerable<ObservableQueryHubMessage> HubMessages =>
+        _messages.Select(TryParseHubMessage).Where(_ => _ is not null).Select(_ => _!);
+
+    IHttpRequestContext CreateSubscribeContext(string queryId)
+    {
+        var subscribeContext = Substitute.For<IHttpRequestContext>();
+        subscribeContext.RequestAborted.Returns(CancellationToken.None);
+
+        // The subscribe POST carries the freshest identity; the demultiplexer transfers it onto the SSE connection.
+        subscribeContext.User.Returns(_principal);
+        subscribeContext.ReadBodyAsJson(typeof(ObservableQuerySSESubscribeRequest), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<object?>(new ObservableQuerySSESubscribeRequest(
+                _connectionId,
+                queryId,
+                new ObservableQuerySubscriptionRequest(QueryName))));
+        subscribeContext.When(_ => _.SetStatusCode(Arg.Any<int>()))
+            .Do(callInfo => _subscribeStatusCodes[queryId] = callInfo.Arg<int>());
+        return subscribeContext;
+    }
+
+    bool TryExtractConnectionId(out string connectionId)
+    {
+        connectionId = string.Empty;
+
+        foreach (var hubMessage in HubMessages)
+        {
+            if (hubMessage.Type != ObservableQueryHubMessageType.Connected || hubMessage.Payload is not JsonElement payload)
+            {
+                continue;
+            }
+
+            connectionId = payload.GetString() ?? string.Empty;
+            return !string.IsNullOrEmpty(connectionId);
+        }
+
+        return false;
+    }
+
+    ObservableQueryHubMessage? TryParseHubMessage(string sseMessage)
+    {
+        if (!sseMessage.StartsWith("data: ", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var json = sseMessage["data: ".Length..].Trim();
+        return JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_websocket_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_websocket_connection.cs
@@ -88,7 +88,7 @@ public class a_guarded_websocket_connection : a_guarded_connection
             {
                 Type = ObservableQueryHubMessageType.Subscribe,
                 QueryId = _queryIds[_receiveCount++],
-                Payload = new ObservableQuerySubscriptionRequest(QueryName)
+                Payload = new ObservableQuerySubscriptionRequest(QueryName, RawArguments)
             };
 
             var bytes = JsonSerializer.SerializeToUtf8Bytes(subscribe, _arcOptions.Value.JsonSerializerOptions);

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_websocket_connection.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/a_guarded_websocket_connection.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.given;
+
+/// <summary>
+/// Drives a full WebSocket connection: every query id in <see cref="a_guarded_connection._queryIds"/> is subscribed in
+/// turn, the spec's script then runs against the live subscriptions, and the client closes.
+/// </summary>
+public class a_guarded_websocket_connection : a_guarded_connection
+{
+    protected IHttpRequestContext _context;
+    protected IWebSocket _webSocket;
+    protected ConcurrentQueue<ObservableQueryHubMessage> _sentMessages;
+
+    Func<Task> _script = () => Task.CompletedTask;
+    int _receiveCount;
+
+    void Establish()
+    {
+        _sentMessages = [];
+        _receiveCount = 0;
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(CancellationToken.None);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.User.Returns(_principal);
+
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        _context.WebSockets.Returns(webSocketContext);
+
+        _webSocket = Substitute.For<IWebSocket>();
+        _webSocket.State.Returns(WebSocketState.Open);
+        webSocketContext.AcceptWebSocket(Arg.Any<CancellationToken>()).Returns(Task.FromResult(_webSocket));
+
+        _webSocket.Receive(Arg.Any<ArraySegment<byte>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => ReceiveNextMessage(callInfo.Arg<ArraySegment<byte>>()));
+
+        _webSocket.Send(Arg.Any<ArraySegment<byte>>(), Arg.Any<System.Net.WebSockets.WebSocketMessageType>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var data = callInfo.Arg<ArraySegment<byte>>();
+                var json = Encoding.UTF8.GetString(data.Array, data.Offset, data.Count);
+                var hubMessage = JsonSerializer.Deserialize<ObservableQueryHubMessage>(json, _arcOptions.Value.JsonSerializerOptions);
+                if (hubMessage is not null)
+                {
+                    _sentMessages.Enqueue(hubMessage);
+                }
+
+                return Task.CompletedTask;
+            });
+
+        _webSocket.Close(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+    }
+
+    protected async Task RunConnection(Func<Task> script)
+    {
+        _script = script;
+        await _hub.HandleWebSocketConnection(_context);
+    }
+
+    protected int CountQueryResultsFor(string queryId) =>
+        _sentMessages.Count(_ => _.Type == ObservableQueryHubMessageType.QueryResult && _.QueryId == queryId);
+
+    protected bool HasUnauthorizedFor(string queryId) =>
+        _sentMessages.Any(_ => _.Type == ObservableQueryHubMessageType.Unauthorized && _.QueryId == queryId);
+
+    protected bool HasErrorFor(string queryId) =>
+        _sentMessages.Any(_ => _.Type == ObservableQueryHubMessageType.Error && _.QueryId == queryId);
+
+    protected IEnumerable<object> DataOfQueryResultsFor(string queryId) =>
+        _sentMessages
+            .Where(_ => _.Type == ObservableQueryHubMessageType.QueryResult && _.QueryId == queryId)
+            .Select(_ => _.Payload!);
+
+    async Task<WebSocketReceiveResult> ReceiveNextMessage(ArraySegment<byte> buffer)
+    {
+        if (_receiveCount < _queryIds.Length)
+        {
+            var subscribe = new ObservableQueryHubMessage
+            {
+                Type = ObservableQueryHubMessageType.Subscribe,
+                QueryId = _queryIds[_receiveCount++],
+                Payload = new ObservableQuerySubscriptionRequest(QueryName)
+            };
+
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(subscribe, _arcOptions.Value.JsonSerializerOptions);
+            Array.Copy(bytes, 0, buffer.Array!, buffer.Offset, bytes.Length);
+            return new WebSocketReceiveResult(bytes.Length, System.Net.WebSockets.WebSocketMessageType.Text, true);
+        }
+
+        if (_receiveCount == _queryIds.Length)
+        {
+            _receiveCount++;
+            await _script();
+        }
+
+        return new WebSocketReceiveResult(0, System.Net.WebSockets.WebSocketMessageType.Close, true, WebSocketCloseStatus.NormalClosure, "done");
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/given/an_observable_query_demultiplexer.cs
@@ -18,6 +18,7 @@ public class an_observable_query_demultiplexer : Specification
     protected IReadModelInterceptors _readModelInterceptors;
     protected IServiceProvider _serviceProvider;
     protected IOptions<ArcOptions> _arcOptions;
+    protected IObservableQueryEmissionGuards _emissionGuards;
     protected ILogger<ObservableQueryDemultiplexer> _logger;
     protected ObservableQueryDemultiplexer _hub;
 
@@ -40,6 +41,12 @@ public class an_observable_query_demultiplexer : Specification
         _serviceProvider = new ServiceCollection().BuildServiceProvider();
 
         _arcOptions = Options.Create(new ArcOptions());
+
+        // No guards by default — HasGuards is false on a fresh substitute, which is the opt-in-by-presence fast
+        // path every existing spec runs on. Specs that exercise a guard configure this substitute in their own
+        // Establish, which runs after this one and is picked up because the hub holds the same instance.
+        _emissionGuards = Substitute.For<IObservableQueryEmissionGuards>();
+
         _logger = Substitute.For<ILogger<ObservableQueryDemultiplexer>>();
         _hub = new ObservableQueryDemultiplexer(
             _queryPipeline,
@@ -50,6 +57,7 @@ public class an_observable_query_demultiplexer : Specification
             _serviceProvider,
             _arcOptions,
             Substitute.For<IQueryHealthTracker>(),
+            _emissionGuards,
             _logger);
     }
 

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_emission_arrives_after_connection_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_emission_arrives_after_connection_is_disposed.cs
@@ -59,6 +59,7 @@ public class and_emission_arrives_after_connection_is_disposed : given.an_observ
             _serviceProvider,
             _arcOptions,
             _observableHealthTracker,
+            _emissionGuards,
             _logger);
 
         // Hold interception open so the first emission stays in flight (holding the emission gate) while the

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_allows_an_emission.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_allows_an_emission : given.a_guarded_sse_connection
+{
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => CountQueryResultsFor(FirstQueryId) == 1);
+    });
+
+    [Fact] void should_consult_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(1);
+    [Fact] void should_not_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_return_200_from_subscribe() => _subscribeStatusCodes[FirstQueryId].ShouldEqual(200);
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_allows_an_emission.cs
@@ -3,6 +3,11 @@
 
 namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
 
+/// <summary>
+/// The client sends its arguments as strings, because that is all a query string can carry; the pipeline coerces them
+/// to the declared parameter types and publishes them on the query context. A guard has to be told those, not the
+/// unconverted strings that came in over the wire — see <c>should_tell_the_guard_the_coerced_arguments</c>.
+/// </summary>
 public class and_guard_allows_an_emission : given.a_guarded_sse_connection
 {
     async Task Because() => await RunConnection(async () =>
@@ -17,4 +22,5 @@ public class and_guard_allows_an_emission : given.a_guarded_sse_connection
     [Fact] void should_return_200_from_subscribe() => _subscribeStatusCodes[FirstQueryId].ShouldEqual(200);
     [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
     [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
+    [Fact] void should_tell_the_guard_the_coerced_arguments() => _guardCalls.First().Arguments["id"].ShouldEqual(42);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_an_async_enumerable_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_an_async_enumerable_emission.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_denies_an_async_enumerable_emission : given.a_guarded_sse_connection
+{
+    void Establish()
+    {
+        _streamingData = ABatchEvery10Milliseconds();
+        _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+    }
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_an_emission.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_denies_an_emission : given.a_guarded_sse_connection
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+
+        // Anything the server produces after the denial must never reach the client.
+        _subject.OnNext(["event-store-b"]);
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_surface_an_error() => HasErrorFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_unregister_the_subscription() => _healthTracker.Received(1).UnregisterSubscription(Arg.Any<string>(), FirstQueryId);
+    [Fact] void should_still_have_accepted_the_subscribe() => _subscribeStatusCodes[FirstQueryId].ShouldEqual(200);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_one_of_two_subscriptions.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_one_of_two_subscriptions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_denies_one_of_two_subscriptions : given.a_guarded_sse_connection
+{
+    CorrelationId _deniedSubscription;
+
+    void Establish()
+    {
+        _queryIds = [FirstQueryId, SecondQueryId];
+        _verdict = context => context.CorrelationId == _deniedSubscription
+            ? ObservableQueryEmissionVerdict.DenyAndTerminate
+            : ObservableQueryEmissionVerdict.Allow;
+    }
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _deniedSubscription = _correlationIds.First();
+
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId) && CountQueryResultsFor(SecondQueryId) == 1);
+
+        _subject.OnNext(["event-store-b"]);
+        await WaitFor(() => CountQueryResultsFor(SecondQueryId) == 2);
+    });
+
+    [Fact] void should_signal_unauthorized_for_the_denied_subscription() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_write_nothing_for_the_denied_subscription() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_not_signal_unauthorized_for_the_sibling() => HasUnauthorizedFor(SecondQueryId).ShouldBeFalse();
+    [Fact] void should_keep_streaming_the_sibling() => CountQueryResultsFor(SecondQueryId).ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_the_first_replayed_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_denies_the_first_replayed_emission.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// A replaying subject hands its buffered value to the observer from inside Subscribe, so the guard denies — and the
+/// denial tears the subscription down — before the subscribe POST has anything tracked to tear down. Everything the
+/// subscription owns lives in one composite (its service scope, the emission gate and the subject subscription), so a
+/// disposed scope and a subject that has lost its observer together prove the composite was released rather than
+/// dropped on the floor for the lifetime of the process.
+/// </summary>
+public class and_guard_denies_the_first_replayed_emission : given.a_guarded_sse_connection
+{
+    readonly ConcurrentQueue<SubscriptionScopeProbe> _probes = new();
+
+    ReplaySubject<IEnumerable<string>> _replaySubject;
+
+    void Establish()
+    {
+        _replaySubject = new ReplaySubject<IEnumerable<string>>(1);
+        _replaySubject.OnNext(["buffered-before-anyone-subscribed"]);
+        _streamingData = _replaySubject;
+    }
+
+    async Task Because() => await RunConnection(() => WaitFor(() => HasUnauthorizedFor(FirstQueryId)));
+
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_return_401_from_subscribe() => _subscribeStatusCodes[FirstQueryId].ShouldEqual(401);
+    [Fact] void should_dispose_the_subscription_scope() => _probes.Single().IsDisposed.ShouldBeTrue();
+    [Fact] void should_stop_observing_the_subject() => _replaySubject.HasObservers.ShouldBeFalse();
+    [Fact] void should_unregister_the_subscription() => _healthTracker.Received(1).UnregisterSubscription(Arg.Any<string>(), FirstQueryId);
+
+    protected override void ConfigureGuards(IServiceCollection services, List<Type> guardTypes)
+    {
+        services.AddSingleton(_probes);
+        services.AddScoped<SubscriptionScopeProbe>();
+        guardTypes.Add(typeof(DenyingScopeProbeGuard));
+    }
+
+    public class SubscriptionScopeProbe : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class DenyingScopeProbeGuard(ConcurrentQueue<SubscriptionScopeProbe> probes, SubscriptionScopeProbe probe) : IGuardObservableQueryEmission
+    {
+        public Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+        {
+            probes.Enqueue(probe);
+            return Task.FromResult(ObservableQueryEmissionVerdict.DenyAndTerminate);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_resolves_scoped_dependencies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_resolves_scoped_dependencies.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// A guard's collaborators must come from the subscription's own scope. Resolving them from the root would hand every
+/// subscription whichever tenant's — or session's — collaborator happened to be cached there first, and would keep it
+/// alive for the lifetime of the process.
+/// </summary>
+public class and_guard_resolves_scoped_dependencies : given.a_guarded_sse_connection
+{
+    readonly ConcurrentQueue<ScopedGuardDependency> _resolved = new();
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["item-a"]);
+        await WaitFor(() => _resolved.Count == 1);
+
+        _subject.OnNext(["item-b"]);
+        await WaitFor(() => _resolved.Count == 2);
+    });
+
+    [Fact] void should_resolve_the_dependency_for_every_emission() => _resolved.Count.ShouldEqual(2);
+    [Fact] void should_reuse_the_subscription_scope_across_emissions() => _resolved.Distinct().Count().ShouldEqual(1);
+    [Fact] void should_not_resolve_from_the_root_provider() => ReferenceEquals(_resolved.First(), _guardedServiceProvider.GetRequiredService<ScopedGuardDependency>()).ShouldBeFalse();
+    [Fact] void should_dispose_the_dependency_with_the_subscription() => _resolved.First().IsDisposed.ShouldBeTrue();
+
+    protected override void ConfigureGuards(IServiceCollection services, List<Type> guardTypes)
+    {
+        services.AddSingleton(_resolved);
+        services.AddScoped<ScopedGuardDependency>();
+        guardTypes.Add(typeof(ScopedDependencyGuard));
+    }
+
+    public class ScopedGuardDependency : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class ScopedDependencyGuard(ConcurrentQueue<ScopedGuardDependency> resolved, ScopedGuardDependency dependency) : IGuardObservableQueryEmission
+    {
+        public Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+        {
+            resolved.Enqueue(dependency);
+            return Task.FromResult(ObservableQueryEmissionVerdict.Allow);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_suppresses_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_suppresses_an_emission.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_suppresses_an_emission : given.a_guarded_sse_connection
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.Suppress;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => _guardCalls.Count == 1);
+
+        _subject.OnNext(["event-store-b"]);
+        await WaitFor(() => _guardCalls.Count == 2);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_not_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_keep_the_subscription_live() => _guardCalls.Count.ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_suppresses_then_allows.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_suppresses_then_allows.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// A suppressed emission must not move the delta baseline. The client never saw it, so the next delivered
+/// <see cref="ChangeSet"/> has to be computed against the last state it actually received — otherwise the changes that
+/// happened while the guard was withholding are folded into "already delivered" and vanish, with no error anywhere.
+/// </summary>
+public class and_guard_suppresses_then_allows : given.a_guarded_sse_connection
+{
+    void Establish() =>
+        _verdict = _ => _guardCalls.Count == 2
+            ? ObservableQueryEmissionVerdict.Suppress
+            : ObservableQueryEmissionVerdict.Allow;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["item-a"]);
+        await WaitFor(() => _guardCalls.Count == 1);
+
+        _subject.OnNext(["item-a", "item-b"]);
+        await WaitFor(() => _guardCalls.Count == 2);
+
+        _subject.OnNext(["item-a", "item-b", "item-c"]);
+        await WaitFor(() => _guardCalls.Count == 3);
+        await WaitFor(() => QueryResultsFor(FirstQueryId).Count == 2);
+    });
+
+    [Fact] void should_withhold_exactly_one_emission() => QueryResultsFor(FirstQueryId).Count.ShouldEqual(2);
+
+    [Fact]
+    void should_report_everything_that_changed_since_the_last_delivered_emission() =>
+        QueryResultsFor(FirstQueryId)[1].ChangeSet!.Added.Count().ShouldEqual(2);
+
+    [Fact]
+    void should_not_report_anything_as_removed() =>
+        QueryResultsFor(FirstQueryId)[1].ChangeSet!.Removed.Count().ShouldEqual(0);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_guard_throws.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+public class and_guard_throws : given.a_guarded_sse_connection
+{
+    void Establish() => _verdict = _ => throw new TimeoutException("the session store did not answer");
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+
+        _subject.OnNext(["event-store-b"]);
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_fail_closed_and_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_surface_an_error() => HasErrorFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_no_guard_is_registered.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_no_guard_is_registered.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// The promise this whole seam is built on is that an application that never implements a guard pays nothing for it.
+/// Nothing else pins that: every unguarded spec merely relies on a substitute's default and asserts what was written,
+/// so hoisting the guard consultation out from behind the <see cref="IObservableQueryEmissionGuards.HasGuards"/> gate
+/// would stay green while costing every existing Arc consumer a dispatch on every emission of every subscription.
+/// </summary>
+public class and_no_guard_is_registered : given.a_guarded_sse_connection
+{
+    void Establish() => UseGuards(_emissionGuards);
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => CountQueryResultsFor(FirstQueryId) == 1);
+    });
+
+    [Fact] void should_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(1);
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_no_guard_is_registered_for_an_async_enumerable.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_sse_subscribe/and_no_guard_is_registered_for_an_async_enumerable.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_sse_subscribe;
+
+/// <summary>
+/// The async-enumerable path pays for a guard twice over — a per-subscription service scope at subscribe time and a
+/// dispatch per item — so it needs its own proof that an application without a guard is charged for neither.
+/// </summary>
+public class and_no_guard_is_registered_for_an_async_enumerable : given.a_guarded_sse_connection
+{
+    void Establish()
+    {
+        _streamingData = ABatchEvery10Milliseconds();
+        UseGuards(_emissionGuards);
+    }
+
+    async Task Because() => await RunConnection(() => WaitFor(() => CountQueryResultsFor(FirstQueryId) > 0));
+
+    [Fact] void should_stream_the_emissions() => CountQueryResultsFor(FirstQueryId).ShouldBeGreaterThan(0);
+    [Fact] void should_not_dispatch_to_the_guards() => _emissionGuards.DidNotReceive().Guard(Arg.Any<ObservableQueryEmissionContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_emission_arrives_after_connection_is_disposed.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_emission_arrives_after_connection_is_disposed.cs
@@ -60,6 +60,7 @@ public class and_emission_arrives_after_connection_is_disposed : given.an_observ
             _serviceProvider,
             _arcOptions,
             _observableHealthTracker,
+            _emissionGuards,
             _logger);
 
         // Hold interception open so the first emission stays in flight (holding the emission gate) while the

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_allows_an_emission.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_allows_an_emission : given.a_guarded_websocket_connection
+{
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => CountQueryResultsFor(FirstQueryId) == 1);
+    });
+
+    [Fact] void should_consult_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(1);
+    [Fact] void should_not_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
+    [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
+    [Fact] void should_tell_the_guard_it_is_the_first_emission() => _guardCalls.First().IsFirstEmission.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_allows_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_allows_an_emission.cs
@@ -3,6 +3,11 @@
 
 namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
 
+/// <summary>
+/// The client sends its arguments as strings, because that is all a query string can carry; the pipeline coerces them
+/// to the declared parameter types and publishes them on the query context. A guard has to be told those, not the
+/// unconverted strings that came in over the wire — see <c>should_tell_the_guard_the_coerced_arguments</c>.
+/// </summary>
 public class and_guard_allows_an_emission : given.a_guarded_websocket_connection
 {
     async Task Because() => await RunConnection(async () =>
@@ -17,4 +22,5 @@ public class and_guard_allows_an_emission : given.a_guarded_websocket_connection
     [Fact] void should_tell_the_guard_the_query_name() => _guardCalls.First().QueryName.Value.ShouldEqual(QueryName);
     [Fact] void should_tell_the_guard_the_caller_identity() => _guardCalls.First().Principal.ShouldEqual(_principal);
     [Fact] void should_tell_the_guard_it_is_the_first_emission() => _guardCalls.First().IsFirstEmission.ShouldBeTrue();
+    [Fact] void should_tell_the_guard_the_coerced_arguments() => _guardCalls.First().Arguments["id"].ShouldEqual(42);
 }

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_an_async_enumerable_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_an_async_enumerable_emission.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_denies_an_async_enumerable_emission : given.a_guarded_websocket_connection
+{
+    void Establish()
+    {
+        _streamingData = ABatchEvery10Milliseconds();
+        _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+    }
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_an_emission.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_denies_an_emission : given.a_guarded_websocket_connection
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.DenyAndTerminate;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+
+        // Anything the server produces after the denial must never reach the client.
+        _subject.OnNext(["event-store-b"]);
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_surface_an_error() => HasErrorFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+    [Fact] void should_unregister_the_subscription() => _healthTracker.Received(1).UnregisterSubscription(Arg.Any<string>(), FirstQueryId);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_one_of_two_subscriptions.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_one_of_two_subscriptions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_denies_one_of_two_subscriptions : given.a_guarded_websocket_connection
+{
+    CorrelationId _deniedSubscription;
+
+    void Establish()
+    {
+        _queryIds = [FirstQueryId, SecondQueryId];
+        _verdict = context => context.CorrelationId == _deniedSubscription
+            ? ObservableQueryEmissionVerdict.DenyAndTerminate
+            : ObservableQueryEmissionVerdict.Allow;
+    }
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _deniedSubscription = _correlationIds.First();
+
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId) && CountQueryResultsFor(SecondQueryId) == 1);
+
+        _subject.OnNext(["event-store-b"]);
+        await WaitFor(() => CountQueryResultsFor(SecondQueryId) == 2);
+    });
+
+    [Fact] void should_signal_unauthorized_for_the_denied_subscription() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_write_nothing_for_the_denied_subscription() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_not_signal_unauthorized_for_the_sibling() => HasUnauthorizedFor(SecondQueryId).ShouldBeFalse();
+    [Fact] void should_keep_streaming_the_sibling() => CountQueryResultsFor(SecondQueryId).ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_the_first_replayed_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_denies_the_first_replayed_emission.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Reactive.Subjects;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+/// <summary>
+/// A replaying subject hands its buffered value to the observer from inside Subscribe, so the guard denies before the
+/// subscribe frame has tracked anything — and the teardown the denial runs finds nothing. The connection would then go
+/// on reporting a live subscription that will never serve a byte, and hold its service scope until the whole
+/// connection ends, so the registration and the release have to be balanced here and not deferred.
+/// </summary>
+public class and_guard_denies_the_first_replayed_emission : given.a_guarded_websocket_connection
+{
+    readonly ConcurrentQueue<SubscriptionScopeProbe> _probes = new();
+
+    ReplaySubject<IEnumerable<string>> _replaySubject;
+    bool _scopeReleasedWhileConnected;
+
+    void Establish()
+    {
+        _replaySubject = new ReplaySubject<IEnumerable<string>>(1);
+        _replaySubject.OnNext(["buffered-before-anyone-subscribed"]);
+        _streamingData = _replaySubject;
+    }
+
+    async Task Because() => await RunConnection(() =>
+    {
+        // Read while the connection is still open: the connection's own teardown disposes everything it tracks, so
+        // asserting afterwards could not tell a prompt release from one that waited for the client to go away.
+        _scopeReleasedWhileConnected = _probes.Count == 1 && _probes.Single().IsDisposed;
+        return Task.CompletedTask;
+    });
+
+    [Fact] void should_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_register_the_subscription() => _healthTracker.Received(1).RegisterSubscription(Arg.Any<string>(), "WebSocket", Arg.Any<QuerySubscriptionMetadata>());
+    [Fact] void should_unregister_the_subscription() => _healthTracker.Received(1).UnregisterSubscription(Arg.Any<string>(), FirstQueryId);
+    [Fact] void should_release_the_subscription_scope_without_waiting_for_the_connection() => _scopeReleasedWhileConnected.ShouldBeTrue();
+
+    protected override void ConfigureGuards(IServiceCollection services, List<Type> guardTypes)
+    {
+        services.AddSingleton(_probes);
+        services.AddScoped<SubscriptionScopeProbe>();
+        guardTypes.Add(typeof(DenyingScopeProbeGuard));
+    }
+
+    public class SubscriptionScopeProbe : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class DenyingScopeProbeGuard(ConcurrentQueue<SubscriptionScopeProbe> probes, SubscriptionScopeProbe probe) : IGuardObservableQueryEmission
+    {
+        public Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+        {
+            probes.Enqueue(probe);
+            return Task.FromResult(ObservableQueryEmissionVerdict.DenyAndTerminate);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_suppresses_an_emission.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_suppresses_an_emission.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_suppresses_an_emission : given.a_guarded_websocket_connection
+{
+    void Establish() => _verdict = _ => ObservableQueryEmissionVerdict.Suppress;
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => _guardCalls.Count == 1);
+
+        _subject.OnNext(["event-store-b"]);
+        await WaitFor(() => _guardCalls.Count == 2);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_not_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_keep_the_subscription_live() => _guardCalls.Count.ShouldEqual(2);
+    [Fact] void should_still_treat_the_next_emission_as_the_first() => _guardCalls.Last().IsFirstEmission.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_handling_websocket_connection/and_guard_throws.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryDemultiplexer.when_handling_websocket_connection;
+
+public class and_guard_throws : given.a_guarded_websocket_connection
+{
+    void Establish() => _verdict = _ => throw new TimeoutException("the session store did not answer");
+
+    async Task Because() => await RunConnection(async () =>
+    {
+        _subject.OnNext(["event-store-a"]);
+        await WaitFor(() => HasUnauthorizedFor(FirstQueryId));
+
+        _subject.OnNext(["event-store-b"]);
+        await Task.Delay(50);
+    });
+
+    [Fact] void should_not_write_the_emission() => CountQueryResultsFor(FirstQueryId).ShouldEqual(0);
+    [Fact] void should_fail_closed_and_signal_unauthorized() => HasUnauthorizedFor(FirstQueryId).ShouldBeTrue();
+    [Fact] void should_not_surface_an_error() => HasErrorFor(FirstQueryId).ShouldBeFalse();
+    [Fact] void should_stop_consulting_the_guard() => _guardCalls.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_subscribing_to_an_async_enumerable_stream.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryDemultiplexer/when_subscribing_to_an_async_enumerable_stream.cs
@@ -33,8 +33,10 @@ public class when_subscribing_to_an_async_enumerable_stream : given.an_observabl
             new PagingInfo(0, 0, 0),
             null,
             CorrelationId.New(),
+            new ObservableQuerySubscriptionIdentity("[TestApp].[TestQuery]", QueryArguments.Empty, null),
             OnNext,
             OnError,
+            OnUnauthorized,
             CancellationToken.None);
 
         // The stream has emitted its first item and is now parked, so cancelling it exercises a real stop.
@@ -55,6 +57,8 @@ public class when_subscribing_to_an_async_enumerable_stream : given.an_observabl
     }
 
     Task OnError(string queryId, string message) => Task.CompletedTask;
+
+    Task OnUnauthorized(string queryId) => Task.CompletedTask;
 
     async IAsyncEnumerable<int> Stream([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/given/all_dependencies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/given/all_dependencies.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.given;
+
+public class all_dependencies : Specification
+{
+    protected ITypes _types;
+    protected ILogger<ObservableQueryEmissionGuards> _logger;
+    protected FirstGuard _first;
+    protected SecondGuard _second;
+    protected ClaimsPrincipal _principal;
+    protected ObservableQueryEmissionContext _context;
+    protected ObservableQueryEmissionGuards _guards;
+
+    void Establish()
+    {
+        _types = Substitute.For<ITypes>();
+        _logger = Substitute.For<ILogger<ObservableQueryEmissionGuards>>();
+        _first = new FirstGuard();
+        _second = new SecondGuard();
+        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "the-caller")], "test"));
+
+        // Registered as instances so the system under test resolves the very objects these specs configured,
+        // the same way it resolves an application's guard from the per-subscription scope.
+        var services = new ServiceCollection();
+        services.AddSingleton(_first);
+        services.AddSingleton(_second);
+
+        _context = new ObservableQueryEmissionContext(
+            "MyApp.Queries.GuardedQuery",
+            new QueryArguments { ["id"] = 42 },
+            _principal,
+            CorrelationId.New(),
+            services.BuildServiceProvider(),
+            true,
+            CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Builds the system under test over the given guard types, in the order they are discovered.
+    /// </summary>
+    /// <param name="guardTypes">The guard types discovery yields.</param>
+    protected void DiscoverGuards(params Type[] guardTypes)
+    {
+        _types.FindMultiple<IGuardObservableQueryEmission>().Returns(guardTypes);
+        _guards = new ObservableQueryEmissionGuards(_types, _logger);
+    }
+
+    public class FirstGuard : RecordingGuard;
+
+    public class SecondGuard : RecordingGuard;
+
+    public abstract class RecordingGuard : IGuardObservableQueryEmission
+    {
+        public List<ObservableQueryEmissionContext> Calls { get; } = [];
+
+        public ObservableQueryEmissionVerdict Verdict { get; set; } = ObservableQueryEmissionVerdict.Allow;
+
+        public Exception Failure { get; set; }
+
+        public Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+        {
+            Calls.Add(context);
+
+            if (Failure is not null)
+            {
+                throw Failure;
+            }
+
+            return Task.FromResult(Verdict);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_all_allow.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_all_allow.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class and_all_allow : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+
+    void Establish() => DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+
+    async Task Because() => _result = await _guards.Guard(_context);
+
+    [Fact] void should_report_having_guards() => _guards.HasGuards.ShouldBeTrue();
+    [Fact] void should_allow_the_emission() => _result.ShouldEqual(ObservableQueryEmissionVerdict.Allow);
+    [Fact] void should_ask_the_first_guard() => _first.Calls.Count.ShouldEqual(1);
+    [Fact] void should_ask_the_second_guard() => _second.Calls.Count.ShouldEqual(1);
+    [Fact] void should_pass_the_query_name_to_the_guard() => _first.Calls[0].QueryName.Value.ShouldEqual("MyApp.Queries.GuardedQuery");
+    [Fact] void should_pass_the_coerced_arguments_to_the_guard() => _first.Calls[0].Arguments["id"].ShouldEqual(42);
+    [Fact] void should_pass_the_caller_identity_to_the_guard() => _first.Calls[0].Principal.ShouldEqual(_principal);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_deny_short_circuits_a_later_guard.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_deny_short_circuits_a_later_guard.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class and_deny_short_circuits_a_later_guard : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+
+    void Establish()
+    {
+        _first.Verdict = ObservableQueryEmissionVerdict.DenyAndTerminate;
+        DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+    }
+
+    async Task Because() => _result = await _guards.Guard(_context);
+
+    [Fact] void should_deny_and_terminate() => _result.ShouldEqual(ObservableQueryEmissionVerdict.DenyAndTerminate);
+    [Fact] void should_not_ask_the_later_guard() => _second.Calls.ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_denies.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_denies.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class and_one_denies : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+
+    void Establish()
+    {
+        _first.Verdict = ObservableQueryEmissionVerdict.Suppress;
+        _second.Verdict = ObservableQueryEmissionVerdict.DenyAndTerminate;
+        DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+    }
+
+    async Task Because() => _result = await _guards.Guard(_context);
+
+    [Fact] void should_deny_and_terminate() => _result.ShouldEqual(ObservableQueryEmissionVerdict.DenyAndTerminate);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_is_cancelled.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_is_cancelled.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+/// <summary>
+/// The context carries the subscription's cancellation token and guard authors are told to observe it, so an ordinary
+/// tab close lands inside a guard call as an <see cref="OperationCanceledException"/>. Teardown is not a verdict: the
+/// emission is still withheld, but reporting every disconnect as "your authorization guard failed" at Error level
+/// would bury the failures that are real.
+/// </summary>
+public class and_one_is_cancelled : given.all_dependencies
+{
+    readonly CancellationToken _subscriptionEnded = new(true);
+
+    ObservableQueryEmissionVerdict _result;
+    Exception _error;
+
+    void Establish()
+    {
+        // A bare substitute answers false to IsEnabled, which would make the source-generated log method return
+        // before ever reaching Log - and this spec would then pass whether or not the cancellation is logged.
+        _logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+        _context = _context with { CancellationToken = _subscriptionEnded };
+        _first.Failure = new OperationCanceledException(_subscriptionEnded);
+        DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+    }
+
+    async Task Because() => _error = await Catch.Exception(AskTheGuards);
+
+    [Fact] void should_still_fail_closed() => _result.ShouldEqual(ObservableQueryEmissionVerdict.DenyAndTerminate);
+    [Fact] void should_not_let_the_cancellation_escape() => _error.ShouldBeNull();
+    [Fact] void should_not_ask_any_later_guard() => _second.Calls.ShouldBeEmpty();
+    [Fact] void should_not_report_it_as_a_security_failure() => LoggedLevels.ShouldNotContain(LogLevel.Error);
+
+    IEnumerable<LogLevel> LoggedLevels =>
+        _logger.ReceivedCalls()
+            .Where(_ => _.GetMethodInfo().Name == nameof(ILogger.Log))
+            .Select(_ => (LogLevel)_.GetArguments()[0]!);
+
+    async Task AskTheGuards() => _result = await _guards.Guard(_context);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_suppresses.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_suppresses.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class and_one_suppresses : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+
+    void Establish()
+    {
+        _second.Verdict = ObservableQueryEmissionVerdict.Suppress;
+        DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+    }
+
+    async Task Because() => _result = await _guards.Guard(_context);
+
+    [Fact] void should_suppress_the_emission() => _result.ShouldEqual(ObservableQueryEmissionVerdict.Suppress);
+    [Fact] void should_still_ask_every_guard() => (_first.Calls.Count + _second.Calls.Count).ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_throws.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/and_one_throws.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class and_one_throws : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+    Exception _error;
+
+    void Establish()
+    {
+        _first.Failure = new TimeoutException("the session store did not answer");
+        DiscoverGuards(typeof(FirstGuard), typeof(SecondGuard));
+    }
+
+    async Task Because() => _error = await Catch.Exception(AskTheGuards);
+
+    [Fact] void should_fail_closed() => _result.ShouldEqual(ObservableQueryEmissionVerdict.DenyAndTerminate);
+    [Fact] void should_not_let_the_failure_escape() => _error.ShouldBeNull();
+    [Fact] void should_not_ask_any_later_guard() => _second.Calls.ShouldBeEmpty();
+
+    async Task AskTheGuards() => _result = await _guards.Guard(_context);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/with_no_guards.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryEmissionGuards/when_guarding/with_no_guards.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryEmissionGuards.when_guarding;
+
+public class with_no_guards : given.all_dependencies
+{
+    ObservableQueryEmissionVerdict _result;
+
+    void Establish() => DiscoverGuards();
+
+    async Task Because() => _result = await _guards.Guard(_context);
+
+    [Fact] void should_not_report_having_guards() => _guards.HasGuards.ShouldBeFalse();
+    [Fact] void should_allow_the_emission() => _result.ShouldEqual(ObservableQueryEmissionVerdict.Allow);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_a_subject_is_requested_over_sse.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_a_subject_is_requested_over_sse.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHandler.when_handling_streaming_result;
+
+public class and_a_subject_is_requested_over_sse : given.a_handler_over_a_real_container
+{
+    readonly BehaviorSubject<string> _subject = new("item-a");
+
+    Exception _error;
+
+    void Establish() => ConnectOverSse();
+
+    async Task Because()
+    {
+        var handling = _handler.HandleStreamingResult(_context, StreamingQueryName, _subject);
+        await WaitFor(() => _written.Count == 1);
+        await _requestAborted.CancelAsync();
+        _error = await Catch.Exception(() => handling);
+    }
+
+    [Fact] void should_construct_the_observable() => _error.ShouldBeNull();
+    [Fact] void should_write_the_emission_to_the_client() => _written.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_a_subject_is_requested_over_websocket.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_a_subject_is_requested_over_websocket.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHandler.when_handling_streaming_result;
+
+public class and_a_subject_is_requested_over_websocket : given.a_handler_over_a_real_container
+{
+    readonly BehaviorSubject<string> _subject = new("item-a");
+
+    Exception _error;
+
+    void Establish() => ConnectOverWebSocket();
+
+    async Task Because() => _error = await Catch.Exception(() => _handler.HandleStreamingResult(_context, StreamingQueryName, _subject));
+
+    [Fact] void should_construct_the_observable() => _error.ShouldBeNull();
+    [Fact] void should_write_the_emission_to_the_client() => _sent.Count.ShouldEqual(1);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_an_async_enumerable_is_requested_over_sse.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_an_async_enumerable_is_requested_over_sse.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHandler.when_handling_streaming_result;
+
+public class and_an_async_enumerable_is_requested_over_sse : given.a_handler_over_a_real_container
+{
+    Exception _error;
+
+    void Establish() => ConnectOverSse();
+
+    async Task Because() => _error = await Catch.Exception(() => _handler.HandleStreamingResult(_context, StreamingQueryName, TwoItems()));
+
+    [Fact] void should_construct_the_observable() => _error.ShouldBeNull();
+    [Fact] void should_write_every_item_to_the_client() => _written.Count.ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_an_async_enumerable_is_requested_over_websocket.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/and_an_async_enumerable_is_requested_over_websocket.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Http;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHandler.when_handling_streaming_result;
+
+/// <summary>
+/// This is the path that was broken outright: the handler passed the query context to a
+/// <see cref="ClientEnumerableObservable{T}"/> whose constructor did not take one, so every model-bound
+/// <see cref="IAsyncEnumerable{T}"/> observable query over WebSocket threw on connect.
+/// </summary>
+public class and_an_async_enumerable_is_requested_over_websocket : given.a_handler_over_a_real_container
+{
+    readonly TaskCompletionSource _incomingCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    Exception _error;
+
+    void Establish()
+    {
+        ConnectOverWebSocket();
+
+        // Stand in for a client that stays connected until the server ends the connection — the observable ends it
+        // once the stream is exhausted, and returning immediately here would instead cancel the stream mid-flight.
+        _webSocketConnectionHandler
+            .HandleIncomingMessages(Arg.Any<IWebSocket>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<CancellationToken>().Register(() => _incomingCompleted.TrySetResult());
+                return _incomingCompleted.Task;
+            });
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _handler.HandleStreamingResult(_context, StreamingQueryName, TwoItems()));
+
+    [Fact] void should_construct_the_observable() => _error.ShouldBeNull();
+    [Fact] void should_write_every_item_to_the_client() => _sent.Count.ShouldEqual(2);
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/given/a_handler_over_a_real_container.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_ObservableQueryHandler/when_handling_streaming_result/given/a_handler_over_a_real_container.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Cratis.Arc.Http;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Queries.for_ObservableQueryHandler.when_handling_streaming_result.given;
+
+/// <summary>
+/// The handler reaches all four observable implementations reflectively, through
+/// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])"/> with a hand-written argument
+/// list. An implementation whose constructor stops lining up with that list still compiles — it throws
+/// <c>InvalidOperationException</c> at runtime, on the first client that asks for that transport. A substituted
+/// service provider cannot catch that, because nothing is ever actually constructed, so these specs run the real
+/// construction over a real container and let each connection deliver something.
+/// </summary>
+public class a_handler_over_a_real_container : Specification
+{
+    protected const string StreamingQueryName = "MyApp.Queries.StreamingQuery";
+
+    protected IHttpRequestContext _context;
+    protected IWebSocketConnectionHandler _webSocketConnectionHandler;
+    protected ConcurrentQueue<string> _written;
+    protected ConcurrentQueue<QueryResult> _sent;
+    protected CancellationTokenSource _requestAborted;
+    protected ObservableQueryHandler _handler;
+
+    void Establish()
+    {
+        _written = [];
+        _sent = [];
+        _requestAborted = new CancellationTokenSource();
+
+        var readModelInterceptors = Substitute.For<IReadModelInterceptors>();
+        readModelInterceptors.Intercept(Arg.Any<Type>(), Arg.Any<IEnumerable<object>>(), Arg.Any<IServiceProvider>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<object>>(1)));
+
+        _webSocketConnectionHandler = Substitute.For<IWebSocketConnectionHandler>();
+        _webSocketConnectionHandler
+            .SendMessage(Arg.Any<IWebSocket>(), Arg.Any<QueryResult>(), Arg.Any<SemaphoreSlim>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _sent.Enqueue(callInfo.Arg<QueryResult>());
+                return Task.FromResult<Exception?>(null);
+            });
+
+        var hostApplicationLifetime = Substitute.For<IHostApplicationLifetime>();
+        hostApplicationLifetime.ApplicationStopping.Returns(CancellationToken.None);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(readModelInterceptors);
+        services.AddSingleton(Substitute.For<IHttpRequestContextAccessor>());
+        services.AddSingleton(_webSocketConnectionHandler);
+        services.AddSingleton(hostApplicationLifetime);
+        services.AddSingleton(Substitute.For<IObservableQueryEmissionGuards>());
+        services.AddSingleton(Options.Create(new ArcOptions()));
+
+        var queryContextManager = Substitute.For<IQueryContextManager>();
+        queryContextManager.Current.Returns(new QueryContext(StreamingQueryName, CorrelationId.New(), Paging.NotPaged, Sorting.None));
+
+        _context = Substitute.For<IHttpRequestContext>();
+        _context.RequestAborted.Returns(_requestAborted.Token);
+        _context.RequestServices.Returns(Substitute.For<IServiceProvider>());
+        _context.Write(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _written.Enqueue(callInfo.Arg<string>());
+                return Task.CompletedTask;
+            });
+
+        _handler = new ObservableQueryHandler(
+            queryContextManager,
+            services.BuildServiceProvider(),
+            Substitute.For<ILogger<ObservableQueryHandler>>());
+    }
+
+    void Destroy() => _requestAborted.Dispose();
+
+    /// <summary>
+    /// Makes the request look like a WebSocket upgrade, so the handler takes the WebSocket branch.
+    /// </summary>
+    protected void ConnectOverWebSocket()
+    {
+        var webSocketContext = Substitute.For<IWebSocketContext>();
+        webSocketContext.IsWebSocketRequest.Returns(true);
+        webSocketContext.AcceptWebSocket(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Substitute.For<IWebSocket>()));
+        _context.WebSockets.Returns(webSocketContext);
+    }
+
+    /// <summary>
+    /// Makes the request ask for Server-Sent Events, so the handler takes the SSE branch.
+    /// </summary>
+    protected void ConnectOverSse()
+    {
+        _context.WebSockets.Returns(Substitute.For<IWebSocketContext>());
+        _context.Headers.Returns(new Dictionary<string, string> { ["Accept"] = HttpRequestContextExtensions.SseContentType });
+    }
+
+    /// <summary>
+    /// Two items, yielded asynchronously — the async-enumerable counterpart of a subject that has a value ready.
+    /// </summary>
+    /// <param name="cancellationToken">Cancelled when the connection ends.</param>
+    /// <returns>The stream of items.</returns>
+    protected static async IAsyncEnumerable<string> TwoItems([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in new[] { "item-a", "item-b" })
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
+    protected static async Task WaitFor(Func<bool> condition)
+    {
+        var timeout = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -176,6 +176,15 @@ public class CommandPipeline(
                 }
             }
 
+            // A response describes what the command produced, and it is bound onto the result as soon as the handler
+            // returns it - before the scopes above complete, and therefore before a transaction has committed. Once
+            // every scope has had its say, a command that did not succeed produced nothing the caller may act on, so
+            // the response is taken back rather than serialized into an error response body.
+            if (!commandResult.IsSuccess)
+            {
+                commandResult.ClearResponse();
+            }
+
             return commandResult;
         }
     }

--- a/Source/DotNET/Arc.Core/Commands/CommandResult.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandResult.cs
@@ -151,6 +151,20 @@ public class CommandResult
             ExceptionStackTrace = ExceptionStackTrace[Environment.NewLine.Length..];
         }
     }
+
+    /// <summary>
+    /// Removes the response value carried by this result, if any. This lets a caller holding an untyped
+    /// <see cref="CommandResult"/> remove the response without knowing its concrete generic type.
+    /// </summary>
+    /// <remarks>
+    /// A response is bound onto the result the moment the handler produces it - before the command's execution scopes
+    /// complete, and therefore before a transaction has committed. Anything failing after that point leaves a result
+    /// that is not successful yet still carries a value the caller must not act on. This is the seam that lets the
+    /// pipeline take that value back. The base result carries no response, so this does nothing.
+    /// </remarks>
+    protected internal virtual void ClearResponse()
+    {
+    }
 }
 
 /// <summary>
@@ -200,4 +214,7 @@ public class CommandResult<TResponse> : CommandResult
     /// <param name="correlationId">The <see cref="CorrelationId"/> associated with the command.</param>
     /// <returns>A <see cref="CommandResult{T}"/>.</returns>
     public static new CommandResult<TResponse> Success(CorrelationId correlationId) => new() { CorrelationId = correlationId };
+
+    /// <inheritdoc/>
+    protected internal override void ClearResponse() => Response = default;
 }

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservable.cs
@@ -10,14 +10,18 @@ namespace Cratis.Arc.Queries;
 /// Represents an implementation of <see cref="IClientEnumerableObservable"/>.
 /// </summary>
 /// <typeparam name="T">Type of data being observed.</typeparam>
+/// <param name="queryContext">The <see cref="QueryContext"/> the observable is for.</param>
 /// <param name="enumerable">The <see cref="IAsyncEnumerable{T}"/> to use for streaming.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
 /// <param name="webSocketConnectionHandler">The <see cref="IWebSocketConnectionHandler"/>.</param>
+/// <param name="emissionGuards">The <see cref="IObservableQueryEmissionGuards"/> consulted per emission when an application opts in with an <see cref="IGuardObservableQueryEmission"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientEnumerableObservable<T>(
+    QueryContext queryContext,
     IAsyncEnumerable<T> enumerable,
     IReadModelInterceptors readModelInterceptors,
     IWebSocketConnectionHandler webSocketConnectionHandler,
+    IObservableQueryEmissionGuards emissionGuards,
     ILogger<IClientObservable> logger)
     : IClientEnumerableObservable
 {
@@ -29,6 +33,7 @@ public class ClientEnumerableObservable<T>(
         using var writeLock = new SemaphoreSlim(1, 1);
         var tsc = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
+        var hasDeliveredEmission = false;
 
         _ = Task.Run(async () =>
         {
@@ -46,9 +51,39 @@ public class ClientEnumerableObservable<T>(
                     // rather than the root, so the interceptor releases compliance/PII data under this
                     // subscription's tenant instead of whichever tenant happened to resolve first.
                     queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, context.RequestServices);
+
+                    if (emissionGuards.HasGuards)
+                    {
+                        var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                            queryContext.Name,
+                            queryContext.Arguments ?? QueryArguments.Empty,
+                            context.User,
+                            queryContext.CorrelationId,
+                            context.RequestServices,
+                            !hasDeliveredEmission,
+                            cts.Token));
+
+                        if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+                        {
+                            logger.ObservableEmissionDenied();
+
+                            // Send the terminal unauthorized result before the stream goes away — a client that only
+                            // sees the socket close reads it as a transport hiccup and reconnects into the same denial.
+                            await webSocketConnectionHandler.SendMessage(webSocket, QueryResult.Unauthorized(queryContext.CorrelationId), writeLock, cts.Token);
+                            break;
+                        }
+
+                        if (verdict == ObservableQueryEmissionVerdict.Suppress)
+                        {
+                            logger.ObservableEmissionSuppressed();
+                            continue;
+                        }
+                    }
+
                     var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                     if (error is null)
                     {
+                        hasDeliveredEmission = true;
                         continue;
                     }
                     if (cts.IsCancellationRequested)

--- a/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientEnumerableObservableSSE.cs
@@ -15,14 +15,18 @@ namespace Cratis.Arc.Queries;
 /// <remarks>
 /// Initializes a new instance of the <see cref="ClientEnumerableObservableSSE{T}"/> class.
 /// </remarks>
+/// <param name="queryContext">The <see cref="QueryContext"/> the observable is for.</param>
 /// <param name="enumerable">The <see cref="IAsyncEnumerable{T}"/> to use for streaming.</param>
 /// <param name="readModelInterceptors">The <see cref="IReadModelInterceptors"/> for intercepting read models.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/>.</param>
+/// <param name="emissionGuards">The <see cref="IObservableQueryEmissionGuards"/> consulted per emission when an application opts in with an <see cref="IGuardObservableQueryEmission"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientEnumerableObservableSSE<T>(
+    QueryContext queryContext,
     IAsyncEnumerable<T> enumerable,
     IReadModelInterceptors readModelInterceptors,
     IOptions<ArcOptions> arcOptions,
+    IObservableQueryEmissionGuards emissionGuards,
     ILogger<IClientObservable> logger)
     : IClientEnumerableObservable
 {
@@ -33,6 +37,7 @@ public class ClientEnumerableObservableSSE<T>(
 
         using var cts = new CancellationTokenSource();
         var queryResult = new QueryResult();
+        var hasDeliveredEmission = false;
 
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, context.RequestAborted);
 
@@ -50,12 +55,43 @@ public class ClientEnumerableObservableSSE<T>(
                 // interceptor releases compliance/PII data under this subscription's tenant instead of
                 // whichever tenant happened to resolve first.
                 queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), item, context.RequestServices);
+
+                if (emissionGuards.HasGuards)
+                {
+                    var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                        queryContext.Name,
+                        queryContext.Arguments ?? QueryArguments.Empty,
+                        context.User,
+                        queryContext.CorrelationId,
+                        context.RequestServices,
+                        !hasDeliveredEmission,
+                        linkedCts.Token));
+
+                    if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+                    {
+                        logger.ObservableEmissionDenied();
+
+                        // Send the terminal unauthorized result before the stream goes away — a client that only sees
+                        // the stream end reads it as a transport hiccup and reconnects into the same denial.
+                        var unauthorizedJson = JsonSerializer.Serialize(QueryResult.Unauthorized(queryContext.CorrelationId), arcOptions.Value.JsonSerializerOptions);
+                        await context.Write($"data: {unauthorizedJson}\n\n", linkedCts.Token);
+                        break;
+                    }
+
+                    if (verdict == ObservableQueryEmissionVerdict.Suppress)
+                    {
+                        logger.ObservableEmissionSuppressed();
+                        continue;
+                    }
+                }
+
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";
 
                 try
                 {
                     await context.Write(sseMessage, linkedCts.Token);
+                    hasDeliveredEmission = true;
                 }
                 catch (Exception ex)
                 {

--- a/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
@@ -46,6 +46,7 @@ public class ClientObservable<T>(
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
         var hasDeliveredEmission = false;
+        var isTerminated = false;
         using var cts = new CancellationTokenSource();
         using var writeLock = new SemaphoreSlim(1, 1);
 
@@ -70,7 +71,7 @@ public class ClientObservable<T>(
 
         async void Next(T data)
         {
-            if (cts.IsCancellationRequested)
+            if (cts.IsCancellationRequested || isTerminated)
             {
                 return;
             }
@@ -98,11 +99,27 @@ public class ClientObservable<T>(
                     return;
                 }
 
-                var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
-                if (error is not null && !cts.IsCancellationRequested)
+                // A guard evaluating a concurrent emission may have terminated the connection while this one was
+                // being intercepted and evaluated. The terminal unauthorized frame has already gone out, so nothing
+                // may be written behind it.
+                if (isTerminated)
                 {
-                    Subject.OnError(error);
+                    return;
                 }
+
+                var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
+                if (error is not null)
+                {
+                    if (!cts.IsCancellationRequested)
+                    {
+                        Subject.OnError(error);
+                    }
+
+                    return;
+                }
+
+                // Only a write that actually reached the client counts as delivered — a guard asking whether this is
+                // the first emission must not be told the client already has one it never received.
                 hasDeliveredEmission = true;
             }
             catch (Exception ex)
@@ -135,6 +152,7 @@ public class ClientObservable<T>(
             if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
             {
                 logger.ObservableEmissionDenied();
+                isTerminated = true;
 
                 // Send the terminal unauthorized result before the stream goes away — a client that only sees the
                 // socket close reads it as a transport hiccup and reconnects straight into the same denial.

--- a/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservable.cs
@@ -21,6 +21,7 @@ namespace Cratis.Arc.Queries;
 /// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> restored around each emission so tenant resolution sees the subscribing connection, not whatever ambient context the emitting thread happens to carry.</param>
 /// <param name="webSocketConnectionHandler">The <see cref="IWebSocketConnectionHandler"/>.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
+/// <param name="emissionGuards">The <see cref="IObservableQueryEmissionGuards"/> consulted per emission when an application opts in with an <see cref="IGuardObservableQueryEmission"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientObservable<T>(
     QueryContext queryContext,
@@ -29,6 +30,7 @@ public class ClientObservable<T>(
     IHttpRequestContextAccessor httpRequestContextAccessor,
     IWebSocketConnectionHandler webSocketConnectionHandler,
     IHostApplicationLifetime hostApplicationLifetime,
+    IObservableQueryEmissionGuards emissionGuards,
     ILogger<ClientObservable<T>> logger) : ClientObservableBase<T>(subject)
 {
     /// <summary>
@@ -43,6 +45,7 @@ public class ClientObservable<T>(
         var webSocket = await context.WebSockets.AcceptWebSocket();
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
+        var hasDeliveredEmission = false;
         using var cts = new CancellationTokenSource();
         using var writeLock = new SemaphoreSlim(1, 1);
 
@@ -90,11 +93,17 @@ public class ClientObservable<T>(
                 httpRequestContextAccessor.Current = context;
                 queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, context.RequestServices);
 
+                if (emissionGuards.HasGuards && !await IsEmissionAllowed())
+                {
+                    return;
+                }
+
                 var error = await webSocketConnectionHandler.SendMessage(webSocket, queryResult, writeLock, cts.Token);
                 if (error is not null && !cts.IsCancellationRequested)
                 {
                     Subject.OnError(error);
                 }
+                hasDeliveredEmission = true;
             }
             catch (Exception ex)
             {
@@ -103,6 +112,41 @@ public class ClientObservable<T>(
                     Subject.OnError(ex);
                 }
             }
+        }
+
+        // Returns true when the emission may be written. A denial also tells the client it is no longer authorized
+        // and ends the connection; a suppression only withholds this one emission and leaves the stream running.
+        async Task<bool> IsEmissionAllowed()
+        {
+            var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                queryContext.Name,
+                queryContext.Arguments ?? QueryArguments.Empty,
+                context.User,
+                queryContext.CorrelationId,
+                context.RequestServices,
+                !hasDeliveredEmission,
+                cts.Token));
+
+            if (verdict == ObservableQueryEmissionVerdict.Allow)
+            {
+                return true;
+            }
+
+            if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+            {
+                logger.ObservableEmissionDenied();
+
+                // Send the terminal unauthorized result before the stream goes away — a client that only sees the
+                // socket close reads it as a transport hiccup and reconnects straight into the same denial.
+                await webSocketConnectionHandler.SendMessage(webSocket, QueryResult.Unauthorized(queryContext.CorrelationId), writeLock, cts.Token);
+                Complete();
+            }
+            else
+            {
+                logger.ObservableEmissionSuppressed();
+            }
+
+            return false;
         }
         void Error(Exception error)
         {

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableLogMessages.cs
@@ -42,4 +42,10 @@ internal static partial class ClientObservableLogMessages
 
     [LoggerMessage(LogLevel.Debug, "The observed stream from the server completed")]
     internal static partial void ObservableCompleted(this ILogger<IClientObservable> logger);
+
+    [LoggerMessage(LogLevel.Debug, "An emission guard withheld a single emission — the subscription stays live")]
+    internal static partial void ObservableEmissionSuppressed(this ILogger<IClientObservable> logger);
+
+    [LoggerMessage(LogLevel.Information, "An emission guard denied the observable query mid-stream — terminating the subscription")]
+    internal static partial void ObservableEmissionDenied(this ILogger<IClientObservable> logger);
 }

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
@@ -43,6 +43,7 @@ public class ClientObservableSSE<T>(
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
         var hasDeliveredEmission = false;
+        var isTerminated = false;
         using var cts = new CancellationTokenSource();
 
         using var subscription = Subject.Subscribe(Next, Error, Complete);
@@ -68,7 +69,7 @@ public class ClientObservableSSE<T>(
 
         async void Next(T data)
         {
-            if (cts.IsCancellationRequested)
+            if (cts.IsCancellationRequested || isTerminated)
             {
                 return;
             }
@@ -92,6 +93,14 @@ public class ClientObservableSSE<T>(
                 queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, context.RequestServices);
 
                 if (emissionGuards.HasGuards && !await IsEmissionAllowed())
+                {
+                    return;
+                }
+
+                // A guard evaluating a concurrent emission may have terminated the stream while this one was being
+                // intercepted and evaluated. The terminal unauthorized frame has already gone out, so nothing may be
+                // written behind it.
+                if (isTerminated)
                 {
                     return;
                 }
@@ -142,6 +151,7 @@ public class ClientObservableSSE<T>(
             if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
             {
                 logger.ObservableEmissionDenied();
+                isTerminated = true;
 
                 // Send the terminal unauthorized result before the stream goes away — a client that only sees the
                 // stream end reads it as a transport hiccup and reconnects straight into the same denial.

--- a/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
+++ b/Source/DotNET/Arc.Core/Queries/ClientObservableSSE.cs
@@ -23,6 +23,7 @@ namespace Cratis.Arc.Queries;
 /// <param name="httpRequestContextAccessor">The <see cref="IHttpRequestContextAccessor"/> restored around each emission so tenant resolution sees the subscribing connection, not whatever ambient context the emitting thread happens to carry.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/>.</param>
 /// <param name="hostApplicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
+/// <param name="emissionGuards">The <see cref="IObservableQueryEmissionGuards"/> consulted per emission when an application opts in with an <see cref="IGuardObservableQueryEmission"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/>.</param>
 public class ClientObservableSSE<T>(
     QueryContext queryContext,
@@ -31,6 +32,7 @@ public class ClientObservableSSE<T>(
     IHttpRequestContextAccessor httpRequestContextAccessor,
     IOptions<ArcOptions> arcOptions,
     IHostApplicationLifetime hostApplicationLifetime,
+    IObservableQueryEmissionGuards emissionGuards,
     ILogger<ClientObservableSSE<T>> logger) : ClientObservableBase<T>(subject)
 {
     /// <inheritdoc/>
@@ -40,6 +42,7 @@ public class ClientObservableSSE<T>(
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queryResult = new QueryResult();
+        var hasDeliveredEmission = false;
         using var cts = new CancellationTokenSource();
 
         using var subscription = Subject.Subscribe(Next, Error, Complete);
@@ -88,12 +91,18 @@ public class ClientObservableSSE<T>(
                 httpRequestContextAccessor.Current = context;
                 queryResult.Data = await readModelInterceptors.InterceptEmission(typeof(T), data, context.RequestServices);
 
+                if (emissionGuards.HasGuards && !await IsEmissionAllowed())
+                {
+                    return;
+                }
+
                 var json = JsonSerializer.Serialize(queryResult, arcOptions.Value.JsonSerializerOptions);
                 var sseMessage = $"data: {json}\n\n";
 
                 try
                 {
                     await context.Write(sseMessage, cts.Token);
+                    hasDeliveredEmission = true;
                 }
                 catch (Exception ex)
                 {
@@ -110,6 +119,42 @@ public class ClientObservableSSE<T>(
                     Subject.OnError(ex);
                 }
             }
+        }
+
+        // Returns true when the emission may be written. A denial also tells the client it is no longer authorized
+        // and ends the stream; a suppression only withholds this one emission and leaves the stream running.
+        async Task<bool> IsEmissionAllowed()
+        {
+            var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                queryContext.Name,
+                queryContext.Arguments ?? QueryArguments.Empty,
+                context.User,
+                queryContext.CorrelationId,
+                context.RequestServices,
+                !hasDeliveredEmission,
+                cts.Token));
+
+            if (verdict == ObservableQueryEmissionVerdict.Allow)
+            {
+                return true;
+            }
+
+            if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+            {
+                logger.ObservableEmissionDenied();
+
+                // Send the terminal unauthorized result before the stream goes away — a client that only sees the
+                // stream end reads it as a transport hiccup and reconnects straight into the same denial.
+                var unauthorizedJson = JsonSerializer.Serialize(QueryResult.Unauthorized(queryContext.CorrelationId), arcOptions.Value.JsonSerializerOptions);
+                await context.Write($"data: {unauthorizedJson}\n\n", cts.Token);
+                Complete();
+            }
+            else
+            {
+                logger.ObservableEmissionSuppressed();
+            }
+
+            return false;
         }
 
         void Error(Exception error)

--- a/Source/DotNET/Arc.Core/Queries/IGuardObservableQueryEmission.cs
+++ b/Source/DotNET/Arc.Core/Queries/IGuardObservableQueryEmission.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Defines a guard that is consulted for every emission an observable query subscription is about to write.
+/// </summary>
+/// <remarks>
+/// Authorization for an observable query is evaluated by the query pipeline when the subscription is established; that
+/// verdict gates <em>obtaining</em> the stream. A subscription can then stay open indefinitely, so implement this
+/// interface when a verdict must be re-checked while the stream is running — an expired token, an ended session, a
+/// revoked role.
+/// <para>
+/// Guards are opt-in and discovered by convention: implement the interface and it is picked up. With no implementation
+/// present, nothing is dispatched and emissions take the same path they always did.
+/// </para>
+/// <para>
+/// Every emission calls this, so keep the implementation fast and prefer cached state over per-emission network calls.
+/// A guard that throws fails closed — the emission is dropped and the subscription is terminated.
+/// </para>
+/// </remarks>
+public interface IGuardObservableQueryEmission
+{
+    /// <summary>
+    /// Decides what should happen to an emission that is about to be written to the client.
+    /// </summary>
+    /// <param name="context">The <see cref="ObservableQueryEmissionContext"/> describing the emission.</param>
+    /// <returns>The <see cref="ObservableQueryEmissionVerdict"/> for the emission.</returns>
+    Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context);
+}

--- a/Source/DotNET/Arc.Core/Queries/IObservableQueryEmissionGuards.cs
+++ b/Source/DotNET/Arc.Core/Queries/IObservableQueryEmissionGuards.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Defines the system that aggregates all discovered <see cref="IGuardObservableQueryEmission"/> implementations into a
+/// single verdict per observable query emission.
+/// </summary>
+public interface IObservableQueryEmissionGuards
+{
+    /// <summary>
+    /// Gets a value indicating whether any <see cref="IGuardObservableQueryEmission"/> implementation exists.
+    /// </summary>
+    /// <remarks>
+    /// Emission paths check this before doing any work for a guard, so an application without guards pays nothing per
+    /// emission — no context is built and no dispatch happens.
+    /// </remarks>
+    bool HasGuards { get; }
+
+    /// <summary>
+    /// Asks every discovered guard about an emission and aggregates their verdicts.
+    /// </summary>
+    /// <param name="context">The <see cref="ObservableQueryEmissionContext"/> describing the emission.</param>
+    /// <returns>The most restrictive <see cref="ObservableQueryEmissionVerdict"/> any guard returned.</returns>
+    /// <remarks>
+    /// The aggregate is most-restrictive-wins, and the first
+    /// <see cref="ObservableQueryEmissionVerdict.DenyAndTerminate"/> short-circuits the remaining guards. A guard that
+    /// throws is treated as <see cref="ObservableQueryEmissionVerdict.DenyAndTerminate"/> — the failure is logged and
+    /// never rethrown, because a guard that fails open would leave an application believing it is protected.
+    /// </remarks>
+    Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context);
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -260,12 +260,6 @@ public class ObservableQueryDemultiplexer(
             },
             state.CancellationTokenSource.Token);
 
-        if (wasUnauthorized)
-        {
-            context.SetStatusCode(401);
-            return;
-        }
-
         if (subscription is not null)
         {
             state.Subscriptions[body.QueryId] = subscription;
@@ -273,6 +267,19 @@ public class ObservableQueryDemultiplexer(
             // Register subscription with health tracker
             var metadata = CreateSubscriptionMetadata(body.QueryId, body.Request, context, "SSE");
             healthTracker.RegisterSubscription(body.ConnectionId, "SSE", metadata);
+        }
+
+        if (wasUnauthorized)
+        {
+            // A replaying subject hands its buffered value to the observer from inside Subscribe, so a guard can deny
+            // — and run the teardown above — before this method ever had a subscription to track. Tracking it first
+            // and then tearing it down here routes every teardown through TerminateSubscription, rather than
+            // returning with the composite (its service scope, emission gate and subject subscription) dropped on the
+            // floor. When the denial came from subscribe-time authorization there is no subscription and this is the
+            // no-op it always was.
+            TerminateSubscription(state.Subscriptions, body.ConnectionId, body.QueryId);
+            context.SetStatusCode(401);
+            return;
         }
 
         context.SetStatusCode(200);
@@ -494,6 +501,7 @@ public class ObservableQueryDemultiplexer(
         }
 
         var queryId = message.QueryId ?? Guid.NewGuid().ToString();
+        var wasUnauthorized = false;
 
         var subscription = await CreateSubscription(
             context,
@@ -512,6 +520,7 @@ public class ObservableQueryDemultiplexer(
             },
             async id =>
             {
+                wasUnauthorized = true;
                 var msg = ObservableQueryHubMessage.CreateUnauthorized(id);
                 await SendWebSocketMessage(webSocket, msg, keepAliveTracker, writeLock, token);
 
@@ -529,6 +538,15 @@ public class ObservableQueryDemultiplexer(
             // Register subscription with health tracker
             var metadata = CreateSubscriptionMetadata(queryId, request, context, "WebSocket");
             healthTracker.RegisterSubscription(connectionId, "WebSocket", metadata);
+        }
+
+        if (wasUnauthorized)
+        {
+            // A replaying subject hands its buffered value to the observer from inside Subscribe, so a guard can deny
+            // — and run the teardown above — before this method ever had a subscription to track. Without this the
+            // connection would keep reporting a live subscription that will never serve a byte, and hold its service
+            // scope until the whole connection ends.
+            TerminateSubscription(subscriptions, connectionId, queryId);
         }
     }
 

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexer.cs
@@ -45,6 +45,13 @@ namespace Cratis.Arc.Queries;
 /// producer thread, where the AsyncLocal tenant context does not flow, so <see cref="IHttpRequestContextAccessor.Current"/>
 /// is restored to the subscribing connection immediately before each interception call.
 /// </para>
+/// <para>
+/// The subscription-time authorization verdict gates <em>obtaining</em> the stream, not the stream itself. An
+/// application that needs the verdict re-checked while a subscription is running implements an
+/// <see cref="IGuardObservableQueryEmission"/>; it is then consulted for every emission, and can withhold a single
+/// emission or terminate the subscription. With no guard implemented nothing is dispatched and emissions take exactly
+/// the path they always did.
+/// </para>
 /// </remarks>
 /// <param name="queryPipeline">The <see cref="IQueryPipeline"/> used to perform and authorize queries.</param>
 /// <param name="queryContextManager">The <see cref="IQueryContextManager"/> for managing query contexts.</param>
@@ -54,6 +61,7 @@ namespace Cratis.Arc.Queries;
 /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to create a per-subscription <see cref="IServiceScope"/> for resolving interceptors — see remarks.</param>
 /// <param name="arcOptions">The <see cref="ArcOptions"/> used for JSON serialization.</param>
 /// <param name="healthTracker">The <see cref="IQueryHealthTracker"/> used to track subscription health.</param>
+/// <param name="emissionGuards">The <see cref="IObservableQueryEmissionGuards"/> consulted per emission when an application opts in with an <see cref="IGuardObservableQueryEmission"/>.</param>
 /// <param name="logger">The logger.</param>
 [Singleton]
 public class ObservableQueryDemultiplexer(
@@ -65,6 +73,7 @@ public class ObservableQueryDemultiplexer(
     IServiceProvider serviceProvider,
     IOptions<ArcOptions> arcOptions,
     IQueryHealthTracker healthTracker,
+    IObservableQueryEmissionGuards emissionGuards,
     ILogger<ObservableQueryDemultiplexer> logger) : IObservableQueryDemultiplexer
 {
     const int WebSocketBufferSize = 1024 * 4;
@@ -243,6 +252,11 @@ public class ObservableQueryDemultiplexer(
                 wasUnauthorized = true;
                 var msg = ObservableQueryHubMessage.CreateUnauthorized(id);
                 await SendSseMessage(state.Context, msg, state.KeepAliveTracker, state.CancellationTokenSource, state.WriteLock);
+
+                // Reached at subscribe time (nothing is tracked yet, so this is a no-op) and again when an emission
+                // guard denies the running stream. Only this query's entry is torn down — every sibling subscription
+                // on the same connection keeps streaming.
+                TerminateSubscription(state.Subscriptions, body.ConnectionId, id);
             },
             state.CancellationTokenSource.Token);
 
@@ -303,8 +317,10 @@ public class ObservableQueryDemultiplexer(
     /// <param name="paging">The <see cref="PagingInfo"/> to report with each result.</param>
     /// <param name="transferMode">The transfer mode (for example delta or full), or null for the default.</param>
     /// <param name="correlationId">The <see cref="CorrelationId"/> to stamp each result with.</param>
+    /// <param name="identity">The <see cref="ObservableQuerySubscriptionIdentity"/> describing the query and the caller that established the subscription.</param>
     /// <param name="onNext">Callback invoked with each streamed <see cref="QueryResult"/>.</param>
     /// <param name="onError">Callback invoked with the query id and message when the subscription errors.</param>
+    /// <param name="onUnauthorized">Callback invoked with the query id when an emission guard denies the stream, ending the subscription.</param>
     /// <param name="token">The connection's <see cref="CancellationToken"/>.</param>
     /// <returns>An <see cref="IDisposable"/> that stops the subscription, or null when the data is not streamable.</returns>
     internal IDisposable? SubscribeToStreamingData(
@@ -314,15 +330,17 @@ public class ObservableQueryDemultiplexer(
         PagingInfo paging,
         string? transferMode,
         CorrelationId correlationId,
+        ObservableQuerySubscriptionIdentity identity,
         Func<QueryResult, Task> onNext,
         Func<string, string, Task> onError,
+        Func<string, Task> onUnauthorized,
         CancellationToken token)
     {
         var type = streamingData.GetType();
 
         if (type.ImplementsOpenGeneric(typeof(ISubject<>)))
         {
-            return SubscribeToSubject(context, streamingData, type, queryId, paging, transferMode, correlationId, onNext, onError, token);
+            return SubscribeToSubject(context, streamingData, type, queryId, paging, transferMode, correlationId, identity, onNext, onError, onUnauthorized, token);
         }
 
         if (type.ImplementsOpenGeneric(typeof(IAsyncEnumerable<>)))
@@ -331,8 +349,24 @@ public class ObservableQueryDemultiplexer(
             // disposable that cancels it. Returning null here left the stream untracked: unsubscribe could not stop
             // it, and re-subscribing the same query started a second one while the first kept pushing results.
             var streamCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
-            _ = StreamAsyncEnumerable(streamingData, type, queryId, paging, correlationId, onNext, onError, streamCancellationTokenSource.Token);
-            return new StreamingQuerySubscription(streamCancellationTokenSource);
+
+            IDisposable subscription = new StreamingQuerySubscription(streamCancellationTokenSource);
+            IServiceScope? guardScope = null;
+
+            // A scope of this subscription's own for the emission guards to resolve from — created only when a guard
+            // exists, so a stream without one keeps exactly the shape (and cost) it had before guards were a thing.
+            // Ownership moves to the composite, which the connection disposes together with the subscription.
+            if (emissionGuards.HasGuards)
+            {
+#pragma warning disable CA2000 // guardScope's ownership is transferred to the returned CompositeDisposable
+                guardScope = serviceProvider.CreateScope();
+#pragma warning restore CA2000
+                subscription = new CompositeDisposable(subscription, guardScope);
+            }
+
+            _ = StreamAsyncEnumerable(streamingData, type, queryId, paging, correlationId, identity, guardScope?.ServiceProvider, onNext, onError, onUnauthorized, streamCancellationTokenSource.Token);
+
+            return subscription;
         }
 
         return null;
@@ -480,6 +514,11 @@ public class ObservableQueryDemultiplexer(
             {
                 var msg = ObservableQueryHubMessage.CreateUnauthorized(id);
                 await SendWebSocketMessage(webSocket, msg, keepAliveTracker, writeLock, token);
+
+                // Reached at subscribe time (nothing is tracked yet, so this is a no-op) and again when an emission
+                // guard denies the running stream. Only this query's entry is torn down — every sibling subscription
+                // on the same connection keeps streaming.
+                TerminateSubscription(subscriptions, connectionId, id);
             },
             token);
 
@@ -490,6 +529,21 @@ public class ObservableQueryDemultiplexer(
             // Register subscription with health tracker
             var metadata = CreateSubscriptionMetadata(queryId, request, context, "WebSocket");
             healthTracker.RegisterSubscription(connectionId, "WebSocket", metadata);
+        }
+    }
+
+    /// <summary>
+    /// Tears down a single tracked subscription, leaving every other subscription on the connection untouched.
+    /// </summary>
+    /// <param name="subscriptions">The connection's tracked subscriptions.</param>
+    /// <param name="connectionId">The id of the connection the subscription belongs to.</param>
+    /// <param name="queryId">The id of the query whose subscription is torn down.</param>
+    void TerminateSubscription(ConcurrentDictionary<string, IDisposable> subscriptions, string connectionId, string queryId)
+    {
+        if (subscriptions.TryRemove(queryId, out var subscription))
+        {
+            subscription.Dispose();
+            healthTracker.UnregisterSubscription(connectionId, queryId);
         }
     }
 
@@ -567,7 +621,16 @@ public class ObservableQueryDemultiplexer(
             return null;
         }
 
-        return SubscribeToStreamingData(context, streamingData, queryId, queryResult.Paging, request.TransferMode, queryResult.CorrelationId, onNext, onError, token);
+        // The pipeline coerces the raw string arguments to their declared parameter types and publishes them on the
+        // query context. Take them from there so an emission guard sees the same typed arguments the query itself ran
+        // with, rather than the unconverted strings that came in over the wire.
+        var performedQueryContext = queryContextManager.Current;
+        var identity = new ObservableQuerySubscriptionIdentity(
+            fullyQualifiedName,
+            performedQueryContext?.Arguments ?? arguments,
+            context.User);
+
+        return SubscribeToStreamingData(context, streamingData, queryId, queryResult.Paging, request.TransferMode, queryResult.CorrelationId, identity, onNext, onError, onUnauthorized, token);
     }
 
     IDisposable SubscribeToSubject(
@@ -578,8 +641,10 @@ public class ObservableQueryDemultiplexer(
         PagingInfo paging,
         string? transferMode,
         CorrelationId correlationId,
+        ObservableQuerySubscriptionIdentity identity,
         Func<QueryResult, Task> onNext,
         Func<string, string, Task> onError,
+        Func<string, Task> onUnauthorized,
         CancellationToken token)
     {
         var elementType = subjectType.GetInterfaces()
@@ -590,7 +655,7 @@ public class ObservableQueryDemultiplexer(
             .GetMethod(nameof(SubscribeToSubjectOfType), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .MakeGenericMethod(elementType);
 
-        return (IDisposable)method.Invoke(this, [context, subject, queryId, paging, transferMode, correlationId, onNext, onError, token])!;
+        return (IDisposable)method.Invoke(this, [context, subject, queryId, paging, transferMode, correlationId, identity, onNext, onError, onUnauthorized, token])!;
     }
 
     CompositeDisposable SubscribeToSubjectOfType<T>(
@@ -600,11 +665,15 @@ public class ObservableQueryDemultiplexer(
         PagingInfo paging,
         string? transferMode,
         CorrelationId correlationId,
+        ObservableQuerySubscriptionIdentity identity,
         Func<QueryResult, Task> onNext,
         Func<string, string, Task> onError,
+        Func<string, Task> onUnauthorized,
         CancellationToken token)
     {
         IEnumerable<object>? previousItems = null;
+        var hasDeliveredEmission = false;
+        var isTerminated = false;
         var isDeltaMode = string.Equals(transferMode, "delta", StringComparison.OrdinalIgnoreCase);
         var isFullMode = string.Equals(transferMode, "full", StringComparison.OrdinalIgnoreCase);
 
@@ -648,11 +717,47 @@ public class ObservableQueryDemultiplexer(
                 await emissionGate.WaitAsync(token);
                 gateAcquired = true;
 
+                // An emission that was already queued behind the gate when a guard terminated the subscription must
+                // not still be written — the client has been told it is no longer authorized.
+                if (isTerminated)
+                {
+                    return;
+                }
+
                 // Restore the subscribing connection's context — this callback runs on the subject's own
                 // producer thread, where the AsyncLocal tenant context set up when the subscription was
                 // created does not flow (see the class remarks).
                 httpRequestContextAccessor.Current = context;
                 var interceptedData = await readModelInterceptors.InterceptEmission(typeof(T), data, interceptionScope.ServiceProvider);
+
+                // Ask the emission guards before the delta baseline below moves. Advancing the baseline first would
+                // fold a withheld emission's changes into "already delivered", so a later allowed emission would
+                // compute its ChangeSet against state the client never received and silently lose those changes.
+                if (emissionGuards.HasGuards)
+                {
+                    var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                        identity.QueryName,
+                        identity.Arguments,
+                        identity.Principal,
+                        correlationId,
+                        interceptionScope.ServiceProvider,
+                        !hasDeliveredEmission,
+                        token));
+
+                    if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+                    {
+                        isTerminated = true;
+                        logger.EmissionDenied(queryId);
+                        await onUnauthorized(queryId);
+                        return;
+                    }
+
+                    if (verdict == ObservableQueryEmissionVerdict.Suppress)
+                    {
+                        logger.EmissionSuppressed(queryId);
+                        return;
+                    }
+                }
 
                 var isFirstEmission = previousItems is null;
 
@@ -699,6 +804,7 @@ public class ObservableQueryDemultiplexer(
                 }
 
                 await onNext(result);
+                hasDeliveredEmission = true;
             }
             catch (OperationCanceledException)
             {
@@ -768,8 +874,11 @@ public class ObservableQueryDemultiplexer(
         string queryId,
         PagingInfo paging,
         CorrelationId correlationId,
+        ObservableQuerySubscriptionIdentity identity,
+        IServiceProvider? guardServiceProvider,
         Func<QueryResult, Task> onNext,
         Func<string, string, Task> onError,
+        Func<string, Task> onUnauthorized,
         CancellationToken token)
     {
         var elementType = enumerableType.GetInterfaces()
@@ -780,7 +889,7 @@ public class ObservableQueryDemultiplexer(
             .GetMethod(nameof(StreamAsyncEnumerableOfType), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .MakeGenericMethod(elementType);
 
-        await (Task)method.Invoke(this, [enumerable, queryId, paging, correlationId, onNext, onError, token])!;
+        await (Task)method.Invoke(this, [enumerable, queryId, paging, correlationId, identity, guardServiceProvider, onNext, onError, onUnauthorized, token])!;
     }
 
     async Task StreamAsyncEnumerableOfType<T>(
@@ -788,10 +897,15 @@ public class ObservableQueryDemultiplexer(
         string queryId,
         PagingInfo paging,
         CorrelationId correlationId,
+        ObservableQuerySubscriptionIdentity identity,
+        IServiceProvider? guardServiceProvider,
         Func<QueryResult, Task> onNext,
         Func<string, string, Task> onError,
+        Func<string, Task> onUnauthorized,
         CancellationToken token)
     {
+        var hasDeliveredEmission = false;
+
         try
         {
             await foreach (var item in enumerable.WithCancellation(token))
@@ -799,6 +913,31 @@ public class ObservableQueryDemultiplexer(
                 if (token.IsCancellationRequested)
                 {
                     break;
+                }
+
+                if (guardServiceProvider is not null)
+                {
+                    var verdict = await emissionGuards.Guard(new ObservableQueryEmissionContext(
+                        identity.QueryName,
+                        identity.Arguments,
+                        identity.Principal,
+                        correlationId,
+                        guardServiceProvider,
+                        !hasDeliveredEmission,
+                        token));
+
+                    if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+                    {
+                        logger.EmissionDenied(queryId);
+                        await onUnauthorized(queryId);
+                        return;
+                    }
+
+                    if (verdict == ObservableQueryEmissionVerdict.Suppress)
+                    {
+                        logger.EmissionSuppressed(queryId);
+                        continue;
+                    }
                 }
 
                 var result = new QueryResult
@@ -813,6 +952,7 @@ public class ObservableQueryDemultiplexer(
                 };
 
                 await onNext(result);
+                hasDeliveredEmission = true;
             }
         }
         catch (OperationCanceledException)

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexerLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryDemultiplexerLogMessages.cs
@@ -51,4 +51,10 @@ internal static partial class ObservableQueryDemultiplexerLogMessages
 
     [LoggerMessage(LogLevel.Debug, "Emission for query id '{QueryId}' arrived after the connection was disposed — dropping it as the client has disconnected")]
     internal static partial void EmissionAfterDisconnect(this ILogger<ObservableQueryDemultiplexer> logger, string queryId);
+
+    [LoggerMessage(LogLevel.Debug, "An emission guard withheld a single emission for query id '{QueryId}' — the subscription stays live")]
+    internal static partial void EmissionSuppressed(this ILogger<ObservableQueryDemultiplexer> logger, string queryId);
+
+    [LoggerMessage(LogLevel.Information, "An emission guard denied query id '{QueryId}' mid-stream — terminating the subscription")]
+    internal static partial void EmissionDenied(this ILogger<ObservableQueryDemultiplexer> logger, string queryId);
 }

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionContext.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionContext.cs
@@ -15,7 +15,10 @@ namespace Cratis.Arc.Queries;
 /// <param name="Principal">The <see cref="ClaimsPrincipal"/> of the caller that established the subscription, or null when the subscription is anonymous.</param>
 /// <param name="CorrelationId">The <see cref="CorrelationId"/> the subscription stamps every emission with.</param>
 /// <param name="ServiceProvider">The per-subscription <see cref="IServiceProvider"/> to resolve guard dependencies from.</param>
-/// <param name="IsFirstEmission">Whether this is the first emission delivered on the subscription.</param>
+/// <param name="IsFirstEmission">Whether this is the first emission delivered on the subscription. On the direct
+/// (non-multiplexed) transports this is best-effort: emissions are dispatched from an <c>async void</c> observer with
+/// no serializing gate, so two emissions racing each other can both be told they are the first. Treat it as a hint for
+/// doing extra work once, never as the sole basis for a security decision.</param>
 /// <param name="CancellationToken">The <see cref="CancellationToken"/> that is cancelled when the subscription ends.</param>
 /// <remarks>
 /// The principal is passed explicitly rather than resolved ambiently. Emissions arrive on the producing stream's own

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionContext.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+using Cratis.Execution;
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Represents the context handed to an <see cref="IGuardObservableQueryEmission"/> for a single emission on an
+/// observable query subscription.
+/// </summary>
+/// <param name="QueryName">The <see cref="FullyQualifiedQueryName"/> the subscription was established for.</param>
+/// <param name="Arguments">The coerced <see cref="QueryArguments"/> the subscription was established with.</param>
+/// <param name="Principal">The <see cref="ClaimsPrincipal"/> of the caller that established the subscription, or null when the subscription is anonymous.</param>
+/// <param name="CorrelationId">The <see cref="CorrelationId"/> the subscription stamps every emission with.</param>
+/// <param name="ServiceProvider">The per-subscription <see cref="IServiceProvider"/> to resolve guard dependencies from.</param>
+/// <param name="IsFirstEmission">Whether this is the first emission delivered on the subscription.</param>
+/// <param name="CancellationToken">The <see cref="CancellationToken"/> that is cancelled when the subscription ends.</param>
+/// <remarks>
+/// The principal is passed explicitly rather than resolved ambiently. Emissions arrive on the producing stream's own
+/// thread, where the request's <c>AsyncLocal</c> context does not flow, so a guard that reached for an ambient accessor
+/// would see whichever identity — or none — that thread happened to carry.
+/// <para>
+/// For a WebSocket subscription the principal is the one captured when the socket was upgraded: the WebSocket protocol
+/// offers no way to re-present credentials on an established connection, so it does not change for the life of that
+/// connection. A guard that needs a fresher verdict must reach its own source of truth (a session store, a token
+/// introspection endpoint, a revocation list) using the identity carried here.
+/// </para>
+/// </remarks>
+public record ObservableQueryEmissionContext(
+    FullyQualifiedQueryName QueryName,
+    QueryArguments Arguments,
+    ClaimsPrincipal? Principal,
+    CorrelationId CorrelationId,
+    IServiceProvider ServiceProvider,
+    bool IsFirstEmission,
+    CancellationToken CancellationToken);

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuards.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuards.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.DependencyInjection;
+using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Represents an implementation of <see cref="IObservableQueryEmissionGuards"/>.
+/// </summary>
+/// <param name="types">The <see cref="ITypes"/> used to discover <see cref="IGuardObservableQueryEmission"/> implementations.</param>
+/// <param name="logger">The logger.</param>
+/// <remarks>
+/// The guard types are discovered once; the instances are created per emission from the <em>per-subscription</em>
+/// service provider carried on the <see cref="ObservableQueryEmissionContext"/>. Resolving them from the root provider
+/// instead would hand a guard whatever scoped collaborator happened to be cached there first, which for a
+/// tenant-resolving or session-reading guard is the wrong answer rather than a missing one.
+/// </remarks>
+[Singleton]
+public class ObservableQueryEmissionGuards(ITypes types, ILogger<ObservableQueryEmissionGuards> logger) : IObservableQueryEmissionGuards
+{
+    readonly Type[] _guardTypes = [.. types.FindMultiple<IGuardObservableQueryEmission>()];
+
+    /// <inheritdoc/>
+    public bool HasGuards => _guardTypes.Length > 0;
+
+    /// <inheritdoc/>
+    public async Task<ObservableQueryEmissionVerdict> Guard(ObservableQueryEmissionContext context)
+    {
+        var aggregate = ObservableQueryEmissionVerdict.Allow;
+
+        foreach (var guardType in _guardTypes)
+        {
+            ObservableQueryEmissionVerdict verdict;
+
+            try
+            {
+                var guard = (IGuardObservableQueryEmission)ActivatorUtilities.GetServiceOrCreateInstance(context.ServiceProvider, guardType);
+                verdict = await guard.Guard(context);
+            }
+            catch (Exception error)
+            {
+                // Fail closed. A guard that cannot answer must not become an implicit allow — the application would
+                // believe the stream is protected while it keeps flowing. The exception is swallowed here on purpose:
+                // the callers are async void emission callbacks, where anything escaping is unobserved and fatal.
+                logger.EmissionGuardFailed(context.QueryName, guardType, error);
+                return ObservableQueryEmissionVerdict.DenyAndTerminate;
+            }
+
+            if (verdict == ObservableQueryEmissionVerdict.DenyAndTerminate)
+            {
+                return ObservableQueryEmissionVerdict.DenyAndTerminate;
+            }
+
+            // Most restrictive wins — the verdicts are ordered, so the highest one seen so far is the aggregate.
+            if (verdict > aggregate)
+            {
+                aggregate = verdict;
+            }
+        }
+
+        return aggregate;
+    }
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuards.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuards.cs
@@ -41,6 +41,14 @@ public class ObservableQueryEmissionGuards(ITypes types, ILogger<ObservableQuery
                 var guard = (IGuardObservableQueryEmission)ActivatorUtilities.GetServiceOrCreateInstance(context.ServiceProvider, guardType);
                 verdict = await guard.Guard(context);
             }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+                // The subscription ended while the guard was running — a closed tab, not a security failure. The
+                // guard is told to observe this token and the documentation tells its author to, so logging an
+                // ordinary teardown as "your authorization guard failed" would turn every disconnect into an Error.
+                // The verdict is still the closed one: there is nothing left to write to.
+                return ObservableQueryEmissionVerdict.DenyAndTerminate;
+            }
             catch (Exception error)
             {
                 // Fail closed. A guard that cannot answer must not become an implicit allow — the application would

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuardsLogMessages.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionGuardsLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Log messages for <see cref="ObservableQueryEmissionGuards"/>.
+/// </summary>
+internal static partial class ObservableQueryEmissionGuardsLogMessages
+{
+    [LoggerMessage(LogLevel.Error, "Observable query emission guard '{GuardType}' failed for query '{QueryName}' - failing closed and terminating the subscription")]
+    internal static partial void EmissionGuardFailed(this ILogger<ObservableQueryEmissionGuards> logger, FullyQualifiedQueryName queryName, Type guardType, Exception error);
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionVerdict.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryEmissionVerdict.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Defines the verdict an <see cref="IGuardObservableQueryEmission"/> gives for a single observable query emission.
+/// </summary>
+/// <remarks>
+/// The values are ordered from least to most restrictive, so aggregating several guards is a matter of keeping the
+/// highest verdict any of them returned.
+/// </remarks>
+public enum ObservableQueryEmissionVerdict
+{
+    /// <summary>
+    /// The emission is written to the client unchanged.
+    /// </summary>
+    Allow = 0,
+
+    /// <summary>
+    /// The emission is withheld, and the subscription stays live so a later emission can be delivered again.
+    /// </summary>
+    Suppress = 1,
+
+    /// <summary>
+    /// The emission is withheld, the client is told it is no longer authorized, and the subscription is torn down.
+    /// </summary>
+    DenyAndTerminate = 2
+}

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryHandler.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryHandler.cs
@@ -170,13 +170,15 @@ public class ObservableQueryHandler(
         // Get the current query context
         var queryContext = queryContextManager.Current;
 
-        // Create ClientEnumerableObservable using ActivatorUtilities to get proper dependency injection
+        // Create ClientEnumerableObservable using ActivatorUtilities to get proper dependency injection.
+        // The enumerable observables implement IClientEnumerableObservable, which is unrelated to IClientObservable —
+        // casting to the latter silently yielded null and made the very next line throw a NullReferenceException.
         var clientEnumerableObservableType = typeof(ClientEnumerableObservable<>).MakeGenericType(elementType);
         var clientEnumerableObservable = ActivatorUtilities.CreateInstance(
             serviceProvider,
             clientEnumerableObservableType,
             queryContext,
-            streamingData) as IClientObservable;
+            streamingData) as IClientEnumerableObservable;
 
         await clientEnumerableObservable!.HandleConnection(context);
     }
@@ -190,13 +192,15 @@ public class ObservableQueryHandler(
         // Get the current query context
         var queryContext = queryContextManager.Current;
 
-        // Create ClientEnumerableObservableSSE using ActivatorUtilities to get proper dependency injection
+        // Create ClientEnumerableObservableSSE using ActivatorUtilities to get proper dependency injection.
+        // The enumerable observables implement IClientEnumerableObservable, which is unrelated to IClientObservable —
+        // casting to the latter silently yielded null and made the very next line throw a NullReferenceException.
         var clientEnumerableObservableType = typeof(ClientEnumerableObservableSSE<>).MakeGenericType(elementType);
         var clientEnumerableObservable = ActivatorUtilities.CreateInstance(
             serviceProvider,
             clientEnumerableObservableType,
             queryContext,
-            streamingData) as IClientObservable;
+            streamingData) as IClientEnumerableObservable;
 
         await clientEnumerableObservable!.HandleConnection(context);
     }

--- a/Source/DotNET/Arc.Core/Queries/ObservableQueryHandler.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQueryHandler.cs
@@ -187,11 +187,15 @@ public class ObservableQueryHandler(
         var enumerableType = type.GetInterfaces().First(_ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
         var elementType = enumerableType.GetGenericArguments()[0];
 
+        // Get the current query context
+        var queryContext = queryContextManager.Current;
+
         // Create ClientEnumerableObservableSSE using ActivatorUtilities to get proper dependency injection
         var clientEnumerableObservableType = typeof(ClientEnumerableObservableSSE<>).MakeGenericType(elementType);
         var clientEnumerableObservable = ActivatorUtilities.CreateInstance(
             serviceProvider,
             clientEnumerableObservableType,
+            queryContext,
             streamingData) as IClientObservable;
 
         await clientEnumerableObservable!.HandleConnection(context);

--- a/Source/DotNET/Arc.Core/Queries/ObservableQuerySubscriptionIdentity.cs
+++ b/Source/DotNET/Arc.Core/Queries/ObservableQuerySubscriptionIdentity.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Claims;
+
+namespace Cratis.Arc.Queries;
+
+/// <summary>
+/// Captures what identifies a multiplexed observable query subscription for the lifetime of its stream.
+/// </summary>
+/// <param name="QueryName">The <see cref="FullyQualifiedQueryName"/> the subscription was established for.</param>
+/// <param name="Arguments">The coerced <see cref="QueryArguments"/> the subscription was established with.</param>
+/// <param name="Principal">The <see cref="ClaimsPrincipal"/> of the caller that established the subscription.</param>
+/// <remarks>
+/// Emissions arrive on the producing stream's own thread, where the request's <c>AsyncLocal</c> context does not flow,
+/// so anything an emission needs about the caller has to be captured at subscribe time and carried explicitly.
+/// </remarks>
+internal sealed record ObservableQuerySubscriptionIdentity(
+    FullyQualifiedQueryName QueryName,
+    QueryArguments Arguments,
+    ClaimsPrincipal? Principal);

--- a/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/given/a_post_request_for_a_command_action.cs
+++ b/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/given/a_post_request_for_a_command_action.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Cratis.Arc.Commands.for_CommandActionFilter.given;
+
+public class a_post_request_for_a_command_action : a_command_action_filter
+{
+    protected TheCommand _command;
+    protected ActionExecutingContext _actionContext;
+    protected ActionExecutedContext _executedContext;
+
+    protected CommandResult<object> ResultingCommandResult => (CommandResult<object>)((ObjectResult)_executedContext.Result!).Value!;
+
+    void Establish()
+    {
+        _command = new TheCommand("test-value");
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = HttpMethod.Post.Method;
+
+        var actionDescriptor = new ControllerActionDescriptor
+        {
+            ControllerName = "TestController",
+            ActionName = "Execute",
+            Parameters =
+            [
+                new ControllerParameterDescriptor
+                {
+                    Name = "command",
+                    ParameterType = typeof(TheCommand),
+                    BindingInfo = new BindingInfo { BindingSource = BindingSource.Body }
+                }
+            ]
+        };
+
+        var actionContext = new ActionContext(
+            httpContext,
+            new Microsoft.AspNetCore.Routing.RouteData(),
+            actionDescriptor,
+            new ModelStateDictionary());
+
+        _actionContext = new ActionExecutingContext(
+            actionContext,
+            [],
+            new Dictionary<string, object?> { { "command", _command } },
+            null!);
+
+        _executedContext = new ActionExecutedContext(
+            new ActionContext(
+                _actionContext.HttpContext,
+                _actionContext.RouteData,
+                _actionContext.ActionDescriptor,
+                _actionContext.ModelState),
+            [],
+            null!);
+    }
+
+    protected record TheCommand(string Value);
+}

--- a/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_added_a_validation_error_after_producing_a_response.cs
+++ b/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_added_a_validation_error_after_producing_a_response.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Cratis.Arc.Commands.for_CommandActionFilter.when_executing;
+
+public class and_the_action_added_a_validation_error_after_producing_a_response : given.a_post_request_for_a_command_action
+{
+    const string ErrorMessage = "The value is not acceptable.";
+
+    string _response;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _executedContext.Result = new ObjectResult(_response);
+    }
+
+    async Task Because() => await _filter.OnActionExecutionAsync(
+        _actionContext,
+        () =>
+        {
+            _actionContext.ModelState.AddModelError(nameof(TheCommand.Value), ErrorMessage);
+            return Task.FromResult(_executedContext);
+        });
+
+    [Fact] void should_not_be_successful() => ResultingCommandResult.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_carry_the_response() => ResultingCommandResult.Response.ShouldBeNull();
+    [Fact] void should_keep_the_validation_error() => ResultingCommandResult.ValidationResults.Select(_ => _.Message).ShouldContain(ErrorMessage);
+}

--- a/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_produced_a_response.cs
+++ b/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_produced_a_response.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Cratis.Arc.Commands.for_CommandActionFilter.when_executing;
+
+public class and_the_action_produced_a_response : given.a_post_request_for_a_command_action
+{
+    string _response;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _executedContext.Result = new ObjectResult(_response);
+    }
+
+    async Task Because() => await _filter.OnActionExecutionAsync(_actionContext, () => Task.FromResult(_executedContext));
+
+    [Fact] void should_be_successful() => ResultingCommandResult.IsSuccess.ShouldBeTrue();
+    [Fact] void should_carry_the_response() => ResultingCommandResult.Response.ShouldEqual(_response);
+}

--- a/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_threw_after_producing_a_response.cs
+++ b/Source/DotNET/Arc.Specs/Commands/for_CommandActionFilter/when_executing/and_the_action_threw_after_producing_a_response.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Cratis.Arc.Commands.for_CommandActionFilter.when_executing;
+
+/// <summary>
+/// A controller-based command bypasses the command pipeline entirely, so no execution scope ever runs for it. The
+/// filter is the only place that can keep a value the action produced out of the error response body.
+/// </summary>
+public class and_the_action_threw_after_producing_a_response : given.a_post_request_for_a_command_action
+{
+    string _response;
+    Exception _failure;
+
+    void Establish()
+    {
+        _response = "Forty two";
+        _failure = new Exception("Something went wrong");
+        _executedContext.Result = new ObjectResult(_response);
+        _executedContext.Exception = _failure;
+    }
+
+    async Task Because() => await _filter.OnActionExecutionAsync(_actionContext, () => Task.FromResult(_executedContext));
+
+    [Fact] void should_not_be_successful() => ResultingCommandResult.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_carry_the_response() => ResultingCommandResult.Response.ShouldBeNull();
+    [Fact] void should_keep_the_exception_message() => ResultingCommandResult.ExceptionMessages.ShouldContain(_failure.Message);
+}

--- a/Source/DotNET/Arc.Specs/Queries/for_ObservableQueryExtensions/given/all_dependencies.cs
+++ b/Source/DotNET/Arc.Specs/Queries/for_ObservableQueryExtensions/given/all_dependencies.cs
@@ -24,6 +24,8 @@ public class all_dependencies : Specification
         services.AddSingleton(Substitute.For<Microsoft.Extensions.Hosting.IHostApplicationLifetime>());
         services.AddSingleton(Substitute.For<IReadModelInterceptors>());
         services.AddSingleton(Substitute.For<IHttpRequestContextAccessor>());
+        services.AddSingleton(Substitute.For<IObservableQueryEmissionGuards>());
+        services.AddSingleton(Substitute.For<IQueryContextManager>());
         services.AddLogging();
 
         _serviceProvider = services.BuildServiceProvider();

--- a/Source/DotNET/Arc/Commands/CommandActionFilter.cs
+++ b/Source/DotNET/Arc/Commands/CommandActionFilter.cs
@@ -74,13 +74,20 @@ public class CommandActionFilter(
                 }
             }
 
+            var blockingValidationResults = FilterValidationResults(validationResult, treatWarningsAsErrors, ignoreWarnings);
+
+            // A response describes what the command produced. A controller action that threw, or whose input was
+            // rejected, produced nothing the caller may act on - so its response must never travel back in the error
+            // response body. This mirrors what the command pipeline does for model-bound commands.
+            var isFailed = exceptionMessages.Count != 0 || blockingValidationResults.Length != 0;
+
             var commandResult = new CommandResult<object>
             {
                 CorrelationId = context.HttpContext.GetCorrelationId(),
-                ValidationResults = FilterValidationResults(validationResult, treatWarningsAsErrors, ignoreWarnings),
+                ValidationResults = blockingValidationResults,
                 ExceptionMessages = [.. exceptionMessages],
                 ExceptionStackTrace = exceptionStackTrace ?? string.Empty,
-                Response = response
+                Response = isFailed ? null : response
             };
 
             context.HttpContext.Response.SetResponseStatusCode(commandResult);

--- a/Source/DotNET/Arc/Commands/CommandActionFilter.cs
+++ b/Source/DotNET/Arc/Commands/CommandActionFilter.cs
@@ -76,19 +76,24 @@ public class CommandActionFilter(
 
             var blockingValidationResults = FilterValidationResults(validationResult, treatWarningsAsErrors, ignoreWarnings);
 
-            // A response describes what the command produced. A controller action that threw, or whose input was
-            // rejected, produced nothing the caller may act on - so its response must never travel back in the error
-            // response body. This mirrors what the command pipeline does for model-bound commands.
-            var isFailed = exceptionMessages.Count != 0 || blockingValidationResults.Length != 0;
-
             var commandResult = new CommandResult<object>
             {
                 CorrelationId = context.HttpContext.GetCorrelationId(),
                 ValidationResults = blockingValidationResults,
                 ExceptionMessages = [.. exceptionMessages],
                 ExceptionStackTrace = exceptionStackTrace ?? string.Empty,
-                Response = isFailed ? null : response
+                Response = response
             };
+
+            // A response describes what the command produced. A controller action that threw, or whose input was
+            // rejected, produced nothing the caller may act on - so its response must never travel back in the error
+            // response body. The result itself decides what "did not succeed" means, exactly as the command pipeline
+            // does for model-bound commands, rather than this filter keeping a second copy of that predicate that
+            // would quietly disagree the moment another outcome (an unauthorized one, say) is added to it.
+            if (!commandResult.IsSuccess)
+            {
+                commandResult.Response = null;
+            }
 
             context.HttpContext.Response.SetResponseStatusCode(commandResult);
 

--- a/Source/DotNET/Arc/Queries/ObservableQueryExtensions.cs
+++ b/Source/DotNET/Arc/Queries/ObservableQueryExtensions.cs
@@ -107,7 +107,7 @@ public static class ObservableQueryExtensions
     {
         var type = objectResult.Value!.GetType();
         var clientEnumerableObservableType = typeof(ClientEnumerableObservable<>).MakeGenericType(type.GetGenericArguments()[0]);
-        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, objectResult.Value) as IClientEnumerableObservable)!;
+        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, CurrentQueryContext(serviceProvider), objectResult.Value) as IClientEnumerableObservable)!;
     }
 
     /// <summary>
@@ -140,7 +140,7 @@ public static class ObservableQueryExtensions
     {
         var type = objectResult.Value!.GetType();
         var clientEnumerableObservableType = typeof(ClientEnumerableObservableSSE<>).MakeGenericType(type.GetGenericArguments()[0]);
-        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, objectResult.Value) as IClientEnumerableObservable)!;
+        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, CurrentQueryContext(serviceProvider), objectResult.Value) as IClientEnumerableObservable)!;
     }
 
     /// <summary>
@@ -155,7 +155,7 @@ public static class ObservableQueryExtensions
         IAsyncEnumerable<T> enumerable)
     {
         var clientEnumerableObservableType = typeof(ClientEnumerableObservable<>).MakeGenericType(typeof(T));
-        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, enumerable) as IClientEnumerableObservable)!;
+        return (ActivatorUtilities.CreateInstance(serviceProvider, clientEnumerableObservableType, CurrentQueryContext(serviceProvider), enumerable) as IClientEnumerableObservable)!;
     }
 
     /// <summary>
@@ -174,4 +174,17 @@ public static class ObservableQueryExtensions
         var clientObservableType = typeof(ClientObservableSSE<>).MakeGenericType(typeof(T));
         return (ActivatorUtilities.CreateInstance(serviceProvider, clientObservableType, queryContext, subject) as IClientObservable)!;
     }
+
+    /// <summary>
+    /// Gets the <see cref="QueryContext"/> the current query is running under.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to resolve the <see cref="IQueryContextManager"/> from.</param>
+    /// <returns>The current <see cref="QueryContext"/>.</returns>
+    /// <remarks>
+    /// The enumerable observables need the query context to identify the query and its caller to an
+    /// <see cref="IGuardObservableQueryEmission"/>. It is resolved here rather than taken as a parameter so the
+    /// public factory signatures stay exactly as they were for every existing caller.
+    /// </remarks>
+    static QueryContext CurrentQueryContext(IServiceProvider serviceProvider) =>
+        serviceProvider.GetService<IQueryContextManager>()?.Current ?? QueryContext.NotSet;
 }

--- a/Source/JavaScript/Arc/queries/ObservableQueryConnection.ts
+++ b/Source/JavaScript/Arc/queries/ObservableQueryConnection.ts
@@ -17,6 +17,7 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
 
     private _socket!: WebSocket;
     private _disconnected = false;
+    private _unauthorized = false;
     private _url: string;
     private _pingInterval?: ReturnType<typeof setInterval>;
     private _pingIntervalMs: number = 10000;
@@ -95,13 +96,13 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
                 this.startPinging();
             };
             this._socket.onclose = () => {
-                if (this._disconnected) return;
+                if (this._disconnected || this._unauthorized) return;
                 console.log(`Unexpected connection closed for route '${url}'`);
                 this.stopPinging();
                 this._reconnectPolicy.schedule(connectSocket, url);
             };
             this._socket.onerror = (error) => {
-                if (this._disconnected) return;
+                if (this._disconnected || this._unauthorized) return;
                 console.log(`Error with connection for '${url}' - ${error}`);
                 this.stopPinging();
                 this._reconnectPolicy.schedule(connectSocket, url);
@@ -115,7 +116,7 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
             };
         };
 
-        if (this._disconnected) return;
+        if (this._disconnected || this._unauthorized) return;
         connectSocket();
     }
 
@@ -172,11 +173,34 @@ export class ObservableQueryConnection<TDataType> implements IObservableQueryCon
                 // For new-style messages (type === 'Data') the query result is wrapped in message.data.
                 // For legacy/backward-compatible messages (no type) the entire message IS the query result.
                 const data = message.type === WebSocketMessageType.Data ? message.data : message;
-                dataReceived(data as QueryResult<TDataType>);
+                const result = data as QueryResult<TDataType>;
+
+                if (result?.isAuthorized === false) {
+                    this.handleUnauthorized(result, dataReceived);
+                    return;
+                }
+
+                dataReceived(result);
             }
         } catch (error) {
             console.error('Error parsing WebSocket message:', error);
         }
+    }
+
+    /**
+     * Handles the terminal result the server sends when the caller is no longer authorized for the query it is
+     * subscribed to. The subscription is over for good, so the result is delivered and the automatic reconnect is
+     * suppressed — reconnecting would re-subscribe, be denied again, and loop.
+     * @param {QueryResult<TDataType>} result The unauthorized result to deliver.
+     * @param {DataReceived<TDataType>} dataReceived Callback that receives the result.
+     */
+    private handleUnauthorized(result: QueryResult<TDataType>, dataReceived: DataReceived<TDataType>) {
+        console.warn(`Connection for '${this._url}' was ended by the server - no longer authorized`);
+        this._unauthorized = true;
+        this.stopPinging();
+        this._reconnectPolicy.cancel();
+        dataReceived(result);
+        this._socket?.close();
     }
 
     private handlePong(message: WebSocketMessage) {

--- a/Source/JavaScript/Arc/queries/ServerSentEventQueryConnection.ts
+++ b/Source/JavaScript/Arc/queries/ServerSentEventQueryConnection.ts
@@ -23,6 +23,7 @@ export const SSE_HUB_ROUTE = '/.cratis/queries/sse';
 export class ServerSentEventQueryConnection<TDataType> implements IObservableQueryConnection<TDataType> {
     private _eventSource?: EventSource;
     private _disconnected = false;
+    private _unauthorized = false;
 
     /** @inheritdoc */
     readonly lastPingLatency: number = 0;
@@ -38,7 +39,7 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
 
     /** @inheritdoc */
     connect(dataReceived: DataReceived<TDataType>, queryArguments?: object): void {
-        if (this._disconnected) return;
+        if (this._disconnected || this._unauthorized) return;
 
         // Guard against environments where EventSource is not available (e.g. Node.js, SSR)
         // and no custom factory has been supplied to substitute it.
@@ -64,6 +65,10 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
             if (this._disconnected) return;
             try {
                 const result = JSON.parse(event.data as string) as QueryResult<TDataType>;
+                if ((result as unknown as { isAuthorized?: boolean })?.isAuthorized === false) {
+                    this.handleUnauthorized(url, result, dataReceived);
+                    return;
+                }
                 dataReceived(result);
             } catch (error) {
                 console.error('SSE: error parsing message', error);
@@ -71,7 +76,7 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
         };
 
         this._eventSource.onerror = () => {
-            if (this._disconnected) return;
+            if (this._disconnected || this._unauthorized) return;
             console.warn(`SSE: connection error for '${url}', EventSource will retry automatically.`);
         };
     }
@@ -82,5 +87,24 @@ export class ServerSentEventQueryConnection<TDataType> implements IObservableQue
         this._disconnected = true;
         this._eventSource?.close();
         this._eventSource = undefined;
+    }
+
+    /**
+     * Handles the terminal result the server sends when the caller is no longer authorized for the query it is
+     * subscribed to.
+     *
+     * Unlike a WebSocket, an `EventSource` re-establishes a stream the server ended - the server closing its response
+     * is precisely the signal the browser retries on, roughly every three seconds. Each retry re-runs the whole query
+     * pipeline server side just to be denied again, so the stream is only actually terminal if this client closes it.
+     * @param {string} url The stream url, for diagnostics.
+     * @param {QueryResult<TDataType>} result The unauthorized result to deliver.
+     * @param {DataReceived<TDataType>} dataReceived Callback that receives the result.
+     */
+    private handleUnauthorized(url: string, result: QueryResult<TDataType>, dataReceived: DataReceived<TDataType>): void {
+        console.warn(`SSE: stream for '${url}' was ended by the server - no longer authorized`);
+        this._unauthorized = true;
+        this._eventSource?.close();
+        this._eventSource = undefined;
+        dataReceived(result);
     }
 }

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_a_reconnect_policy.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/given/an_observable_query_connection_with_a_reconnect_policy.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { ObservableQueryConnection } from '../../ObservableQueryConnection';
+import { IReconnectPolicy } from '../../IReconnectPolicy';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type FakeWebSocketWithPolicy = {
+    onopen: (() => void) | null;
+    onclose: (() => void) | null;
+    onerror: ((error: unknown) => void) | null;
+    onmessage: ((event: { data: string }) => void) | null;
+    close: sinon.SinonStub;
+    send: sinon.SinonStub;
+    readyState: number;
+};
+
+export class an_observable_query_connection_with_a_reconnect_policy {
+    connection: ObservableQueryConnection<unknown>;
+    fakeWebSocket!: FakeWebSocketWithPolicy;
+    reconnectPolicy: IReconnectPolicy;
+    schedule: sinon.SinonStub;
+    cancel: sinon.SinonStub;
+
+    constructor() {
+        this.fakeWebSocket = {
+            onopen: null,
+            onclose: null,
+            onerror: null,
+            onmessage: null,
+            close: sinon.stub(),
+            send: sinon.stub(),
+            readyState: WebSocket.OPEN,
+        };
+
+        const fakeWebSocket = this.fakeWebSocket;
+        const FakeWebSocketClass = function (this: any) {
+            fakeWebSocket.onopen = null;
+            fakeWebSocket.onclose = null;
+            fakeWebSocket.onerror = null;
+            fakeWebSocket.onmessage = null;
+            return fakeWebSocket;
+        };
+        (globalThis as any)['WebSocket'] = FakeWebSocketClass;
+
+        this.schedule = sinon.stub().returns(true);
+        this.cancel = sinon.stub();
+        this.reconnectPolicy = {
+            attempt: 0,
+            schedule: this.schedule,
+            reset: sinon.stub(),
+            cancel: this.cancel,
+        } as unknown as IReconnectPolicy;
+
+        this.connection = new ObservableQueryConnection<unknown>(
+            new URL('https://example.com/api/test'),
+            'test-microservice',
+            10000,
+            this.reconnectPolicy
+        );
+    }
+
+    simulateMessage(payload: object): void {
+        this.fakeWebSocket.onmessage?.({ data: JSON.stringify(payload) });
+    }
+
+    simulateClose(): void {
+        this.fakeWebSocket.onclose?.();
+    }
+}

--- a/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_unauthorized/terminates_without_reconnecting.ts
+++ b/Source/JavaScript/Arc/queries/for_ObservableQueryConnection/when_receiving_unauthorized/terminates_without_reconnecting.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { given } from '../../../given';
+import { an_observable_query_connection_with_a_reconnect_policy } from '../given/an_observable_query_connection_with_a_reconnect_policy';
+import { QueryResult } from '../../QueryResult';
+import { WebSocketMessageType } from '../../WebSocketMessage';
+
+describe('when receiving unauthorized it terminates without reconnecting', given(an_observable_query_connection_with_a_reconnect_policy, context => {
+    const unauthorizedResult = {
+        data: null,
+        isSuccess: false,
+        isAuthorized: false,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+    };
+
+    let receivedResults: QueryResult<unknown>[] = [];
+
+    beforeEach(() => {
+        receivedResults = [];
+        context.connection.connect((data) => {
+            receivedResults.push(data as QueryResult<unknown>);
+        });
+        context.simulateMessage({
+            type: WebSocketMessageType.Data,
+            data: unauthorizedResult
+        });
+
+        // The server closes the stream right after the terminal result.
+        context.simulateClose();
+    });
+
+    it('should deliver the unauthorized result', () => {
+        receivedResults.should.have.lengthOf(1);
+    });
+
+    it('should deliver it as not authorized', () => {
+        (receivedResults[0] as unknown as { isAuthorized: boolean }).isAuthorized.should.be.false;
+    });
+
+    it('should not schedule a reconnect', () => {
+        context.schedule.called.should.be.false;
+    });
+
+    it('should cancel any pending reconnect', () => {
+        context.cancel.called.should.be.true;
+    });
+
+    it('should close the socket', () => {
+        context.fakeWebSocket.close.called.should.be.true;
+    });
+}));

--- a/Source/JavaScript/Arc/queries/for_ServerSentEventQueryConnection/when_receiving_unauthorized/terminates_without_reconnecting.ts
+++ b/Source/JavaScript/Arc/queries/for_ServerSentEventQueryConnection/when_receiving_unauthorized/terminates_without_reconnecting.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import sinon from 'sinon';
+import { ServerSentEventQueryConnection } from '../../ServerSentEventQueryConnection';
+import { QueryResult } from '../../QueryResult';
+
+/**
+ * Unlike a WebSocket, an EventSource treats the server ending its response as the signal to retry - roughly every
+ * three seconds, and each retry re-runs the entire query pipeline server side just to be denied again. The terminal
+ * unauthorized result is only terminal if this client closes the stream itself.
+ */
+describe('when receiving unauthorized it terminates without reconnecting', () => {
+    const unauthorizedResult = {
+        data: null,
+        isSuccess: false,
+        isAuthorized: false,
+        isValid: true,
+        hasExceptions: false,
+        validationResults: [],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+    };
+
+    let fakeEventSource: Record<string, unknown>;
+    let closeStub: sinon.SinonStub;
+    let constructedCount: number;
+    let connection: ServerSentEventQueryConnection<string[]>;
+    let receivedResults: QueryResult<string[]>[];
+
+    beforeEach(() => {
+        closeStub = sinon.stub();
+        constructedCount = 0;
+        fakeEventSource = { onmessage: null, onerror: null, close: closeStub };
+
+        (globalThis as Record<string, unknown>)['EventSource'] = function () {
+            constructedCount++;
+            return fakeEventSource;
+        };
+
+        receivedResults = [];
+        connection = new ServerSentEventQueryConnection<string[]>(new URL('http://localhost/api/queries/latest'));
+        connection.connect((result: QueryResult<string[]>) => receivedResults.push(result));
+
+        (fakeEventSource['onmessage'] as (event: MessageEvent) => void)(
+            { data: JSON.stringify(unauthorizedResult) } as MessageEvent
+        );
+
+        // Anything that would normally bring the stream back up must now be refused.
+        connection.connect(() => { });
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)['EventSource'];
+        sinon.restore();
+    });
+
+    it('should deliver the unauthorized result', () => receivedResults.length.should.equal(1));
+    it('should deliver it as not authorized', () => (receivedResults[0] as unknown as { isAuthorized: boolean }).isAuthorized.should.be.false);
+    it('should close the event source', () => closeStub.calledOnce.should.be.true);
+    it('should not re-establish the stream', () => constructedCount.should.equal(1));
+});


### PR DESCRIPTION
# Summary

Two recorded defects in what a command hands back when it fails, and in how long an observable query stays authorized.

## Added

- An opt-in guard consulted before each observable-query emission, so an application can withhold an emission or end a subscription when authorization changes mid-stream. Authorization was previously evaluated once, when the subscription was established, and never again — nothing ended a stream on token expiry, session end or role revocation. With no guard registered nothing is allocated and no dispatch happens, so existing applications are unaffected (#2476)

## Fixed

- A command that did not succeed no longer carries its response value. The value was bound before execution scopes completed, and a commit-time constraint or concurrency failure returned it alongside the failure, serialized into the error body — so a caller could act on a value produced by a command whose transaction rolled back (#2495)
- Model-bound `IAsyncEnumerable` observable queries now work over WebSocket and Server-Sent Events. Both transports previously failed on connect: the observable was cast to an interface it does not implement and the null dereferenced before a single item was streamed
