### PR TITLE
Carry AuthorizationFailureReason when merging command results

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_multiple_command_results.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_multiple_command_results.cs
@@ -36,4 +36,5 @@ public class when_merging_multiple_command_results : Specification
     [Fact] void should_contain_all_exception_messages() => _result.ExceptionMessages.ShouldContainOnly("Exception 1", "Exception 2");
     [Fact] void should_contain_all_validation_results() => _result.ValidationResults.Select(v => v.Message).ShouldContainOnly("Error 1", "Error 2");
     [Fact] void should_contain_stack_trace_from_other_result() => _result.ExceptionStackTrace.ShouldEqual("Stack trace 1\nStack trace 2");
+    [Fact] void should_leave_authorization_failure_reason_empty() => _result.AuthorizationFailureReason.ShouldEqual(string.Empty);
 }

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_multiple_unauthorized_results.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_multiple_unauthorized_results.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResult;
+
+public class when_merging_with_multiple_unauthorized_results : Specification
+{
+    CommandResult _result;
+    CommandResult _unauthorizedResultWithoutReason;
+    CommandResult _firstUnauthorizedResultWithReason;
+    CommandResult _secondUnauthorizedResultWithReason;
+
+    void Establish()
+    {
+        _result = CommandResult.Success(CorrelationId.New());
+        _unauthorizedResultWithoutReason = CommandResult.Unauthorized(CorrelationId.New());
+        _firstUnauthorizedResultWithReason = CommandResult.Unauthorized(CorrelationId.New(), "First reason");
+        _secondUnauthorizedResultWithReason = CommandResult.Unauthorized(CorrelationId.New(), "Second reason");
+    }
+
+    void Because() => _result.MergeWith(_unauthorizedResultWithoutReason, _firstUnauthorizedResultWithReason, _secondUnauthorizedResultWithReason);
+
+    [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_carry_first_non_empty_authorization_failure_reason() => _result.AuthorizationFailureReason.ShouldEqual("First reason");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_unauthorized_result_and_reason_already_set.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_unauthorized_result_and_reason_already_set.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResult;
+
+public class when_merging_with_unauthorized_result_and_reason_already_set : Specification
+{
+    CommandResult _result;
+    CommandResult _unauthorizedResult;
+
+    void Establish()
+    {
+        _result = CommandResult.Unauthorized(CorrelationId.New(), "Original reason");
+        _unauthorizedResult = CommandResult.Unauthorized(CorrelationId.New(), "Other reason");
+    }
+
+    void Because() => _result.MergeWith(_unauthorizedResult);
+
+    [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_keep_already_set_authorization_failure_reason() => _result.AuthorizationFailureReason.ShouldEqual("Original reason");
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_unauthorized_result_with_reason.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResult/when_merging_with_unauthorized_result_with_reason.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResult;
+
+public class when_merging_with_unauthorized_result_with_reason : Specification
+{
+    CommandResult _result;
+    CommandResult _unauthorizedResult;
+
+    void Establish()
+    {
+        _result = CommandResult.Success(CorrelationId.New());
+        _unauthorizedResult = CommandResult.Unauthorized(CorrelationId.New(), "License required");
+    }
+
+    void Because() => _result.MergeWith(_unauthorizedResult);
+
+    [Fact] void should_not_be_authorized() => _result.IsAuthorized.ShouldBeFalse();
+    [Fact] void should_carry_authorization_failure_reason() => _result.AuthorizationFailureReason.ShouldEqual("License required");
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandResult.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandResult.cs
@@ -143,6 +143,11 @@ public class CommandResult
     public void MergeWith(params CommandResult[] commandResults)
     {
         IsAuthorized = IsAuthorized && commandResults.All(r => r.IsAuthorized);
+        if (string.IsNullOrEmpty(AuthorizationFailureReason))
+        {
+            AuthorizationFailureReason = commandResults.Select(r => r.AuthorizationFailureReason).FirstOrDefault(reason => !string.IsNullOrEmpty(reason)) ?? string.Empty;
+        }
+
         ValidationResults = [.. ValidationResults, .. commandResults.SelectMany(r => r.ValidationResults)];
         ExceptionMessages = [.. ExceptionMessages, .. commandResults.SelectMany(r => r.ExceptionMessages)];
         ExceptionStackTrace = string.Join(Environment.NewLine, new[] { ExceptionStackTrace }.Concat(commandResults.Select(r => r.ExceptionStackTrace)));


### PR DESCRIPTION
## Fixed

- `CommandResult.MergeWith` now carries the `AuthorizationFailureReason` from merged-in results: when the result's own reason is empty, the first non-empty reason from the merged results is used, and an already-set reason is never overwritten. Previously a command filter rejecting with `CommandResult.Unauthorized(correlationId, reason)` surfaced as an unauthorized result with a blank reason, leaving callers with no explanation for the rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)