### PR TITLE
Carry the identity provider the ingress authenticated a caller with

### DIFF
--- a/Documentation/backend/asp-net-core/microsoft-identity.md
+++ b/Documentation/backend/asp-net-core/microsoft-identity.md
@@ -45,6 +45,45 @@ app.UseAuthentication();
 app.UseAuthorization();
 ```
 
+## Knowing which identity provider signed the caller in
+
+The `x-ms-client-principal` payload carries an `identityProvider` field describing the provider the ingress
+authenticated the caller with. Without it, everything downstream sees is a set of claims that look the same whether
+they came from Entra ID or GitHub — so the application has no way to tell one federation apart from another.
+
+Arc keeps that value on the reconstructed principal as a claim, so both normal request authorization and the
+`/.cratis/me` identity resolution can read it:
+
+```csharp
+using Cratis.Arc.Identity;
+using Microsoft.AspNetCore.Http;
+
+public class IdentityProviderReader(IHttpContextAccessor httpContextAccessor)
+{
+    public string? Current =>
+        httpContextAccessor.HttpContext?.User.FindFirst(MicrosoftIdentityPlatformClaims.IdentityProvider)?.Value;
+}
+```
+
+| Aspect | Detail |
+| ------ | ------ |
+| Claim type | `urn:cratis:arc:identity:provider` — use the `MicrosoftIdentityPlatformClaims.IdentityProvider` constant |
+| Value | The exact `identityProvider` value the ingress forwarded, for example `aad` or `github` |
+| When absent | The forwarded principal carried no identity provider |
+
+The claim type is **reserved for Arc**. The `x-ms-client-principal` header is base64, not a signature, so any caller
+that can reach the application can put whatever it likes in the serialized `claims` array — including a claim of this
+very type. Arc therefore removes every claim of the reserved type from the deserialized payload, ignoring casing,
+*before* writing its own value. A caller cannot smuggle in an identity provider of its own choosing, and when the
+forwarded principal carries no identity provider the claim is simply absent rather than attacker-supplied.
+
+> [!IMPORTANT]
+> This value is authentication-scheme metadata and is typically derived from a provider display name. It is useful for
+> diagnostics, for telling federations apart, and for provider-aware behavior — but it is not a stable provider
+> registration key, and renaming a provider can change it. Do not use it as a durable identity, membership or storage
+> key. An ingress that needs a stable key emits its own claim for that purpose, and Arc copies such claims through
+> untouched.
+
 ## Identity Details
 
 For information about providing additional identity details for logged-in users, including authorization checks and custom identity information, see the [Identity documentation](../identity/index.md).

--- a/Documentation/backend/asp-net-core/microsoft-identity.md
+++ b/Documentation/backend/asp-net-core/microsoft-identity.md
@@ -69,20 +69,39 @@ public class IdentityProviderReader(IHttpContextAccessor httpContextAccessor)
 | ------ | ------ |
 | Claim type | `urn:cratis:arc:identity:provider` — use the `MicrosoftIdentityPlatformClaims.IdentityProvider` constant |
 | Value | The exact `identityProvider` value the ingress forwarded, for example `aad` or `github` |
-| When absent | The forwarded principal carried no identity provider |
+| When absent | The forwarded principal carried no `identityProvider` field, or the field held only blank characters |
 
 The claim type is **reserved for Arc**. The `x-ms-client-principal` header is base64, not a signature, so any caller
-that can reach the application can put whatever it likes in the serialized `claims` array — including a claim of this
-very type. Arc therefore removes every claim of the reserved type from the deserialized payload, ignoring casing,
-*before* writing its own value. A caller cannot smuggle in an identity provider of its own choosing, and when the
-forwarded principal carries no identity provider the claim is simply absent rather than attacker-supplied.
+that can reach the application can put whatever it likes in the serialized payload — including a claim of this very
+type. Arc therefore removes every claim of the reserved type from the deserialized payload, ignoring casing, *before*
+writing its own value.
+
+> [!WARNING]
+> **What the strip guarantees is single provenance, not authenticity.** The claim always carries exactly one value,
+> and that value always comes from one place — the `identityProvider` field of the forwarded principal — so a claim of
+> the reserved type passed through by the ingress or by the identity provider can never displace it. It does **not**
+> make the value trustworthy. The same unsigned header carries that field too, and Arc does not check who sent the
+> header, so a caller that can reach the application authors the whole document; the strip only decides which of its
+> fields wins. **Trust this claim exactly as far as you trust the `x-ms-client-principal` header itself — that is,
+> only insofar as your ingress is the only thing that can set it.** Terminate the header at the ingress and reject or
+> overwrite an inbound one; nothing inside Arc can do that for you.
+
+Read the claim with `FindFirst` or `FindAll`, as in the example above, and **never normalize the claim type yourself**.
+Those lookups compare the claim type the same way the strip does, so what they return is exactly what Arc wrote.
+Enumerating `User.Claims` and folding the type with `ToUpperInvariant()` or `Trim()` widens the match beyond what was
+removed — a forged type differing only by Unicode case folding (`urn:cratiſ:arc:identity:provider`, U+017F) or by
+trailing whitespace then matches, and because forwarded claims are added before Arc's own, a `FirstOrDefault()` over
+that widened set returns the forgery.
 
 > [!IMPORTANT]
-> This value is authentication-scheme metadata and is typically derived from a provider display name. It is useful for
-> diagnostics, for telling federations apart, and for provider-aware behavior — but it is not a stable provider
-> registration key, and renaming a provider can change it. Do not use it as a durable identity, membership or storage
-> key. An ingress that needs a stable key emits its own claim for that purpose, and Arc copies such claims through
-> untouched.
+> The value is the exact `identityProvider` field the ingress forwarded, verbatim and untrimmed — Arc neither
+> interprets nor normalizes it. What it *means* is therefore the ingress's choice, not Arc's. Cratis AuthProxy
+> forwards the canonical provider key, the same value it publishes as its own `urn:cratis:identity:provider-key`
+> claim, so in a canonical AuthProxy deployment the two carry identical values. Another ingress may forward an
+> authentication scheme name or a provider display name that changes when the provider is renamed. **Arc guarantees
+> neither**, so use this claim for telling federations apart, for diagnostics, and for provider-aware behavior. If you
+> need a durable provider key, read the claim the ingress publishes for that purpose — `urn:cratis:identity:provider-key`
+> in an AuthProxy deployment — rather than this one. Arc copies such ingress-authored claims through untouched.
 
 ## Identity Details
 

--- a/Documentation/backend/core/authentication.md
+++ b/Documentation/backend/core/authentication.md
@@ -48,10 +48,14 @@ This registers `MicrosoftIDentityPlatformAuthHandler`, which reads the standard 
 
 The reconstructed principal also carries the identity provider the ingress authenticated the caller with, as the
 reserved `MicrosoftIdentityPlatformClaims.IdentityProvider` (`urn:cratis:arc:identity:provider`) claim. Arc strips any
-claim of that type out of the forwarded payload before writing its own value, so a caller cannot forge it.
+claim of that type out of the forwarded payload before writing its own value, so the claim always holds exactly one
+value taken from one place — the `identityProvider` field of the forwarded principal. That is a guarantee of single
+provenance, not of authenticity: `x-ms-client-principal` is base64 rather than signed, and Arc does not check who sent
+it, so trust the claim exactly as far as you trust that header — only insofar as your ingress is the only thing that
+can set it. Read it with `FindFirst`/`FindAll` and never normalize the claim type yourself.
 
-See [Microsoft Identity Platform](../asp-net-core/microsoft-identity.md) for the full setup guide, including how the
-identity provider claim behaves and how to test locally with a generated principal.
+See [Microsoft Identity Platform](../asp-net-core/microsoft-identity.md) for the full setup guide, including what the
+identity provider claim does and does not guarantee, and how to test locally with a generated principal.
 
 ### Arc.Core (non-ASP.NET Core)
 

--- a/Documentation/backend/core/authentication.md
+++ b/Documentation/backend/core/authentication.md
@@ -46,7 +46,12 @@ This registers `MicrosoftIDentityPlatformAuthHandler`, which reads the standard 
 | `x-ms-client-principal-name` | Display name |
 | `x-ms-client-principal` | Base64-encoded JSON payload with roles and claims |
 
-See [Microsoft Identity Platform](../asp-net-core/microsoft-identity.md) for the full setup guide, including how to test locally with a generated principal.
+The reconstructed principal also carries the identity provider the ingress authenticated the caller with, as the
+reserved `MicrosoftIdentityPlatformClaims.IdentityProvider` (`urn:cratis:arc:identity:provider`) claim. Arc strips any
+claim of that type out of the forwarded payload before writing its own value, so a caller cannot forge it.
+
+See [Microsoft Identity Platform](../asp-net-core/microsoft-identity.md) for the full setup guide, including how the
+identity provider claim behaves and how to test locally with a generated principal.
 
 ### Arc.Core (non-ASP.NET Core)
 

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/given/a_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/given/a_handler.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Arc.Authentication;
+using Cratis.Arc.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.given;
+
+public class a_handler : Specification
+{
+    protected const string IdentityIdFromHeader = "identity-id-from-header";
+    protected const string IdentityNameFromHeader = "identity-name-from-header";
+    protected const string UserDetails = "user@example.com";
+    protected const string BenignClaimType = "email";
+    protected const string BenignClaimValue = "user@example.com";
+    protected const string IngressProviderKeyClaimType = "urn:cratis:identity:provider-key";
+    protected const string IngressProviderKeyClaimValue = "workforce";
+
+    protected MicrosoftIdentityPlatformAuthenticationHandler _handler;
+
+    void Establish()
+    {
+        var options = Substitute.For<IOptions<ArcOptions>>();
+        options.Value.Returns(new ArcOptions());
+        _handler = new(options, NullLoggerFactory.Instance);
+    }
+
+    /// <summary>
+    /// Builds a request context carrying the three Microsoft Identity Platform headers, with the principal header
+    /// holding the exact base64 encoded JSON wire shape the ingress forwards.
+    /// </summary>
+    /// <param name="identityProvider">The value of the <c>identityProvider</c> field, or null to omit the field entirely.</param>
+    /// <param name="claims">The claims to put in the serialized principal.</param>
+    /// <returns>The <see cref="IHttpRequestContext"/> to authenticate.</returns>
+    protected static IHttpRequestContext ContextForPrincipal(string? identityProvider, params (string Type, string Value)[] claims)
+    {
+        var context = Substitute.For<IHttpRequestContext>();
+        context.Headers.Returns(new Dictionary<string, string>
+        {
+            [MicrosoftIdentityPlatformHeaders.IdentityIdHeader] = IdentityIdFromHeader,
+            [MicrosoftIdentityPlatformHeaders.IdentityNameHeader] = IdentityNameFromHeader,
+            [MicrosoftIdentityPlatformHeaders.PrincipalHeader] = PrincipalHeaderValue(identityProvider, claims)
+        });
+
+        return context;
+    }
+
+    /// <summary>
+    /// Serializes the principal exactly the way the ingress does - camel cased field names, claims as typ/val pairs -
+    /// so the specs pin the wire contract rather than whatever Arc's own serializer options happen to produce.
+    /// </summary>
+    /// <param name="identityProvider">The value of the <c>identityProvider</c> field, or null to omit the field entirely.</param>
+    /// <param name="claims">The claims to put in the serialized principal.</param>
+    /// <returns>The base64 encoded principal header value.</returns>
+    protected static string PrincipalHeaderValue(string? identityProvider, params (string Type, string Value)[] claims)
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["userId"] = "provider-user-id",
+            ["userDetails"] = UserDetails,
+            ["userRoles"] = new[] { "authenticated" },
+            ["claims"] = claims.Select(claim => new { typ = claim.Type, val = claim.Value }).ToArray()
+        };
+
+        if (identityProvider is not null)
+        {
+            payload["identityProvider"] = identityProvider;
+        }
+
+        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload));
+    }
+
+    protected static string[] IdentityProviderClaimsFrom(AuthenticationResult result) =>
+        [.. result.Principal!.FindAll(MicrosoftIdentityPlatformClaims.IdentityProvider).Select(claim => claim.Value)];
+
+    protected static string[] ClaimValuesFrom(AuthenticationResult result, string claimType) =>
+        [.. result.Principal!.FindAll(claimType).Select(claim => claim.Value)];
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/given/a_handler.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/given/a_handler.cs
@@ -78,4 +78,24 @@ public class a_handler : Specification
 
     protected static string[] ClaimValuesFrom(AuthenticationResult result, string claimType) =>
         [.. result.Principal!.FindAll(claimType).Select(claim => claim.Value)];
+
+    /// <summary>
+    /// Enumerates the reconstructed principal the way a consumer that normalizes the claim type itself would - upper
+    /// casing before comparing, instead of going through FindFirst/FindAll.
+    /// </summary>
+    /// <param name="result">The <see cref="AuthenticationResult"/> to read the claims from.</param>
+    /// <returns>The values of the matching claims, in the order they sit on the principal.</returns>
+    /// <remarks>
+    /// The handler strips with OrdinalIgnoreCase and FindFirst/FindAll match with OrdinalIgnoreCase, so every other
+    /// helper here shares the blind spot of the guard it observes and can never see a claim type the strip missed.
+    /// This one deliberately compares differently, so a survivor is observable and the documented "never normalize
+    /// the claim type yourself" warning is pinned by something that fails when it stops being true.
+    /// </remarks>
+    protected static string[] ClaimValuesNormalizedWithUpperInvariant(AuthenticationResult result) =>
+        [.. result.Principal!.Claims
+            .Where(claim => string.Equals(
+                claim.Type.ToUpperInvariant(),
+                MicrosoftIdentityPlatformClaims.IdentityProvider.ToUpperInvariant(),
+                StringComparison.Ordinal))
+            .Select(claim => claim.Value)];
 }

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_differs_only_by_unicode_case_folding.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_differs_only_by_unicode_case_folding.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+/// <summary>
+/// Pins the boundary of the strip, and with it the documented rule that a consumer must read reserved claims with
+/// FindFirst/FindAll and never normalize the claim type itself.
+/// </summary>
+/// <remarks>
+/// The handler strips with OrdinalIgnoreCase and FindFirst/FindAll match with OrdinalIgnoreCase, so a claim type
+/// those two agree is different both survives the strip and stays invisible to the documented lookup - every
+/// assertion that observes through FindAll shares the guard's blind spot by construction. The last two assertions
+/// therefore observe with a different comparison, which is the only way this suite can show what the warning in the
+/// documentation is about. They describe a known limitation rather than a desirable property: if the strip is ever
+/// widened to fold Unicode casing, they fail, and the documentation must be corrected in the same change.
+/// </remarks>
+public class and_the_colliding_claim_differs_only_by_unicode_case_folding : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    /// <summary>
+    /// The reserved type with U+017F LATIN SMALL LETTER LONG S in place of the <c>s</c> of <c>cratis</c>.
+    /// </summary>
+    /// <remarks>
+    /// OrdinalIgnoreCase says this is a different claim type, so it is neither stripped nor found by FindAll.
+    /// ToUpperInvariant folds it to the same string as the reserved type, so a consumer that upper cases the type
+    /// before comparing does match it - and forwarded claims are added before Arc writes its own, so that consumer
+    /// meets the forgery first.
+    /// </remarks>
+    const string LongSClaimType = "urn:cratiſ:arc:identity:provider";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            IdentityProviderFromIngress,
+            (LongSClaimType, ForgedIdentityProvider),
+            (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_only_the_ingress_identity_provider_through_the_documented_lookup() => IdentityProviderClaimsFrom(_result).ShouldContainOnly(IdentityProviderFromIngress);
+    [Fact] void should_leave_the_unicode_variant_as_a_claim_type_of_its_own() => ClaimValuesFrom(_result, LongSClaimType).ShouldContainOnly(ForgedIdentityProvider);
+    [Fact] void should_match_both_claims_for_a_consumer_that_upper_cases_the_claim_type() => ClaimValuesNormalizedWithUpperInvariant(_result).Length.ShouldEqual(2);
+    [Fact] void should_put_the_forgery_first_for_a_consumer_that_upper_cases_the_claim_type() => ClaimValuesNormalizedWithUpperInvariant(_result)[0].ShouldEqual(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_only_differs_in_casing.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_only_differs_in_casing.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_colliding_claim_only_differs_in_casing : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string CaseVariedClaimType = "URN:CRATIS:ARC:Identity:Provider";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            IdentityProviderFromIngress,
+            (CaseVariedClaimType, ForgedIdentityProvider),
+            (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+    [Fact] void should_strip_the_case_varied_forgery() => IdentityProviderClaimsFrom(_result).ShouldNotContain(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_uses_the_published_wire_literal.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_colliding_claim_uses_the_published_wire_literal.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_colliding_claim_uses_the_published_wire_literal : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    /// <summary>
+    /// Spelled out here instead of taken from <see cref="MicrosoftIdentityPlatformClaims"/> on purpose.
+    /// </summary>
+    /// <remarks>
+    /// That constant is a <c>public const</c>, so it is inlined into every consumer at compile time - this literal,
+    /// not the constant, is what the documentation publishes and what an already built consumer keeps looking for.
+    /// Every other assertion in this suite routes through the constant, so without the arm below a rename of it
+    /// would leave the whole suite green while turning the published literal into an unstripped, caller controlled
+    /// claim type carried on an authenticated principal.
+    /// </remarks>
+    const string PublishedClaimType = "urn:cratis:arc:identity:provider";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            IdentityProviderFromIngress,
+            (PublishedClaimType, ForgedIdentityProvider),
+            (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_publish_the_documented_wire_claim_type() => MicrosoftIdentityPlatformClaims.IdentityProvider.ShouldEqual("urn:cratis:arc:identity:provider");
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_strip_the_forgery_from_the_published_claim_type() => ClaimValuesFrom(_result, PublishedClaimType).ShouldNotContain(ForgedIdentityProvider);
+    [Fact] void should_expose_the_ingress_identity_provider_under_the_published_claim_type() => ClaimValuesFrom(_result, PublishedClaimType).ShouldContainOnly(IdentityProviderFromIngress);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_identity_provider_is_blank.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_identity_provider_is_blank.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+/// <summary>
+/// A blank but present claim is worse for a consumer than an absent one - a null check passes and the value is
+/// meaningless - so a forwarded field holding nothing but whitespace must produce no claim at all, exactly as an
+/// empty or omitted field does.
+/// </summary>
+public class and_the_identity_provider_is_blank : given.a_handler
+{
+    const string EmptyIdentityProvider = "";
+    const string SpacesOnlyIdentityProvider = "   ";
+    const string TabAndNewlineIdentityProvider = "\t\n";
+
+    AuthenticationResult _empty;
+    AuthenticationResult _spacesOnly;
+    AuthenticationResult _tabAndNewline;
+
+    async Task Because()
+    {
+        _empty = await _handler.HandleAuthentication(ContextForPrincipal(EmptyIdentityProvider, (BenignClaimType, BenignClaimValue)));
+        _spacesOnly = await _handler.HandleAuthentication(ContextForPrincipal(SpacesOnlyIdentityProvider, (BenignClaimType, BenignClaimValue)));
+        _tabAndNewline = await _handler.HandleAuthentication(ContextForPrincipal(TabAndNewlineIdentityProvider, (BenignClaimType, BenignClaimValue)));
+    }
+
+    [Fact] void should_authenticate_the_principal_with_an_empty_identity_provider() => _empty.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_authenticate_the_principal_with_a_spaces_only_identity_provider() => _spacesOnly.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_authenticate_the_principal_with_a_tab_and_newline_identity_provider() => _tabAndNewline.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_not_expose_an_identity_provider_for_the_empty_field() => IdentityProviderClaimsFrom(_empty).ShouldBeEmpty();
+    [Fact] void should_not_expose_an_identity_provider_for_the_spaces_only_field() => IdentityProviderClaimsFrom(_spacesOnly).ShouldBeEmpty();
+    [Fact] void should_not_expose_an_identity_provider_for_the_tab_and_newline_field() => IdentityProviderClaimsFrom(_tabAndNewline).ShouldBeEmpty();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_spacesOnly, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_identity_provider_is_padded_with_whitespace.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_identity_provider_is_padded_with_whitespace.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+/// <summary>
+/// The blank guard rejects a field that is nothing but whitespace - it does not trim one that merely carries some.
+/// </summary>
+/// <remarks>
+/// This is the control for <c>and_the_identity_provider_is_blank</c>: without it, a handler that stopped writing the
+/// claim altogether would satisfy every "should not expose" assertion there. It also pins the documented promise that
+/// the value is the forwarded field verbatim, which a well meaning <c>Trim()</c> would silently break.
+/// </remarks>
+public class and_the_identity_provider_is_padded_with_whitespace : given.a_handler
+{
+    const string PaddedIdentityProvider = "  aad  ";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(PaddedIdentityProvider, (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_forwarded_value_including_its_padding() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(PaddedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_carries_a_colliding_identity_provider_claim.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_carries_a_colliding_identity_provider_claim.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_carries_a_colliding_identity_provider_claim : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            IdentityProviderFromIngress,
+            (MicrosoftIdentityPlatformClaims.IdentityProvider, ForgedIdentityProvider),
+            (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+    [Fact] void should_strip_the_forged_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldNotContain(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            IdentityProviderFromIngress,
+            (IngressProviderKeyClaimType, IngressProviderKeyClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_leave_the_provider_key_claim_the_ingress_authored_untouched() => ClaimValuesFrom(_result, IngressProviderKeyClaimType).ShouldContainOnly(IngressProviderKeyClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_has_no_identity_provider : given.a_handler
+{
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(null, (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_not_expose_an_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim : given.a_handler
+{
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticationResult _result;
+
+    async Task Because() => _result = await _handler.HandleAuthentication(
+        ContextForPrincipal(
+            null,
+            (MicrosoftIdentityPlatformClaims.IdentityProvider, ForgedIdentityProvider),
+            (BenignClaimType, BenignClaimValue)));
+
+    [Fact] void should_authenticate() => _result.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_not_expose_an_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_two_principals_differ_only_by_identity_provider.cs
+++ b/Source/DotNET/Arc.Core.Specs/Identity/for_MicrosoftIdentityPlatformAuthenticationHandler/when_handling_authentication/and_two_principals_differ_only_by_identity_provider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIdentityPlatformAuthenticationHandler.when_handling_authentication;
+
+public class and_two_principals_differ_only_by_identity_provider : given.a_handler
+{
+    const string FirstIdentityProvider = "aad";
+    const string SecondIdentityProvider = "github";
+
+    AuthenticationResult _first;
+    AuthenticationResult _second;
+
+    async Task Because()
+    {
+        _first = await _handler.HandleAuthentication(ContextForPrincipal(FirstIdentityProvider));
+        _second = await _handler.HandleAuthentication(ContextForPrincipal(SecondIdentityProvider));
+    }
+
+    [Fact] void should_authenticate_the_first_principal() => _first.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_authenticate_the_second_principal() => _second.IsAuthenticated.ShouldBeTrue();
+    [Fact] void should_expose_exactly_one_identity_provider_for_the_first_principal() => IdentityProviderClaimsFrom(_first).Length.ShouldEqual(1);
+    [Fact] void should_expose_exactly_one_identity_provider_for_the_second_principal() => IdentityProviderClaimsFrom(_second).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_exact_first_identity_provider() => IdentityProviderClaimsFrom(_first)[0].ShouldEqual(FirstIdentityProvider);
+    [Fact] void should_expose_the_exact_second_identity_provider() => IdentityProviderClaimsFrom(_second)[0].ShouldEqual(SecondIdentityProvider);
+    [Fact] void should_keep_the_identity_id_from_the_header() => ClaimValuesFrom(_first, "sub")[0].ShouldEqual(IdentityIdFromHeader);
+    [Fact] void should_keep_the_authentication_type_as_the_handler_name() => _first.Principal!.Identity!.AuthenticationType.ShouldEqual(nameof(MicrosoftIdentityPlatformAuthenticationHandler));
+}

--- a/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformAuthenticationHandler.cs
+++ b/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformAuthenticationHandler.cs
@@ -63,7 +63,7 @@ public class MicrosoftIdentityPlatformAuthenticationHandler(
         claims.Add(new Claim(ClaimTypes.NameIdentifier, headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader]));
         claims.Add(new Claim("sub", headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader]));
 
-        if (!string.IsNullOrEmpty(clientPrincipal.IdentityProvider))
+        if (!string.IsNullOrWhiteSpace(clientPrincipal.IdentityProvider))
         {
             claims.Add(new Claim(MicrosoftIdentityPlatformClaims.IdentityProvider, clientPrincipal.IdentityProvider));
         }

--- a/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformAuthenticationHandler.cs
+++ b/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformAuthenticationHandler.cs
@@ -55,10 +55,19 @@ public class MicrosoftIdentityPlatformAuthenticationHandler(
 
         var claims = clientPrincipal.Claims.Select(c => new Claim(c.typ, c.val)).ToList();
 
-        claims.RemoveAll(claim => claim.Type == ClaimTypes.NameIdentifier || claim.Type == "sub");
+        claims.RemoveAll(claim =>
+            claim.Type == ClaimTypes.NameIdentifier ||
+            claim.Type == "sub" ||
+            claim.Type.Equals(MicrosoftIdentityPlatformClaims.IdentityProvider, StringComparison.OrdinalIgnoreCase));
         claims.Add(new Claim(ClaimTypes.Name, clientPrincipal.UserDetails));
         claims.Add(new Claim(ClaimTypes.NameIdentifier, headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader]));
         claims.Add(new Claim("sub", headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader]));
+
+        if (!string.IsNullOrEmpty(clientPrincipal.IdentityProvider))
+        {
+            claims.Add(new Claim(MicrosoftIdentityPlatformClaims.IdentityProvider, clientPrincipal.IdentityProvider));
+        }
+
         claims.AddRange(clientPrincipal.UserRoles.Select(role => new Claim(ClaimTypes.Role, role)));
 
         var identity = new ClaimsIdentity(claims, nameof(MicrosoftIdentityPlatformAuthenticationHandler));

--- a/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformClaims.cs
+++ b/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformClaims.cs
@@ -8,11 +8,31 @@ namespace Cratis.Arc.Identity;
 /// the Microsoft Identity Platform headers.
 /// </summary>
 /// <remarks>
-/// A reserved claim type is written exclusively by Arc from the forwarded <see cref="ClientPrincipal"/>.
-/// Any claim of a reserved type that is already present in the serialized principal is removed, ignoring casing,
-/// before Arc writes its own value, so a caller able to reach the application cannot forge this metadata.
+/// <para>
+/// A reserved claim type is written exclusively by Arc from the forwarded <see cref="ClientPrincipal"/>. Any claim
+/// of a reserved type already present in the serialized principal is removed, ignoring casing, before Arc writes
+/// its own value. What that buys is single provenance, not authenticity: the claim carries exactly one value and
+/// that value always comes from the same field of the forwarded principal, so a claim of the reserved type passed
+/// through by the ingress or by the identity provider can never displace it.
+/// </para>
+/// <para>
+/// It does not make the value trustworthy. The <c>x-ms-client-principal</c> header is base64, not a signature, and
+/// Arc does not check who sent it, so any caller that can reach the application can author the entire serialized
+/// principal - including the field Arc reads. Trust this claim exactly as far as you trust that header: only
+/// insofar as your ingress is the only thing that can set it. Arc's own contribution is that there is one value
+/// with one provenance to reason about instead of several with unknown ones.
+/// </para>
+/// <para>
+/// Read reserved claims with <c>ClaimsPrincipal.FindFirst</c> or <c>ClaimsPrincipal.FindAll</c>, and never
+/// normalize the claim type yourself. Those lookups compare the way the removal above does, so what they return is
+/// exactly what Arc wrote. Enumerating the claims and folding types with <c>ToUpperInvariant</c> or <c>Trim</c>
+/// widens the match beyond what was removed - a forged type that differs only by Unicode case folding or trailing
+/// whitespace then matches, and it precedes Arc's claim in the list.
+/// </para>
+/// <para>
 /// Claim types outside this set are copied through untouched, including the canonical identity claims the
 /// producing ingress reserves for itself under <c>urn:cratis:identity:</c>.
+/// </para>
 /// </remarks>
 public static class MicrosoftIdentityPlatformClaims
 {
@@ -21,10 +41,15 @@ public static class MicrosoftIdentityPlatformClaims
     /// taken from <see cref="ClientPrincipal.IdentityProvider"/>.
     /// </summary>
     /// <remarks>
-    /// The value is the exact authentication scheme metadata the ingress forwarded. It is typically derived from a
-    /// provider display name and is therefore descriptive rather than stable - do not treat it as a durable provider
-    /// registration key, and do not use it as an identity or membership key. The claim is absent when the forwarded
-    /// principal carries no identity provider.
+    /// The value is the exact <c>identityProvider</c> field the ingress forwarded, verbatim and untrimmed - Arc
+    /// neither interprets nor normalizes it. What it means is therefore the ingress's choice rather than Arc's:
+    /// Cratis AuthProxy forwards the canonical provider key, the same value it publishes as its own
+    /// <c>urn:cratis:identity:provider-key</c> claim, while another ingress may forward an authentication scheme
+    /// name or a provider display name that changes when the provider is renamed. Arc guarantees neither, so treat
+    /// this claim as metadata for telling federations apart, for diagnostics, and for provider-aware behavior. A
+    /// consumer that needs a durable provider key should read the claim the ingress publishes for that purpose -
+    /// <c>urn:cratis:identity:provider-key</c> in an AuthProxy deployment - instead of this one. The claim is
+    /// absent when the forwarded principal carries no identity provider, or only blank characters.
     /// </remarks>
     public const string IdentityProvider = "urn:cratis:arc:identity:provider";
 }

--- a/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformClaims.cs
+++ b/Source/DotNET/Arc.Core/Identity/MicrosoftIdentityPlatformClaims.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Identity;
+
+/// <summary>
+/// Claim types reserved by Arc for metadata it authors itself while reconstructing a principal from
+/// the Microsoft Identity Platform headers.
+/// </summary>
+/// <remarks>
+/// A reserved claim type is written exclusively by Arc from the forwarded <see cref="ClientPrincipal"/>.
+/// Any claim of a reserved type that is already present in the serialized principal is removed, ignoring casing,
+/// before Arc writes its own value, so a caller able to reach the application cannot forge this metadata.
+/// Claim types outside this set are copied through untouched, including the canonical identity claims the
+/// producing ingress reserves for itself under <c>urn:cratis:identity:</c>.
+/// </remarks>
+public static class MicrosoftIdentityPlatformClaims
+{
+    /// <summary>
+    /// The claim type carrying the identity provider that the ingress authenticated the caller with,
+    /// taken from <see cref="ClientPrincipal.IdentityProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// The value is the exact authentication scheme metadata the ingress forwarded. It is typically derived from a
+    /// provider display name and is therefore descriptive rather than stable - do not treat it as a durable provider
+    /// registration key, and do not use it as an identity or membership key. The claim is absent when the forwarded
+    /// principal carries no identity provider.
+    /// </remarks>
+    public const string IdentityProvider = "urn:cratis:arc:identity:provider";
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/given/a_handler.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/given/a_handler.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.given;
+
+public class a_handler : Specification
+{
+    protected const string IdentityIdFromHeader = "identity-id-from-header";
+    protected const string IdentityNameFromHeader = "identity-name-from-header";
+    protected const string UserDetails = "user@example.com";
+    protected const string BenignClaimType = "email";
+    protected const string BenignClaimValue = "user@example.com";
+    protected const string IngressProviderKeyClaimType = "urn:cratis:identity:provider-key";
+    protected const string IngressProviderKeyClaimValue = "workforce";
+
+    protected IServiceProvider _services;
+
+    void Establish() =>
+        _services = new ServiceCollection()
+            .AddSingleton(Options.Create(new ArcOptions()))
+            .BuildServiceProvider();
+
+    /// <summary>
+    /// Runs one authentication through a freshly initialized handler, with the principal header holding the exact
+    /// base64 encoded JSON wire shape the ingress forwards.
+    /// </summary>
+    /// <param name="identityProvider">The value of the <c>identityProvider</c> field, or null to omit the field entirely.</param>
+    /// <param name="claims">The claims to put in the serialized principal.</param>
+    /// <returns>The <see cref="AuthenticateResult"/> from the handler.</returns>
+    protected async Task<AuthenticateResult> Authenticate(string? identityProvider, params (string Type, string Value)[] claims)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = _services };
+        httpContext.Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader] = IdentityIdFromHeader;
+        httpContext.Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityNameHeader] = IdentityNameFromHeader;
+        httpContext.Request.Headers[MicrosoftIdentityPlatformHeaders.PrincipalHeader] = PrincipalHeaderValue(identityProvider, claims);
+
+        var schemeOptions = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        schemeOptions.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+
+        var handler = new MicrosoftIDentityPlatformAuthHandler(schemeOptions, NullLoggerFactory.Instance, UrlEncoder.Default);
+        await handler.InitializeAsync(
+            new AuthenticationScheme(
+                MicrosoftIDentityPlatformAuthHandler.SchemeName,
+                null,
+                typeof(MicrosoftIDentityPlatformAuthHandler)),
+            httpContext);
+
+        return await handler.AuthenticateAsync();
+    }
+
+    /// <summary>
+    /// Serializes the principal exactly the way the ingress does - camel cased field names, claims as typ/val pairs -
+    /// so the specs pin the wire contract rather than whatever Arc's own serializer options happen to produce.
+    /// </summary>
+    /// <param name="identityProvider">The value of the <c>identityProvider</c> field, or null to omit the field entirely.</param>
+    /// <param name="claims">The claims to put in the serialized principal.</param>
+    /// <returns>The base64 encoded principal header value.</returns>
+    protected static string PrincipalHeaderValue(string? identityProvider, params (string Type, string Value)[] claims)
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["userId"] = "provider-user-id",
+            ["userDetails"] = UserDetails,
+            ["userRoles"] = new[] { "authenticated" },
+            ["claims"] = claims.Select(claim => new { typ = claim.Type, val = claim.Value }).ToArray()
+        };
+
+        if (identityProvider is not null)
+        {
+            payload["identityProvider"] = identityProvider;
+        }
+
+        return Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(payload));
+    }
+
+    protected static string[] IdentityProviderClaimsFrom(AuthenticateResult result) =>
+        [.. result.Principal!.FindAll(MicrosoftIdentityPlatformClaims.IdentityProvider).Select(claim => claim.Value)];
+
+    protected static string[] ClaimValuesFrom(AuthenticateResult result, string claimType) =>
+        [.. result.Principal!.FindAll(claimType).Select(claim => claim.Value)];
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/given/a_handler.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/given/a_handler.cs
@@ -86,4 +86,24 @@ public class a_handler : Specification
 
     protected static string[] ClaimValuesFrom(AuthenticateResult result, string claimType) =>
         [.. result.Principal!.FindAll(claimType).Select(claim => claim.Value)];
+
+    /// <summary>
+    /// Enumerates the reconstructed principal the way a consumer that normalizes the claim type itself would - upper
+    /// casing before comparing, instead of going through FindFirst/FindAll.
+    /// </summary>
+    /// <param name="result">The <see cref="AuthenticateResult"/> to read the claims from.</param>
+    /// <returns>The values of the matching claims, in the order they sit on the principal.</returns>
+    /// <remarks>
+    /// The handler strips with OrdinalIgnoreCase and FindFirst/FindAll match with OrdinalIgnoreCase, so every other
+    /// helper here shares the blind spot of the guard it observes and can never see a claim type the strip missed.
+    /// This one deliberately compares differently, so a survivor is observable and the documented "never normalize
+    /// the claim type yourself" warning is pinned by something that fails when it stops being true.
+    /// </remarks>
+    protected static string[] ClaimValuesNormalizedWithUpperInvariant(AuthenticateResult result) =>
+        [.. result.Principal!.Claims
+            .Where(claim => string.Equals(
+                claim.Type.ToUpperInvariant(),
+                MicrosoftIdentityPlatformClaims.IdentityProvider.ToUpperInvariant(),
+                StringComparison.Ordinal))
+            .Select(claim => claim.Value)];
 }

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_differs_only_by_unicode_case_folding.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_differs_only_by_unicode_case_folding.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+/// <summary>
+/// Pins the boundary of the strip, and with it the documented rule that a consumer must read reserved claims with
+/// FindFirst/FindAll and never normalize the claim type itself.
+/// </summary>
+/// <remarks>
+/// The handler strips with OrdinalIgnoreCase and FindFirst/FindAll match with OrdinalIgnoreCase, so a claim type
+/// those two agree is different both survives the strip and stays invisible to the documented lookup - every
+/// assertion that observes through FindAll shares the guard's blind spot by construction. The last two assertions
+/// therefore observe with a different comparison, which is the only way this suite can show what the warning in the
+/// documentation is about. They describe a known limitation rather than a desirable property: if the strip is ever
+/// widened to fold Unicode casing, they fail, and the documentation must be corrected in the same change.
+/// </remarks>
+public class and_the_colliding_claim_differs_only_by_unicode_case_folding : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    /// <summary>
+    /// The reserved type with U+017F LATIN SMALL LETTER LONG S in place of the <c>s</c> of <c>cratis</c>.
+    /// </summary>
+    /// <remarks>
+    /// OrdinalIgnoreCase says this is a different claim type, so it is neither stripped nor found by FindAll.
+    /// ToUpperInvariant folds it to the same string as the reserved type, so a consumer that upper cases the type
+    /// before comparing does match it - and forwarded claims are added before Arc writes its own, so that consumer
+    /// meets the forgery first.
+    /// </remarks>
+    const string LongSClaimType = "urn:cratiſ:arc:identity:provider";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        IdentityProviderFromIngress,
+        (LongSClaimType, ForgedIdentityProvider),
+        (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_only_the_ingress_identity_provider_through_the_documented_lookup() => IdentityProviderClaimsFrom(_result).ShouldContainOnly(IdentityProviderFromIngress);
+    [Fact] void should_leave_the_unicode_variant_as_a_claim_type_of_its_own() => ClaimValuesFrom(_result, LongSClaimType).ShouldContainOnly(ForgedIdentityProvider);
+    [Fact] void should_match_both_claims_for_a_consumer_that_upper_cases_the_claim_type() => ClaimValuesNormalizedWithUpperInvariant(_result).Length.ShouldEqual(2);
+    [Fact] void should_put_the_forgery_first_for_a_consumer_that_upper_cases_the_claim_type() => ClaimValuesNormalizedWithUpperInvariant(_result)[0].ShouldEqual(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_only_differs_in_casing.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_only_differs_in_casing.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_colliding_claim_only_differs_in_casing : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string CaseVariedClaimType = "URN:CRATIS:ARC:Identity:Provider";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        IdentityProviderFromIngress,
+        (CaseVariedClaimType, ForgedIdentityProvider),
+        (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+    [Fact] void should_strip_the_case_varied_forgery() => IdentityProviderClaimsFrom(_result).ShouldNotContain(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_uses_the_published_wire_literal.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_colliding_claim_uses_the_published_wire_literal.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_colliding_claim_uses_the_published_wire_literal : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    /// <summary>
+    /// Spelled out here instead of taken from <see cref="MicrosoftIdentityPlatformClaims"/> on purpose.
+    /// </summary>
+    /// <remarks>
+    /// That constant is a <c>public const</c>, so it is inlined into every consumer at compile time - this literal,
+    /// not the constant, is what the documentation publishes and what an already built consumer keeps looking for.
+    /// Every other assertion in this suite routes through the constant, so without the arm below a rename of it
+    /// would leave the whole suite green while turning the published literal into an unstripped, caller controlled
+    /// claim type carried on an authenticated principal.
+    /// </remarks>
+    const string PublishedClaimType = "urn:cratis:arc:identity:provider";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        IdentityProviderFromIngress,
+        (PublishedClaimType, ForgedIdentityProvider),
+        (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_publish_the_documented_wire_claim_type() => MicrosoftIdentityPlatformClaims.IdentityProvider.ShouldEqual("urn:cratis:arc:identity:provider");
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_strip_the_forgery_from_the_published_claim_type() => ClaimValuesFrom(_result, PublishedClaimType).ShouldNotContain(ForgedIdentityProvider);
+    [Fact] void should_expose_the_ingress_identity_provider_under_the_published_claim_type() => ClaimValuesFrom(_result, PublishedClaimType).ShouldContainOnly(IdentityProviderFromIngress);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_identity_provider_is_blank.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_identity_provider_is_blank.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+/// <summary>
+/// A blank but present claim is worse for a consumer than an absent one - a null check passes and the value is
+/// meaningless - so a forwarded field holding nothing but whitespace must produce no claim at all, exactly as an
+/// empty or omitted field does.
+/// </summary>
+public class and_the_identity_provider_is_blank : given.a_handler
+{
+    const string EmptyIdentityProvider = "";
+    const string SpacesOnlyIdentityProvider = "   ";
+    const string TabAndNewlineIdentityProvider = "\t\n";
+
+    AuthenticateResult _empty;
+    AuthenticateResult _spacesOnly;
+    AuthenticateResult _tabAndNewline;
+
+    async Task Because()
+    {
+        _empty = await Authenticate(EmptyIdentityProvider, (BenignClaimType, BenignClaimValue));
+        _spacesOnly = await Authenticate(SpacesOnlyIdentityProvider, (BenignClaimType, BenignClaimValue));
+        _tabAndNewline = await Authenticate(TabAndNewlineIdentityProvider, (BenignClaimType, BenignClaimValue));
+    }
+
+    [Fact] void should_authenticate_the_principal_with_an_empty_identity_provider() => _empty.Succeeded.ShouldBeTrue();
+    [Fact] void should_authenticate_the_principal_with_a_spaces_only_identity_provider() => _spacesOnly.Succeeded.ShouldBeTrue();
+    [Fact] void should_authenticate_the_principal_with_a_tab_and_newline_identity_provider() => _tabAndNewline.Succeeded.ShouldBeTrue();
+    [Fact] void should_not_expose_an_identity_provider_for_the_empty_field() => IdentityProviderClaimsFrom(_empty).ShouldBeEmpty();
+    [Fact] void should_not_expose_an_identity_provider_for_the_spaces_only_field() => IdentityProviderClaimsFrom(_spacesOnly).ShouldBeEmpty();
+    [Fact] void should_not_expose_an_identity_provider_for_the_tab_and_newline_field() => IdentityProviderClaimsFrom(_tabAndNewline).ShouldBeEmpty();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_spacesOnly, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_identity_provider_is_padded_with_whitespace.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_identity_provider_is_padded_with_whitespace.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+/// <summary>
+/// The blank guard rejects a field that is nothing but whitespace - it does not trim one that merely carries some.
+/// </summary>
+/// <remarks>
+/// This is the control for <c>and_the_identity_provider_is_blank</c>: without it, a handler that stopped writing the
+/// claim altogether would satisfy every "should not expose" assertion there. It also pins the documented promise that
+/// the value is the forwarded field verbatim, which a well meaning <c>Trim()</c> would silently break.
+/// </remarks>
+public class and_the_identity_provider_is_padded_with_whitespace : given.a_handler
+{
+    const string PaddedIdentityProvider = "  aad  ";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(PaddedIdentityProvider, (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_forwarded_value_including_its_padding() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(PaddedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_carries_a_colliding_identity_provider_claim.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_carries_a_colliding_identity_provider_claim.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_carries_a_colliding_identity_provider_claim : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        IdentityProviderFromIngress,
+        (MicrosoftIdentityPlatformClaims.IdentityProvider, ForgedIdentityProvider),
+        (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+    [Fact] void should_strip_the_forged_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldNotContain(ForgedIdentityProvider);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_carries_the_ingress_authored_provider_key_claim : given.a_handler
+{
+    const string IdentityProviderFromIngress = "aad";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        IdentityProviderFromIngress,
+        (IngressProviderKeyClaimType, IngressProviderKeyClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_leave_the_provider_key_claim_the_ingress_authored_untouched() => ClaimValuesFrom(_result, IngressProviderKeyClaimType).ShouldContainOnly(IngressProviderKeyClaimValue);
+    [Fact] void should_expose_exactly_one_identity_provider() => IdentityProviderClaimsFrom(_result).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_identity_provider_the_ingress_supplied() => IdentityProviderClaimsFrom(_result)[0].ShouldEqual(IdentityProviderFromIngress);
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_has_no_identity_provider : given.a_handler
+{
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(null, (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_not_expose_an_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_the_serialized_principal_has_no_identity_provider_but_a_colliding_claim : given.a_handler
+{
+    const string ForgedIdentityProvider = "forged-by-the-caller";
+
+    AuthenticateResult _result;
+
+    async Task Because() => _result = await Authenticate(
+        null,
+        (MicrosoftIdentityPlatformClaims.IdentityProvider, ForgedIdentityProvider),
+        (BenignClaimType, BenignClaimValue));
+
+    [Fact] void should_authenticate() => _result.Succeeded.ShouldBeTrue();
+    [Fact] void should_keep_the_unrelated_claim() => ClaimValuesFrom(_result, BenignClaimType).ShouldContainOnly(BenignClaimValue);
+    [Fact] void should_not_expose_an_identity_provider() => IdentityProviderClaimsFrom(_result).ShouldBeEmpty();
+}

--- a/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_two_principals_differ_only_by_identity_provider.cs
+++ b/Source/DotNET/Arc.Specs/Identity/for_MicrosoftIDentityPlatformAuthHandler/when_handling_authentication/and_two_principals_differ_only_by_identity_provider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Authentication;
+
+namespace Cratis.Arc.Identity.for_MicrosoftIDentityPlatformAuthHandler.when_handling_authentication;
+
+public class and_two_principals_differ_only_by_identity_provider : given.a_handler
+{
+    const string FirstIdentityProvider = "aad";
+    const string SecondIdentityProvider = "github";
+
+    AuthenticateResult _first;
+    AuthenticateResult _second;
+
+    async Task Because()
+    {
+        _first = await Authenticate(FirstIdentityProvider);
+        _second = await Authenticate(SecondIdentityProvider);
+    }
+
+    [Fact] void should_authenticate_the_first_principal() => _first.Succeeded.ShouldBeTrue();
+    [Fact] void should_authenticate_the_second_principal() => _second.Succeeded.ShouldBeTrue();
+    [Fact] void should_expose_exactly_one_identity_provider_for_the_first_principal() => IdentityProviderClaimsFrom(_first).Length.ShouldEqual(1);
+    [Fact] void should_expose_exactly_one_identity_provider_for_the_second_principal() => IdentityProviderClaimsFrom(_second).Length.ShouldEqual(1);
+    [Fact] void should_expose_the_exact_first_identity_provider() => IdentityProviderClaimsFrom(_first)[0].ShouldEqual(FirstIdentityProvider);
+    [Fact] void should_expose_the_exact_second_identity_provider() => IdentityProviderClaimsFrom(_second)[0].ShouldEqual(SecondIdentityProvider);
+    [Fact] void should_keep_the_identity_id_from_the_header() => ClaimValuesFrom(_first, "sub")[0].ShouldEqual(IdentityIdFromHeader);
+    [Fact] void should_keep_the_authentication_type_as_the_scheme_name() => _first.Principal!.Identity!.AuthenticationType.ShouldEqual(MicrosoftIDentityPlatformAuthHandler.SchemeName);
+}

--- a/Source/DotNET/Arc/Identity/MicrosoftIDentityPlatformAuthHandler.cs
+++ b/Source/DotNET/Arc/Identity/MicrosoftIDentityPlatformAuthHandler.cs
@@ -55,10 +55,19 @@ public class MicrosoftIDentityPlatformAuthHandler(
 
         var claims = clientPrincipal.GetClaims().ToList();
 
-        claims.RemoveAll(claim => claim.Type == ClaimTypes.NameIdentifier || claim.Type == "sub");
+        claims.RemoveAll(claim =>
+            claim.Type == ClaimTypes.NameIdentifier ||
+            claim.Type == "sub" ||
+            claim.Type.Equals(MicrosoftIdentityPlatformClaims.IdentityProvider, StringComparison.OrdinalIgnoreCase));
         claims.Add(new Claim(ClaimTypes.Name, clientPrincipal.UserDetails));
         claims.Add(new Claim(ClaimTypes.NameIdentifier, Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader].ToString()));
         claims.Add(new Claim("sub", Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader].ToString()));
+
+        if (!string.IsNullOrEmpty(clientPrincipal.IdentityProvider))
+        {
+            claims.Add(new Claim(MicrosoftIdentityPlatformClaims.IdentityProvider, clientPrincipal.IdentityProvider));
+        }
+
         claims.AddRange(clientPrincipal.UserRoles.Select(_ => new Claim(ClaimTypes.Role, _)));
 
         var identity = new ClaimsIdentity(claims, Scheme.Name);

--- a/Source/DotNET/Arc/Identity/MicrosoftIDentityPlatformAuthHandler.cs
+++ b/Source/DotNET/Arc/Identity/MicrosoftIDentityPlatformAuthHandler.cs
@@ -63,7 +63,7 @@ public class MicrosoftIDentityPlatformAuthHandler(
         claims.Add(new Claim(ClaimTypes.NameIdentifier, Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader].ToString()));
         claims.Add(new Claim("sub", Request.Headers[MicrosoftIdentityPlatformHeaders.IdentityIdHeader].ToString()));
 
-        if (!string.IsNullOrEmpty(clientPrincipal.IdentityProvider))
+        if (!string.IsNullOrWhiteSpace(clientPrincipal.IdentityProvider))
         {
             claims.Add(new Claim(MicrosoftIdentityPlatformClaims.IdentityProvider, clientPrincipal.IdentityProvider));
         }


### PR DESCRIPTION
## Added

- The identity provider the ingress authenticated a caller with is carried on the authenticated principal as a reserved claim, available to the identity details an application provides (#2501)
