### PR TITLE
Read a scenario's values through the project that declares them

### DIFF
--- a/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
@@ -20,7 +20,9 @@ namespace Cratis.Arc.Screenplay.EndToEnd;
 /// construction. Two shipped that way.
 /// <para>
 /// A solution is read as every project it holds that could hold part of the application, which is what an application
-/// written as several projects really is. Whether a project could is asked of what it can see rather than of what it
+/// written as several projects really is. A single project is read the same way, because opening one opens everything
+/// it references too - an application is no less written as several projects for having been named by its topmost one.
+/// Whether a project could hold part of it is asked of what it can see rather than of what it
 /// is called: an artifact is declared with an attribute the framework ships, so a project resolving neither the Arc
 /// nor the Chronicle one cannot declare a single thing the document is made of. A Roslyn analyzer beside the
 /// application is exactly that project, and reading its <c>netstandard2.0</c> compilation in as though it were part
@@ -69,11 +71,18 @@ public static class ProjectCompilation
         Array.Exists(_solutions, extension => string.Equals(Path.GetExtension(path), extension, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// Loads a single project.
+    /// Loads a single project, and every project it references.
     /// </summary>
     /// <param name="path">The full path of the project file.</param>
     /// <param name="failures">Everything the workspace reported while loading.</param>
-    /// <returns>The compilation, empty when the project yielded none.</returns>
+    /// <returns>The compilations, empty when nothing yielded one.</returns>
+    /// <remarks>
+    /// Opening a project opens everything it references along with it, and wires each one in as the compilation the
+    /// workspace built rather than as an assembly on disk. A type a referenced project declares is therefore a type
+    /// with source behind it, and that source belongs to a compilation of its own - so handing over only the project
+    /// that was named leaves every one of those declarations unreadable while looking exactly like an application
+    /// that has none. What the workspace already built is handed over instead.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
     static async Task<IReadOnlyList<Compilation>> LoadProject(string path, ICollection<string> failures)
     {
@@ -83,7 +92,7 @@ public static class ProjectCompilation
 
         var project = await workspace.OpenProjectAsync(path);
 
-        return await project.GetCompilationAsync() is { } compilation ? [compilation] : [];
+        return await CompilationsOf(project.Solution);
     }
 
     /// <summary>
@@ -99,7 +108,16 @@ public static class ProjectCompilation
         using var workspace = MSBuildWorkspace.Create();
         using var subscription = workspace.RegisterWorkspaceFailedHandler(args => Report(args, reported, failures));
 
-        var solution = await workspace.OpenSolutionAsync(path);
+        return await CompilationsOf(await workspace.OpenSolutionAsync(path));
+    }
+
+    /// <summary>
+    /// Gets the compilation of every loaded project that holds part of the application.
+    /// </summary>
+    /// <param name="solution">The projects the workspace loaded.</param>
+    /// <returns>The compilations, ordered by the name of the project each one came from.</returns>
+    static async Task<IReadOnlyList<Compilation>> CompilationsOf(Solution solution)
+    {
         var compilations = new List<Compilation>();
 
         foreach (var project in solution.Projects

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_scenario_stating_an_identity_a_sibling_project_declares.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing_the_projects_of_an_application/a_scenario_stating_an_identity_a_sibling_project_declares.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing_the_projects_of_an_application;
+
+/// <summary>
+/// A value a scenario states is followed back to the member holding it, and the project declaring that member is not
+/// the project the scenario is written in - a well known identity, a sentinel or a member of an enumeration lives in
+/// the contracts project below the handlers, which is where an application really puts them.
+/// </summary>
+/// <remarks>
+/// A project reference is handed to the analyzer as the compilation the workspace built rather than as an assembly on
+/// disk, so the member is a symbol with real source behind it and that source belongs to another compilation.
+/// Reading it through the compilation of the project doing the naming is not a wrong answer but a crash, which is why
+/// every body is read through the models of the whole application.
+/// <para>
+/// Not crashing is the smaller half of this. Reading the declaration through the project that actually holds it is
+/// what lets the identity still be recognized as one made on the spot, and therefore still be left out of the
+/// document rather than reported as a value nothing was recovered from - so the assertions are about the values, and
+/// a guard that merely declined to read across the boundary would fail them.
+/// </para>
+/// </remarks>
+public class a_scenario_stating_an_identity_a_sibling_project_declares : Specification
+{
+    const string Contracts = """
+        using System;
+        using Cratis.Chronicle.Events;
+        using Cratis.Concepts;
+
+        namespace Library.Authors.Registration;
+
+        public record AuthorId(Guid Value) : ConceptAs<Guid>(Value)
+        {
+            public static AuthorId New() => new(Guid.NewGuid());
+
+            public static implicit operator Guid(AuthorId id) => id.Value;
+        }
+
+        public static class KnownAuthors
+        {
+            public static readonly AuthorId Jane = AuthorId.New();
+        }
+
+        [EventType]
+        public record AuthorRegistered(AuthorId Id, string Name);
+        """;
+
+    const string Slice = """
+        using Cratis.Arc.Commands.ModelBound;
+
+        namespace Library.Authors.Registration;
+
+        [Command]
+        public record RegisterAuthor(AuthorId Id, string Name)
+        {
+            public AuthorRegistered Handle() => new(Id, Name);
+        }
+        """;
+
+    const string Scenario = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Testing.Commands;
+        using Cratis.Chronicle.Testing.EventSequences;
+        using Library.Authors.Registration;
+        using Xunit;
+
+        namespace Library.Authors.Registration.when_registering;
+
+        public class and_the_author_was_registered_before
+        {
+            readonly CommandScenario<RegisterAuthor> _scenario = new();
+            Result _result = null!;
+
+            void Establish() => _scenario.Given.ForEventSource("author").Events(new AuthorRegistered(KnownAuthors.Jane, "Jane Austen"));
+
+            async Task Because() => _result = await _scenario.Execute(new RegisterAuthor(KnownAuthors.Jane, "Mary Shelley"));
+
+            [Fact] void should_not_succeed() => _result.ShouldNotBeSuccessful();
+        }
+        """;
+
+    Compilation _contracts;
+    Compilation _application;
+    ApplicationModelAnalysis _analysis;
+    SpecificationModel _specification;
+
+    void Establish()
+    {
+        _contracts = Analyzed.Project(
+            "Library.Contracts",
+            [],
+            ("Source/Library.Contracts/Contracts.cs", "namespace Library;"),
+            ("Source/Library.Contracts/Authors/Registration/Registration.cs", Contracts));
+
+        _application = Analyzed.Project(
+            "Library",
+            [_contracts.ToMetadataReference()],
+            ("Source/Library/Program.cs", "namespace Library;"),
+            ("Source/Library/Authors/Registration/Registration.cs", Slice),
+            ("Source/Library/Authors/Registration/when_registering/and_the_author_was_registered_before.cs", Scenario),
+            ("Source/Library/Testing/IntegrationTesting.cs", IntegrationTesting.Source));
+    }
+
+    void Because()
+    {
+        _analysis = Analyzed.Projects(_application, _contracts);
+        _specification = _analysis.Model.Slices.Single(_ => _.Name == "Registration").Specifications.Single();
+    }
+
+    [Fact] void should_compile_the_contracts_project() => Analyzed.ErrorsIn(_contracts).ShouldBeEmpty();
+    [Fact] void should_compile_the_application_project() => Analyzed.ErrorsIn(_application).ShouldBeEmpty();
+    [Fact] void should_state_the_values_of_what_it_starts_from() => _specification.Given.Single().Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Jane Austen"))]);
+    [Fact] void should_state_the_values_the_command_was_issued_with() => _specification.When.Values.ShouldContainOnly([new PropertyMappingModel("Name", new LiteralSource("Mary Shelley"))]);
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
+++ b/Source/DotNET/Screenplay/Analysis/ArtifactReaders.cs
@@ -92,34 +92,33 @@ public class ArtifactReaders
     /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
     /// <returns>The <see cref="ArtifactReaders"/>.</returns>
     public static ArtifactReaders For(Compilation compilation, ArtifactCatalog catalog, ScreenplayDiagnostics diagnostics) =>
-        For(compilation, catalog, SourcePaths.For(compilation, catalog), WholeApplication.Of(compilation, diagnostics));
+        For(catalog, SourcePaths.For(compilation, catalog), WholeApplication.Of(compilation, diagnostics));
 
     /// <summary>
     /// Composes every reader for one project of an application, sharing what belongs to the application as a whole.
     /// </summary>
-    /// <param name="compilation">The compilation being analyzed.</param>
     /// <param name="catalog">The catalogue of everything the compilation declares.</param>
     /// <param name="paths">The <see cref="SourcePaths"/> the paths of this project are written relative to.</param>
     /// <param name="whole">What the application as a whole holds.</param>
     /// <returns>The <see cref="ArtifactReaders"/>.</returns>
     /// <remarks>
-    /// A concept is declared once at the top of a document however many projects refer to it, an aggregate root one
-    /// project declares is handed its work by a command another project may hold, and the body of that aggregate
-    /// root's behavior is read through the project it was written in rather than the one calling it. Everything else
-    /// here reads a declaration the project itself catalogued, which is why there is a set of readers per project at
-    /// all.
+    /// A concept is declared once at the top of a document however many projects refer to it, and an aggregate root
+    /// one project declares is handed its work by a command another project may hold. Which declarations are read is
+    /// decided by the catalogue of this project, because a type is declared where it is written - but every body
+    /// reached from one of them is read through the models of the whole application, because a declaration reached
+    /// from another declaration is under no obligation to have been written beside it.
     /// </remarks>
     public static ArtifactReaders For(
-        Compilation compilation,
         ArtifactCatalog catalog,
         SourcePaths paths,
         WholeApplication whole)
     {
         var types = whole.Types;
+        var models = whole.Models;
         var diagnostics = whole.Diagnostics;
         var properties = new PropertyReader(types);
-        var produces = new ProducesReader(whole.Models, whole.AggregateRoots, diagnostics);
-        var validators = ValidatorCatalog.From(catalog, new(compilation, diagnostics));
+        var produces = new ProducesReader(models, whole.AggregateRoots, diagnostics);
+        var validators = ValidatorCatalog.From(catalog, new(models, diagnostics));
 
         return new(
             types,
@@ -130,9 +129,9 @@ public class ArtifactReaders
             new ControllerCommandReader(types, properties, produces, validators, paths),
             new QueryReader(types, diagnostics),
             new ModelBoundProjectionReader(diagnostics),
-            new FluentProjectionReader(compilation, diagnostics),
+            new FluentProjectionReader(models, diagnostics),
             new ReducerReader(diagnostics),
-            new ReactorReader(compilation, paths),
-            new ConstraintReader(compilation, paths, diagnostics));
+            new ReactorReader(models, paths),
+            new ConstraintReader(models, paths, diagnostics));
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/CompilationAnalysis.cs
+++ b/Source/DotNET/Screenplay/Analysis/CompilationAnalysis.cs
@@ -24,12 +24,14 @@ public class CompilationAnalysis
     readonly ArtifactCatalog _catalog;
     readonly ArtifactReaders _readers;
     readonly RecoveredArtifacts _recovered;
+    readonly SemanticModels _models;
 
     CompilationAnalysis(
         Compilation compilation,
         ArtifactCatalog catalog,
         ArtifactReaders readers,
         RecoveredArtifacts recovered,
+        SemanticModels models,
         IReadOnlyList<SliceModel> slices)
     {
         Compilation = compilation;
@@ -37,6 +39,7 @@ public class CompilationAnalysis
         _catalog = catalog;
         _readers = readers;
         _recovered = recovered;
+        _models = models;
     }
 
     /// <summary>
@@ -64,7 +67,7 @@ public class CompilationAnalysis
         WholeApplication whole)
     {
         var diagnostics = whole.Diagnostics;
-        var readers = ArtifactReaders.For(compilation, catalog, paths, whole);
+        var readers = ArtifactReaders.For(catalog, paths, whole);
         var screens = new ScreenReader(
             whole.Files,
             paths,
@@ -80,7 +83,7 @@ public class CompilationAnalysis
             .OfType<SliceModel>()
             .ToList();
 
-        return new(compilation, catalog, readers, recovered, slices);
+        return new(compilation, catalog, readers, recovered, whole.Models, slices);
     }
 
     /// <summary>
@@ -94,7 +97,7 @@ public class CompilationAnalysis
     /// that declares a slice - and the project declaring that slice need not be the one the scenario is written in.
     /// </remarks>
     public SpecificationCatalog Specifications(IEnumerable<string> slices, ScreenplayDiagnostics diagnostics) =>
-        SpecificationCatalog.Read(Compilation, _catalog, slices, diagnostics);
+        SpecificationCatalog.Read(_models, _catalog, slices, diagnostics);
 
     /// <summary>
     /// Attaches the rules the validators of this project declare to the concepts they validate.

--- a/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Constraints/ConstraintReader.cs
@@ -11,14 +11,18 @@ namespace Cratis.Arc.Screenplay.Analysis.Constraints;
 /// <summary>
 /// Reads the constraints a slice declares, in both shapes an application can write them.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every defining method is read through.</param>
 /// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each constraint lives in.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Screenplay knows exactly two rules - a property of an event has to be unique, and an event may occur once. A
 /// rule declared in code that says anything else is pointed at rather than described as something it is not.
+/// <para>
+/// A rule whose defining method belongs to a project that was not handed over is a rule nothing can be read from, so
+/// the file holding it is pointed at exactly as one saying something unmappable is.
+/// </para>
 /// </remarks>
-public class ConstraintReader(Compilation compilation, SourcePaths paths, ScreenplayDiagnostics diagnostics)
+public class ConstraintReader(SemanticModels models, SourcePaths paths, ScreenplayDiagnostics diagnostics)
 {
     /// <summary>
     /// The call declaring a uniqueness rule.
@@ -97,7 +101,10 @@ public class ConstraintReader(Compilation compilation, SourcePaths paths, Screen
     /// <param name="declared">The constraints collected so far.</param>
     void ReadDeclaration(INamedTypeSymbol type, SyntaxNode declaration, string location, List<ConstraintModel> declared)
     {
-        var semanticModel = compilation.GetSemanticModel(declaration.SyntaxTree);
+        if (models.For(declaration.SyntaxTree) is not { } semanticModel)
+        {
+            return;
+        }
 
         foreach (var invocation in declaration.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {

--- a/Source/DotNET/Screenplay/Analysis/Projections/FluentProjectionReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/FluentProjectionReader.cs
@@ -10,13 +10,17 @@ namespace Cratis.Arc.Screenplay.Analysis.Projections;
 /// <summary>
 /// Reads the projection a type declares by defining it against a builder.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every defining method is read through.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Reading the chain from the source is what makes a fluent projection expressible at all - at runtime it is an
 /// expression tree that has already been compiled down to something a document cannot be recovered from.
+/// <para>
+/// A projection defined in a base a project below it declares is written wherever that base is, so which model reads
+/// a body is asked rather than assumed.
+/// </para>
 /// </remarks>
-public class FluentProjectionReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class FluentProjectionReader(SemanticModels models, ScreenplayDiagnostics diagnostics)
 {
     /// <summary>
     /// The method a projection is defined in.
@@ -53,7 +57,10 @@ public class FluentProjectionReader(Compilation compilation, ScreenplayDiagnosti
 
         foreach (var body in Bodies(type))
         {
-            _scopes.Read(body, compilation.GetSemanticModel(body.SyntaxTree), scope, location);
+            if (models.For(body.SyntaxTree) is { } semanticModel)
+            {
+                _scopes.Read(body, semanticModel, scope, location);
+            }
         }
 
         if (scope.IsEmpty)

--- a/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Reactors/ReactorReader.cs
@@ -11,14 +11,18 @@ namespace Cratis.Arc.Screenplay.Analysis.Reactors;
 /// <summary>
 /// Reads the reactors a slice declares.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every handler is read through.</param>
 /// <param name="paths">The <see cref="SourcePaths"/> rewriting the path of the file each reactor lives in.</param>
 /// <remarks>
 /// A reactor translates rather than automates when it turns what happened into something else that happens - by
 /// returning further events, by executing a command, or by observing a sequence other than the event log. That is
 /// read from the body, so a reactor that merely holds a command pipeline without using it is still an automation.
+/// <para>
+/// A handler inherited from a base a project below it declares is written wherever that base is, so which model
+/// reads a body is asked rather than assumed.
+/// </para>
 /// </remarks>
-public class ReactorReader(Compilation compilation, SourcePaths paths)
+public class ReactorReader(SemanticModels models, SourcePaths paths)
 {
     /// <summary>
     /// The name of the argument naming the sequence a reactor observes.
@@ -142,7 +146,10 @@ public class ReactorReader(Compilation compilation, SourcePaths paths)
         foreach (var reference in handler.DeclaringSyntaxReferences)
         {
             var node = reference.GetSyntax();
-            var semanticModel = compilation.GetSemanticModel(node.SyntaxTree);
+            if (models.For(node.SyntaxTree) is not { } semanticModel)
+            {
+                continue;
+            }
 
             if (node.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(_ => IsPipelineExecution(_, semanticModel)))
             {

--- a/Source/DotNET/Screenplay/Analysis/Specifications/GeneratedIdentities.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/GeneratedIdentities.cs
@@ -10,7 +10,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// <summary>
 /// Recognizes an expression yielding an identity made on the spot.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every declaration is read through.</param>
 /// <remarks>
 /// Every other value a scenario states that cannot be read is a gap: the source says something concrete and the
 /// document says less than the source. A fresh identity is not that. It has no value to state - the whole point of
@@ -27,8 +27,14 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// therefore holds it in a field rather than writing it twice. Following the initializer of that field is what makes
 /// the recognition about the value rather than about how close to the step it happens to be written.
 /// </para>
+/// <para>
+/// Where that member is declared is not where the scenario is. A sentinel identity or an enumeration member the
+/// scenario names is routinely declared in the contracts project below it, so the declaration followed belongs to
+/// another project's compilation - which is why it is read through the models of the whole application rather than
+/// through any one of them.
+/// </para>
 /// </remarks>
-public class GeneratedIdentities(Compilation compilation)
+public class GeneratedIdentities(SemanticModels models)
 {
     /// <summary>
     /// The fully qualified metadata name of the type every generated identity is a value of, or wraps.
@@ -104,6 +110,11 @@ public class GeneratedIdentities(Compilation compilation)
     /// <param name="symbol">The member the expression names.</param>
     /// <param name="followed">The members already followed.</param>
     /// <returns>True when the member holds one.</returns>
+    /// <remarks>
+    /// A member declared in a project that was not handed over holds nothing this can read, so it is not one of these.
+    /// The value naming it is then stated as one nothing was recovered from, which says less than the source does but
+    /// says it out loud - and is what the reader is owed when a project is missing.
+    /// </remarks>
     bool Holds(ISymbol? symbol, ISet<string> followed)
     {
         if (symbol is not (IFieldSymbol or IPropertySymbol) || !followed.Add(symbol.ToDisplayString()))
@@ -114,6 +125,6 @@ public class GeneratedIdentities(Compilation compilation)
         return symbol.DeclaringSyntaxReferences
             .Select(_ => ValueOf(_.GetSyntax()))
             .OfType<ExpressionSyntax>()
-            .Any(value => Yields(value, compilation.GetSemanticModel(value.SyntaxTree), followed));
+            .Any(value => models.For(value.SyntaxTree) is { } semanticModel && Yields(value, semanticModel, followed));
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationCatalog.cs
@@ -23,18 +23,23 @@ public class SpecificationCatalog
     /// <summary>
     /// Reads every specification the compilation declares.
     /// </summary>
-    /// <param name="compilation">The compilation being analyzed.</param>
+    /// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
     /// <param name="catalog">The catalogue of everything the compilation declares.</param>
     /// <param name="slices">The namespaces a slice was recovered from.</param>
     /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
     /// <returns>The <see cref="SpecificationCatalog"/>.</returns>
+    /// <remarks>
+    /// Which scenarios are read is decided by the catalogue of one project, because a scenario is declared where it is
+    /// written. What each of them states is read through the models of the whole application, because the values it
+    /// states are routinely declared somewhere else entirely.
+    /// </remarks>
     public static SpecificationCatalog Read(
-        Compilation compilation,
+        SemanticModels models,
         ArtifactCatalog catalog,
         IEnumerable<string> slices,
         ScreenplayDiagnostics diagnostics)
     {
-        var reader = new SpecificationReader(compilation, diagnostics);
+        var reader = new SpecificationReader(models, diagnostics);
         var placement = new SpecificationPlacement(slices);
         var bySlice = new Dictionary<string, List<SpecificationModel>>(StringComparer.Ordinal);
 

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationOutcomeReader.cs
@@ -12,14 +12,18 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// <summary>
 /// Reads what a specification says followed from the command it issued.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
 /// <remarks>
 /// Each assertion is one sentence about the outcome, and several of them routinely say the same sentence about a
 /// different part of the same event - once for each value it carries. Screenplay says an event followed once, so a
 /// sentence already said is passed over rather than repeated.
+/// <para>
+/// An assertion inherited from a base context is written wherever that context is, which need not be the project the
+/// scenario is - so which model reads a body is asked rather than assumed.
+/// </para>
 /// </remarks>
-public class SpecificationOutcomeReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class SpecificationOutcomeReader(SemanticModels models, ScreenplayDiagnostics diagnostics)
 {
     /// <summary>
     /// Reads what a specification says followed.
@@ -34,7 +38,10 @@ public class SpecificationOutcomeReader(Compilation compilation, ScreenplayDiagn
         {
             foreach (var body in HandlerBodies.Of(assertion))
             {
-                ReadBody(body, compilation.GetSemanticModel(body.SyntaxTree), draft, name, location);
+                if (models.For(body.SyntaxTree) is { } semanticModel)
+                {
+                    ReadBody(body, semanticModel, draft, name, location);
+                }
             }
         }
     }

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationReader.cs
@@ -11,7 +11,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// <summary>
 /// Reads the scenario one type specifies a slice by.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unreadable is reported to.</param>
 /// <remarks>
 /// Only a specification driving a command through the real pipeline is read. A unit level one stands a collaborator
@@ -20,7 +20,7 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// the other is decided by what it touches: holding a scenario the pipeline runs in, or reaching the event log, is
 /// what an integration specification does and nothing else does.
 /// </remarks>
-public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class SpecificationReader(SemanticModels models, ScreenplayDiagnostics diagnostics)
 {
     /// <summary>
     /// Determines whether a type specifies a slice by driving a command through the pipeline.
@@ -84,10 +84,10 @@ public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics 
         var draft = new SpecificationDraft();
         var stated = new ScreenplayDiagnostics();
 
-        var reader = new SpecificationStepReader(compilation, new(stated, new GeneratedIdentities(compilation)));
+        var reader = new SpecificationStepReader(models, new(stated, new GeneratedIdentities(models)));
         reader.ReadGiven(steps, draft, name, location, alsoWhereTheActionIs: readModel is not null);
         reader.ReadWhen(steps, draft, name, location);
-        new SpecificationOutcomeReader(compilation, stated).Read(type, draft, name, location);
+        new SpecificationOutcomeReader(models, stated).Read(type, draft, name, location);
 
         if (readModel is not null && draft.When is null)
         {
@@ -186,10 +186,13 @@ public class SpecificationReader(Compilation compilation, ScreenplayDiagnostics 
     /// Gets every call a body resolves to.
     /// </summary>
     /// <param name="body">The body to walk.</param>
-    /// <returns>The methods called.</returns>
+    /// <returns>The methods called, empty when the project the body was written in was not handed over.</returns>
     IEnumerable<IMethodSymbol> CallsIn(SyntaxNode body)
     {
-        var semanticModel = compilation.GetSemanticModel(body.SyntaxTree);
+        if (models.For(body.SyntaxTree) is not { } semanticModel)
+        {
+            return [];
+        }
 
         return body.DescendantNodesAndSelf()
             .OfType<InvocationExpressionSyntax>()

--- a/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Specifications/SpecificationStepReader.cs
@@ -12,9 +12,13 @@ namespace Cratis.Arc.Screenplay.Analysis.Specifications;
 /// <summary>
 /// Reads what a specification starts from and the command it issues, from the bodies stating them.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every body is read through.</param>
 /// <param name="values">The <see cref="SpecificationValues"/> reading the values each step states.</param>
-public class SpecificationStepReader(Compilation compilation, SpecificationValues values)
+/// <remarks>
+/// The steps are walked from the base of the chain down, and a base context is routinely written in a project below
+/// the scenario inheriting it - so which model reads a body is asked rather than assumed.
+/// </remarks>
+public class SpecificationStepReader(SemanticModels models, SpecificationValues values)
 {
     /// <summary>
     /// Reads what a specification had already seen when it issued its command.
@@ -127,7 +131,9 @@ public class SpecificationStepReader(Compilation compilation, SpecificationValue
     IEnumerable<Step> CallsIn(INamedTypeSymbol type, string method) =>
         SpecificationMembers.MethodsIn(type, method)
             .SelectMany(HandlerBodies.Of)
-            .SelectMany(body => Calls(body, compilation.GetSemanticModel(body.SyntaxTree)));
+            .Select(body => (body, model: models.For(body.SyntaxTree)))
+            .Where(read => read.model is not null)
+            .SelectMany(read => Calls(read.body, read.model!));
 
     /// <summary>
     /// Adds one state a specification starts from, or records that it cannot be read.

--- a/Source/DotNET/Screenplay/Analysis/Validation/ValidationReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Validation/ValidationReader.cs
@@ -10,13 +10,17 @@ namespace Cratis.Arc.Screenplay.Analysis.Validation;
 /// <summary>
 /// Finds the rule chains a validator's constructor declares.
 /// </summary>
-/// <param name="compilation">The compilation being analyzed.</param>
+/// <param name="models">The <see cref="SemanticModels"/> every constructor is read through.</param>
 /// <param name="diagnostics">The <see cref="ScreenplayDiagnostics"/> anything unmappable is reported to.</param>
 /// <remarks>
 /// Reading the constructor recovers what the runtime rule descriptor loses - which rules were declared for each
 /// element of a collection, and which comparisons were made against something other than a number.
+/// <para>
+/// A validator declaring rules for a concept the project below it holds is written wherever it is, so which model
+/// reads its constructor is asked rather than assumed.
+/// </para>
 /// </remarks>
-public class ValidationReader(Compilation compilation, ScreenplayDiagnostics diagnostics)
+public class ValidationReader(SemanticModels models, ScreenplayDiagnostics diagnostics)
 {
     /// <summary>
     /// The call declaring a rule for a property.
@@ -67,7 +71,10 @@ public class ValidationReader(Compilation compilation, ScreenplayDiagnostics dia
     /// <param name="rules">The rules collected so far.</param>
     void ReadDeclaration(SyntaxNode declaration, string location, List<ValidationRuleModel> rules)
     {
-        var semanticModel = compilation.GetSemanticModel(declaration.SyntaxTree);
+        if (models.For(declaration.SyntaxTree) is not { } semanticModel)
+        {
+            return;
+        }
 
         foreach (var statement in declaration.DescendantNodes().OfType<ExpressionStatementSyntax>())
         {


### PR DESCRIPTION
## Changed

- Generating from a single project now reads every project it references as well, instead of only the project named. An application whose events, commands and concepts live in contracts projects below the one named no longer generates a document that leaves all of them out (#2521)

## Fixed

- Generating a Screenplay document no longer fails with `SyntaxTree is not part of the compilation` on an application written as several projects. A scenario naming a value another project declares - a sentinel identity, a well known identity, a member of an enumeration - is now read through the project that actually holds it, so it is recognized for what it is instead of taking generation down with it (#2521)
- A value a scenario states that no handed-over project declares is now left unrecovered and reported, rather than throwing (#2521)
