### PR TITLE
Carry every projection a slice declares

### DIFF
--- a/Source/DotNET/Screenplay.Specs/Library/LibraryAuthors.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryAuthors.cs
@@ -36,7 +36,7 @@ public static class LibraryAuthors
             ],
             [new EventModel("AuthorRegistered", [Declare.Property("Name", "AuthorName")], ["audit", "authors"])],
             [],
-            null,
+            [],
             [],
             [new UniquePropertyConstraintModel("UniqueAuthorName", "Name", "AuthorRegistered")]);
 
@@ -61,16 +61,18 @@ public static class LibraryAuthors
                     [],
                     null)
             ],
-            new ProjectionModel(
-                "Library.Authors.Listing.AuthorProjection",
-                "Author",
-                "event-log",
-                ProjectionAutoMapMode.Enabled,
-                false,
-                ProjectionScopeModel.Empty with
-                {
-                    From = [new(["AuthorRegistered"], "$eventSourceId", null, Declare.Map(("name", "name")))]
-                }),
+            [
+                new ProjectionModel(
+                    "Library.Authors.Listing.AuthorProjection",
+                    "Author",
+                    "event-log",
+                    ProjectionAutoMapMode.Enabled,
+                    false,
+                    ProjectionScopeModel.Empty with
+                    {
+                        From = [new(["AuthorRegistered"], "$eventSourceId", null, Declare.Map(("name", "name")))]
+                    })
+            ],
             [],
             []);
 }

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryInventory.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryInventory.cs
@@ -56,7 +56,7 @@ public static class LibraryInventory
                     [])
             ],
             [],
-            null,
+            [],
             [],
             []);
 
@@ -73,23 +73,25 @@ public static class LibraryInventory
             [],
             [],
             [new QueryModel("AllBooks", Declare.Many("Book"), null, [], null)],
-            new ProjectionModel(
-                "Library.Inventory.Listing.BookProjection",
-                "Book",
-                "event-log",
-                ProjectionAutoMapMode.Enabled,
-                false,
-                ProjectionScopeModel.Empty with
-                {
-                    From =
-                    [
-                        new(
-                            ["BookAddedToInventory"],
-                            "$eventSourceId",
-                            null,
-                            Declare.Map(("title", "title"), ("available", "count")))
-                    ]
-                }),
+            [
+                new ProjectionModel(
+                    "Library.Inventory.Listing.BookProjection",
+                    "Book",
+                    "event-log",
+                    ProjectionAutoMapMode.Enabled,
+                    false,
+                    ProjectionScopeModel.Empty with
+                    {
+                        From =
+                        [
+                            new(
+                                ["BookAddedToInventory"],
+                                "$eventSourceId",
+                                null,
+                                Declare.Map(("title", "title"), ("available", "count")))
+                        ]
+                    })
+            ],
             [],
             []);
 }

--- a/Source/DotNET/Screenplay.Specs/Library/LibraryLending.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/LibraryLending.cs
@@ -33,7 +33,7 @@ public static class LibraryLending
                 new EventModel("PremiumReservationGranted", [Declare.Property("MemberId", "MemberId")], [])
             ],
             [],
-            Availability(),
+            [Availability()],
             [],
             []);
 
@@ -50,7 +50,7 @@ public static class LibraryLending
             [],
             [],
             [],
-            null,
+            [],
             [
                 new ReactorModel(
                     "ReservationNotifier",
@@ -77,7 +77,7 @@ public static class LibraryLending
             [],
             [new EventModel("RestockRequested", [Declare.Property("Isbn", "ISBN")], [])],
             [],
-            null,
+            [],
             [new ReactorModel("RestockRequester", ["BookReserved"], true, null)],
             []);
 

--- a/Source/DotNET/Screenplay.Specs/Library/OrderingSlice.cs
+++ b/Source/DotNET/Screenplay.Specs/Library/OrderingSlice.cs
@@ -27,7 +27,7 @@ public static class OrderingSlice
             [],
             [.. Events()],
             [new QueryModel("AllOrders", Declare.Many("Order"), null, [], null)],
-            Projection(),
+            [Projection()],
             [],
             []);
 

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_of_the_type_holding_it.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_of_the_type_holding_it.cs
@@ -41,7 +41,7 @@ public class a_child_collection_of_the_type_holding_it : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+        _children = _analysis.Slice().Projections.Single().Scope.Children.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_that_names_no_parent_key.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_that_names_no_parent_key.cs
@@ -46,7 +46,7 @@ public class a_child_collection_that_names_no_parent_key : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _from = _analysis.Slice().Projection!.Scope.Children.Single().Scope.From.Single();
+        _from = _analysis.Slice().Projections.Single().Scope.Children.Single().Scope.From.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_whose_parent_carries_no_identifier.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_collection_whose_parent_carries_no_identifier.cs
@@ -45,7 +45,7 @@ public class a_child_collection_whose_parent_carries_no_identifier : Specificati
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _from = _analysis.Slice().Projection!.Scope.Children.Single().Scope.From.Single();
+        _from = _analysis.Slice().Projections.Single().Scope.Children.Single().Scope.From.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_removed_by_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_removed_by_an_event.cs
@@ -53,7 +53,7 @@ public class a_child_removed_by_an_event : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+        _children = _analysis.Slice().Projections.Single().Scope.Children.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_scope_declared_in_both_shapes.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_child_scope_declared_in_both_shapes.cs
@@ -119,5 +119,5 @@ public class a_child_scope_declared_in_both_shapes : Specification
     ProjectionChildScopeModel ChildrenOf(string @namespace) =>
         _analysis.Model.Slices
             .Single(_ => string.Equals(_.Namespace, @namespace, StringComparison.Ordinal))
-            .Projection!.Scope.Children.Single();
+            .Projections.Single().Scope.Children.Single();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_fluent_projection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_fluent_projection.cs
@@ -53,7 +53,7 @@ public class a_fluent_projection : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _projection = _analysis.Slice().Projection!;
+        _projection = _analysis.Slice().Projections.Single();
     }
 
     ProjectionFromModel From => _projection.Scope.From.Single();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection.cs
@@ -48,7 +48,7 @@ public class a_model_bound_projection : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _projection = _analysis.Slice().Projection!;
+        _projection = _analysis.Slice().Projections.Single();
     }
 
     ProjectionFromModel From => _projection.Scope.From.Single();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_a_nested_object.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_a_nested_object.cs
@@ -43,7 +43,7 @@ public class a_model_bound_projection_with_a_nested_object : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _nested = _analysis.Slice().Projection!.Scope.Nested.Single();
+        _nested = _analysis.Slice().Projections.Single().Scope.Nested.Single();
     }
 
     ProjectionFromModel From => _nested.Scope.From.Single();
@@ -55,6 +55,6 @@ public class a_model_bound_projection_with_a_nested_object : Specification
     [Fact] void should_observe_the_event_its_type_names() => From.EventTypes.ShouldContainOnly(["LoanShipped"]);
     [Fact] void should_map_what_its_type_declares() => From.Properties["Carrier"].ShouldEqual("carrier");
     [Fact] void should_map_every_property_its_type_declares() => From.Properties["TrackingNumber"].ShouldEqual("trackingNumber");
-    [Fact] void should_declare_no_children_alongside_it() => _analysis.Slice().Projection!.Scope.Children.ShouldBeEmpty();
+    [Fact] void should_declare_no_children_alongside_it() => _analysis.Slice().Projections.Single().Scope.Children.ShouldBeEmpty();
     [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_children.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_model_bound_projection_with_children.cs
@@ -49,7 +49,7 @@ public class a_model_bound_projection_with_children : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _children = _analysis.Slice().Projection!.Scope.Children.Single();
+        _children = _analysis.Slice().Projections.Single().Scope.Children.Single();
     }
 
     ProjectionFromModel From => _children.Scope.From.Single();
@@ -62,6 +62,6 @@ public class a_model_bound_projection_with_children : Specification
     [Fact] void should_key_a_child_on_the_property_the_declaration_names() => From.Key.ShouldEqual("bookId");
     [Fact] void should_find_the_parent_by_the_property_the_declaration_names() => From.ParentKey.ShouldEqual("shelfId");
     [Fact] void should_map_what_the_type_of_the_child_declares() => From.Properties["Title"].ShouldEqual("title");
-    [Fact] void should_still_observe_the_event_the_read_model_names() => _analysis.Slice().Projection!.Scope.From.Single().EventTypes.ShouldContainOnly(["ShelfInstalled"]);
+    [Fact] void should_still_observe_the_event_the_read_model_names() => _analysis.Slice().Projections.Single().Scope.From.Single().EventTypes.ShouldContainOnly(["ShelfInstalled"]);
     [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_nested_object_emptied_by_an_event.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_nested_object_emptied_by_an_event.cs
@@ -45,8 +45,8 @@ public class a_nested_object_emptied_by_an_event : Specification
     void Establish() => _analysis = Analyzed.Source(Source);
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
-    [Fact] void should_still_recover_the_nested_object() => _analysis.Slice().Projection!.Scope.Nested.Single().Property.ShouldEqual("Shipping");
-    [Fact] void should_still_recover_what_fills_it_in() => _analysis.Slice().Projection!.Scope.Nested.Single().Scope.From.Single().Properties["Carrier"].ShouldEqual("carrier");
+    [Fact] void should_still_recover_the_nested_object() => _analysis.Slice().Projections.Single().Scope.Nested.Single().Property.ShouldEqual("Shipping");
+    [Fact] void should_still_recover_what_fills_it_in() => _analysis.Slice().Projections.Single().Scope.Nested.Single().Scope.From.Single().Properties["Carrier"].ShouldEqual("carrier");
     [Fact] void should_report_what_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionConstruct);
     [Fact] void should_name_the_event_emptying_it() => _analysis.Diagnostics.Any(_ => _.Message.Contains("LoanShipmentCancelled", StringComparison.Ordinal)).ShouldBeTrue();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_keyed_on_several_properties.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_keyed_on_several_properties.cs
@@ -46,10 +46,10 @@ public class a_projection_keyed_on_several_properties : Specification
 
     void Establish() => _analysis = Analyzed.Source(Source);
 
-    Model.ProjectionFromModel From => _analysis.Slice().Projection!.Scope.From.Single();
+    Model.ProjectionFromModel From => _analysis.Slice().Projections.Single().Scope.From.Single();
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
-    [Fact] void should_turn_automatic_mapping_off() => _analysis.Slice().Projection!.AutoMap.ShouldEqual(Model.ProjectionAutoMapMode.Disabled);
+    [Fact] void should_turn_automatic_mapping_off() => _analysis.Slice().Projections.Single().AutoMap.ShouldEqual(Model.ProjectionAutoMapMode.Disabled);
     [Fact] void should_name_the_type_the_key_identifies() => From.Key!.Contains("$composite(OrderKey,", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_carry_every_part_of_the_key() => From.Key!.Contains("CustomerId=customerId", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_carry_the_second_part_too() => From.Key!.Contains("Number=orderNumber", StringComparison.Ordinal).ShouldBeTrue();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_member_of_an_enumeration.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_member_of_an_enumeration.cs
@@ -51,7 +51,7 @@ public class a_projection_setting_a_member_of_an_enumeration : Specification
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _from = _analysis.Slice().Projection!.Scope.From.Single();
+        _from = _analysis.Slice().Projections.Single().Scope.From.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_value_no_member_is_declared_with.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_projection_setting_a_value_no_member_is_declared_with.cs
@@ -50,7 +50,7 @@ public class a_projection_setting_a_value_no_member_is_declared_with : Specifica
     void Establish()
     {
         _analysis = Analyzed.Source(Source);
-        _from = _analysis.Slice().Projection!.Scope.From.Single();
+        _from = _analysis.Slice().Projections.Single().Scope.From.Single();
     }
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reducer.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_reducer.cs
@@ -44,7 +44,7 @@ public class a_reducer : Specification
 
     void Establish() => _analysis = Analyzed.Source(Source);
 
-    ProjectionModel Projection => _analysis.Slice().Projection!;
+    ProjectionModel Projection => _analysis.Slice().Projections.Single();
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
     [Fact] void should_still_state_the_read_model_it_builds() => Projection.ReadModel.ShouldEqual("Balance");

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_a_projection_and_a_reducer.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_a_projection_and_a_reducer.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A reducer builds a read model of its own, so what is recovered from it stands beside the projections of the slice
+/// rather than in place of one. A slice keeping a single projection made the two compete, and which read model
+/// survived was decided by the order the compilation happened to be walked in - so an application mixing the two
+/// shapes, which is the ordinary one, lost read models it really builds and lost different ones as it grew.
+/// </summary>
+public class a_slice_declaring_a_projection_and_a_reducer : Specification
+{
+    const string Source = """
+        using System.Threading.Tasks;
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+        using Cratis.Chronicle.Reducers;
+
+        namespace Library.Lending.Balances;
+
+        [EventType]
+        public record BookReserved(string Isbn);
+
+        [EventType]
+        public record BookReturned(string Isbn);
+
+        [ReadModel]
+        public record Balance(int Outstanding);
+
+        public class BalanceReducer : IReducerFor<Balance>
+        {
+            public Task<Balance> Reserved(BookReserved @event, Balance? current, EventContext context) =>
+                Task.FromResult(new Balance((current?.Outstanding ?? 0) + 1));
+        }
+
+        [ReadModel]
+        [FromEvent<BookReserved>]
+        public record Reservation
+        {
+            [SetFrom<BookReserved>("isbn")]
+            public string Isbn { get; init; } = string.Empty;
+        }
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
+    [Fact] void should_carry_both_read_models() => _analysis.Slice().Projections.Select(_ => _.ReadModel).ShouldContainOnly(["Balance", "Reservation"]);
+    [Fact] void should_leave_neither_out() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableProjectionConstruct).ShouldBeFalse();
+    [Fact] void should_still_report_the_fold_as_lost() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.ReducerWithoutCounterpart);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_several_projections.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_slice_declaring_several_projections.cs
@@ -6,11 +6,11 @@ using Cratis.Arc.Screenplay.Analysis;
 namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
 
 /// <summary>
-/// A slice may declare at most one projection, and a document declaring two does not compile at all. Keeping the
-/// first and reporting the second is what keeps the rest of the document valid, where emitting both would lose
-/// everything.
+/// A slice declares as many projections as its behavior needs. The read model a screen binds to and the one a command
+/// reads to decide are two projections of one behavior, and an application routinely writes both - so keeping
+/// whichever happened to be catalogued first stated one of them and silently dropped the rest of the read side.
 /// </summary>
-public class a_slice_declaring_a_second_projection : Specification
+public class a_slice_declaring_several_projections : Specification
 {
     const string Source = """
         using Cratis.Arc.Queries.ModelBound;
@@ -44,8 +44,7 @@ public class a_slice_declaring_a_second_projection : Specification
     void Establish() => _analysis = Analyzed.Source(Source);
 
     [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(("Library/Feature/Slice/Slice.cs", Source)).ShouldBeEmpty();
-    [Fact] void should_keep_exactly_one_projection() => _analysis.Slice().Projection.ShouldNotBeNull();
-    [Fact] void should_keep_the_first_one_it_read() => _analysis.Slice().Projection!.ReadModel.ShouldEqual("Author");
-    [Fact] void should_report_the_one_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionConstruct);
-    [Fact] void should_say_a_slice_may_declare_only_one() => _analysis.Diagnostics.Any(_ => _.Message.Contains("a slice may declare at most one", StringComparison.Ordinal)).ShouldBeTrue();
+    [Fact] void should_keep_both_of_them() => _analysis.Slice().Projections.Select(_ => _.ReadModel).ShouldContainOnly(["Author", "AuthorSummary"]);
+    [Fact] void should_leave_neither_out() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableProjectionConstruct).ShouldBeFalse();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
 }

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/the_same_source_twice.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/the_same_source_twice.cs
@@ -84,7 +84,7 @@ public class the_same_source_twice : Specification
             yield return string.Join(',', slice.Commands.SelectMany(_ => _.Produces).Select(_ => _.EventName));
             yield return string.Join(',', slice.Events.Select(_ => $"{_.Name}[{string.Join('|', _.Tags)}]"));
             yield return string.Join(',', slice.Queries.Select(_ => _.Name));
-            yield return string.Join(',', slice.Projection?.Scope.From.SelectMany(_ => _.EventTypes) ?? []);
+            yield return string.Join(',', slice.Projections.SelectMany(_ => _.Scope.From.SelectMany(from => from.EventTypes)));
         }
 
         yield return string.Join(',', analysis.Diagnostics.Select(_ => _.Code));

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/two_slices_building_one_read_model.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/two_slices_building_one_read_model.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// A read model is what a projection builds, and Screenplay holds one builder for each - a document naming two of
+/// them does not compile at all, whichever slices they are written in. So the rule is document wide rather than slice
+/// wide, and the second builder is turned away and reported rather than emitted into a document nothing can read.
+/// </summary>
+/// <remarks>
+/// This is the half of the old "a slice declares at most one projection" rule that was real. Dropping every
+/// projection after the first was too broad - it cost read models that were never in conflict - but dropping none at
+/// all writes a document that does not compile, which loses the whole of it rather than one projection.
+/// </remarks>
+public class two_slices_building_one_read_model : Specification
+{
+    const string Listing = """
+        using Cratis.Arc.Queries.ModelBound;
+        using Cratis.Chronicle.Events;
+        using Cratis.Chronicle.Projections.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [EventType]
+        public record AuthorRegistered(string Name);
+
+        [ReadModel]
+        [FromEvent<AuthorRegistered>]
+        public record Author
+        {
+            [SetFrom<AuthorRegistered>("name")]
+            public string Name { get; init; } = string.Empty;
+        }
+        """;
+
+    const string Reporting = """
+        using Cratis.Chronicle.Projections;
+        using Library.Authors.Listing;
+
+        namespace Library.Authors.Reporting;
+
+        public class AuthorAgain : IProjectionFor<Author>
+        {
+            public void Define(IProjectionBuilderFor<Author> builder) => builder
+                .From<AuthorRegistered>(_ => _.Set(m => m.Name).To(e => e.Name));
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Authors/Listing/Listing.cs", Listing),
+        ("Library/Authors/Reporting/Reporting.cs", Reporting)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    IEnumerable<string> BuildersOf(string readModel) =>
+        _analysis.Model.Slices.SelectMany(_ => _.Projections).Where(_ => _.ReadModel == readModel).Select(_ => _.Identifier);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_keep_one_builder_for_the_read_model() => BuildersOf("Author").Count().ShouldEqual(1);
+    [Fact] void should_report_the_one_it_left_out() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableProjectionConstruct);
+    [Fact] void should_say_the_read_model_is_built_once() => _analysis.Diagnostics.Any(_ => _.Message.Contains("a read model is built once", StringComparison.Ordinal)).ShouldBeTrue();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_with_an_unmappable_expression.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_projection_with_an_unmappable_expression.cs
@@ -24,7 +24,7 @@ public class a_projection_with_an_unmappable_expression : given.an_emitter
             Slices =
             [
                 LibraryAuthors.Registration(),
-                LibraryAuthors.Listing() with { Projection = ProjectionWithAnUnmappableMapping() }
+                LibraryAuthors.Listing() with { Projections = [ProjectionWithAnUnmappableMapping()] }
             ]
         };
 

--- a/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_naming_its_members_after_directives.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ScreenplayEmitter/when_emitting/a_slice_naming_its_members_after_directives.cs
@@ -84,7 +84,7 @@ public class a_slice_naming_its_members_after_directives : given.an_emitter
                     [])
             ],
             [],
-            null,
+            [],
             [],
             []);
 }

--- a/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
+++ b/Source/DotNET/Screenplay/Analysis/ApplicationModelAnalyzer.cs
@@ -63,7 +63,7 @@ public class ApplicationModelAnalyzer(IUserInterfaceFiles userInterfaceFiles) : 
         whole.Elsewhere.Report(diagnostics);
         TypesTheDocumentCannotName.Report(whole.Types, diagnostics, domain);
 
-        var joined = SliceUnion.Of(projects.SelectMany(_ => _.Slices), diagnostics);
+        var joined = SliceUnion.OneBuilderPerReadModel(SliceUnion.Of(projects.SelectMany(_ => _.Slices), diagnostics), diagnostics);
         var slices = Specified(projects, joined, diagnostics);
         var imports = ExternalEvents.Resolve(ordered, slices, diagnostics);
         NamespacesWithoutStructure.Report(slices, diagnostics, options.SegmentsToSkip ?? 0);

--- a/Source/DotNET/Screenplay/Analysis/Events/ExternalEvents.cs
+++ b/Source/DotNET/Screenplay/Analysis/Events/ExternalEvents.cs
@@ -78,7 +78,7 @@ public static class ExternalEvents
         slice.Commands.SelectMany(_ => _.Produces).Select(_ => _.EventName)
             .Concat(slice.Reactors.SelectMany(_ => _.ObservedEvents))
             .Concat(slice.Constraints.SelectMany(EventsOf))
-            .Concat(ProjectionEvents.In(slice.Projection))
+            .Concat(slice.Projections.SelectMany(ProjectionEvents.In))
             .Distinct(StringComparer.Ordinal);
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Projections/ReducerReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Projections/ReducerReader.cs
@@ -58,7 +58,7 @@ public class ReducerReader(ScreenplayDiagnostics diagnostics)
 
         diagnostics.Warning(
             ScreenplayDiagnosticCodes.ReducerWithoutCounterpart,
-            $"'{type.Name}' folds events into '{readModel.Name}' with code, which Screenplay has no counterpart for, so only the events it observes are stated",
+            $"'{type.Name}' folds events into '{readModel.Name}' with code, and what that code works out cannot be stated, so it is carried as a projection over the events it observes and nothing is said of the fold",
             location);
 
         return new(

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceArtifactReader.cs
@@ -46,6 +46,24 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
     }
 
     /// <summary>
+    /// Adds a projection the slice declares.
+    /// </summary>
+    /// <param name="content">The content collected so far.</param>
+    /// <param name="projection">The projection to add, or <see langword="null"/> when nothing could be read.</param>
+    /// <remarks>
+    /// A slice declares as many projections as its behavior needs, so they accumulate rather than compete. The read
+    /// model a screen binds to and the one a command reads to decide are two projections of one behavior, and a slice
+    /// keeping only whichever was catalogued first stated one of them and silently dropped the rest.
+    /// </remarks>
+    static void Assign(SliceContents content, ProjectionModel? projection)
+    {
+        if (projection is not null)
+        {
+            content.Projections.Add(projection);
+        }
+    }
+
+    /// <summary>
     /// Asks every recognizer what the type is.
     /// </summary>
     /// <param name="type">The type to read.</param>
@@ -68,17 +86,17 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
         {
             ReportWhatTheReadModelCannotSay(type, @namespace);
             AddQueries(content, type, QueryReader.MethodsOf(type), @namespace);
-            Assign(content, readers.ModelBoundProjections.Read(type, @namespace), @namespace);
+            Assign(content, readers.ModelBoundProjections.Read(type, @namespace));
         }
 
         if (FluentProjectionReader.ReadModelOf(type) is { } projected)
         {
-            Assign(content, readers.FluentProjections.Read(type, projected, @namespace), @namespace);
+            Assign(content, readers.FluentProjections.Read(type, projected, @namespace));
         }
 
         if (ReducerReader.ReadModelOf(type) is { } reduced)
         {
-            Assign(content, readers.Reducers.Read(type, reduced, @namespace), @namespace);
+            Assign(content, readers.Reducers.Read(type, reduced, @namespace));
         }
 
         if (ReactorReader.IsReactor(type))
@@ -194,31 +212,5 @@ public class SliceArtifactReader(ArtifactReaders readers, ScreenplayDiagnostics 
                 content.Queries.Add(new(declaring.Name, query));
             }
         }
-    }
-
-    /// <summary>
-    /// Assigns the single projection a slice may declare, reporting any beyond the first.
-    /// </summary>
-    /// <param name="content">The content collected so far.</param>
-    /// <param name="projection">The projection to assign.</param>
-    /// <param name="namespace">The namespace the slice lives in.</param>
-    void Assign(SliceContents content, ProjectionModel? projection, string @namespace)
-    {
-        if (projection is null)
-        {
-            return;
-        }
-
-        if (content.Projection is not null)
-        {
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
-                $"'{projection.Identifier}' is a second projection in one slice, and a slice may declare at most one, so it was left out",
-                @namespace);
-
-            return;
-        }
-
-        content.Projection = projection;
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceContents.cs
@@ -36,9 +36,9 @@ public class SliceContents
     public IList<ConstraintModel> Constraints { get; } = [];
 
     /// <summary>
-    /// Gets or sets the single projection the slice declares.
+    /// Gets the projections the slice declares.
     /// </summary>
-    public ProjectionModel? Projection { get; set; }
+    public IList<ProjectionModel> Projections { get; } = [];
 
     /// <summary>
     /// Gets or sets a value indicating whether the slice declares an aggregate root.
@@ -62,7 +62,7 @@ public class SliceContents
         Queries.Count +
         Reactors.Count +
         Constraints.Count +
-        (Projection is null ? 0 : 1);
+        Projections.Count;
 
     /// <summary>
     /// Gets a value indicating whether the slice declares nothing at all.

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceReader.cs
@@ -59,7 +59,7 @@ public class SliceReader(
             commands,
             [.. content.Events.OrderBy(_ => _.Name, StringComparer.Ordinal)],
             queries,
-            content.Projection,
+            [.. content.Projections.OrderBy(_ => _.Identifier, StringComparer.Ordinal)],
             reactors,
             [.. content.Constraints.OrderBy(_ => _.Name, StringComparer.Ordinal)])
         {

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
@@ -82,7 +82,7 @@ public static class SliceUnion
             Once(parts.SelectMany(_ => _.Commands), _ => _.Name, "command", @namespace, diagnostics),
             Once(parts.SelectMany(_ => _.Events), _ => _.Name, "event", @namespace, diagnostics),
             Once(parts.SelectMany(_ => _.Queries), _ => _.Name, "query", @namespace, diagnostics),
-            OneProjection(parts, @namespace, diagnostics),
+            Once(parts.SelectMany(_ => _.Projections), _ => _.Identifier, "projection", @namespace, diagnostics),
             Once(parts.SelectMany(_ => _.Reactors), _ => _.Name, "reactor", @namespace, diagnostics),
             Once(parts.SelectMany(_ => _.Constraints), _ => _.Name, "constraint", @namespace, diagnostics))
         {
@@ -126,37 +126,5 @@ public static class SliceUnion
         }
 
         return [.. kept.OrderBy(name, StringComparer.Ordinal)];
-    }
-
-    /// <summary>
-    /// Keeps the single projection a slice may declare, reporting any beyond the first.
-    /// </summary>
-    /// <param name="parts">The parts, in the order the projects declaring them were read.</param>
-    /// <param name="namespace">The namespace of the slice.</param>
-    /// <param name="diagnostics">The diagnostics to report to.</param>
-    /// <returns>The projection, or <see langword="null"/> when no part declares one.</returns>
-    static ProjectionModel? OneProjection(
-        IReadOnlyList<SliceModel> parts,
-        string @namespace,
-        ScreenplayDiagnostics diagnostics)
-    {
-        ProjectionModel? kept = null;
-
-        foreach (var projection in parts.Select(_ => _.Projection).OfType<ProjectionModel>())
-        {
-            if (kept is null)
-            {
-                kept = projection;
-
-                continue;
-            }
-
-            diagnostics.Warning(
-                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
-                $"'{projection.Identifier}' is a second projection in one slice, and a slice may declare at most one, so it was left out",
-                @namespace);
-        }
-
-        return kept;
     }
 }

--- a/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
+++ b/Source/DotNET/Screenplay/Analysis/Slices/SliceUnion.cs
@@ -37,6 +37,33 @@ public static class SliceUnion
     ];
 
     /// <summary>
+    /// Keeps one builder per read model across the whole document, reporting every one beyond the first.
+    /// </summary>
+    /// <param name="slices">The slices of the application, joined across every project.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The slices, each carrying only the projections that build a read model nothing else builds.</returns>
+    /// <remarks>
+    /// A read model is what a projection builds, and Screenplay holds one builder for each - a document declaring two
+    /// of them does not compile at all, whichever slices they are written in. That is a document wide rule rather than
+    /// a slice wide one, so it is applied once the slices are joined: an application declaring a projection and a
+    /// reducer for one read model, or projecting the same read model from two slices, is the shape that reaches it.
+    /// <para>
+    /// The projection that survives is the first in namespace order, which is the same one whichever order the
+    /// projects were handed over in. The rest are reported rather than dropped quietly, because a read model the
+    /// application really builds is missing from the document either way and a reader counting them otherwise has no
+    /// way of seeing which one went.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<SliceModel> OneBuilderPerReadModel(
+        IReadOnlyList<SliceModel> slices,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var built = new HashSet<string>(StringComparer.Ordinal);
+
+        return [.. slices.Select(slice => slice with { Projections = Building(slice, built, diagnostics) })];
+    }
+
+    /// <summary>
     /// Joins the scenarios every project specifies one slice by.
     /// </summary>
     /// <param name="specifications">The scenarios each project placed under the slice, in the order they were read.</param>
@@ -88,6 +115,38 @@ public static class SliceUnion
         {
             Screens = Once(parts.SelectMany(_ => _.Screens), _ => _.Name, "screen", @namespace, diagnostics)
         };
+    }
+
+    /// <summary>
+    /// Keeps the projections of one slice that build a read model nothing has built yet.
+    /// </summary>
+    /// <param name="slice">The slice to read.</param>
+    /// <param name="built">The read models already built, added to as they are taken.</param>
+    /// <param name="diagnostics">The diagnostics to report to.</param>
+    /// <returns>The projections kept.</returns>
+    static List<ProjectionModel> Building(
+        SliceModel slice,
+        HashSet<string> built,
+        ScreenplayDiagnostics diagnostics)
+    {
+        var kept = new List<ProjectionModel>();
+
+        foreach (var projection in slice.Projections)
+        {
+            if (built.Add(projection.ReadModel))
+            {
+                kept.Add(projection);
+
+                continue;
+            }
+
+            diagnostics.Warning(
+                ScreenplayDiagnosticCodes.UnmappableProjectionConstruct,
+                $"'{projection.Identifier}' builds '{projection.ReadModel}', which something else already builds, and a read model is built once, so it was left out",
+                slice.Namespace);
+        }
+
+        return kept;
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Slices/SliceSyntaxBuilder.cs
@@ -86,16 +86,16 @@ public class SliceSyntaxBuilder(
     /// <param name="slice">The slice to build for.</param>
     /// <returns>The projections, empty when the slice declares none.</returns>
     /// <remarks>
-    /// A slice can now hold several projections, while the model recovered from source still holds at most one -
-    /// a second one is turned away during analysis and reported. This yields what the model has, so widening the
-    /// analysis is the only thing left to do to carry them all.
-    /// <para>
     /// A projection nothing could be expressed of yields nothing rather than an absent entry, so a slice left with
     /// no other content is still recognized as empty and dropped.
-    /// </para>
     /// </remarks>
     IEnumerable<ProjectionSyntax> BuildProjections(SliceModel slice) =>
-        slice.Projection is { } projection && projections.Build(projection, slice.Namespace) is { } built ? [built] : [];
+    [
+        .. slice.Projections
+            .Select(_ => projections.Build(_, slice.Namespace))
+            .OfType<ProjectionSyntax>()
+            .OrderBy(_ => _.Name, StringComparer.Ordinal)
+    ];
 
     /// <summary>
     /// Gets the name of the slice, falling back to the last segment of its namespace.

--- a/Source/DotNET/Screenplay/Model/SliceModel.cs
+++ b/Source/DotNET/Screenplay/Model/SliceModel.cs
@@ -13,9 +13,14 @@ namespace Cratis.Arc.Screenplay.Model;
 /// <param name="Commands">The commands the slice declares.</param>
 /// <param name="Events">The events the slice declares.</param>
 /// <param name="Queries">The queries the slice declares.</param>
-/// <param name="Projection">The single projection the slice declares, if it has one.</param>
+/// <param name="Projections">The projections the slice declares.</param>
 /// <param name="Reactors">The reactors the slice declares.</param>
 /// <param name="Constraints">The constraints the slice declares.</param>
+/// <remarks>
+/// A slice declares as many projections as its behavior needs. The read model a screen binds to and the one a
+/// command reads to decide belong to the same behavior, so they belong to the same slice - and an application
+/// routinely writes both, alongside whatever a fold over events builds.
+/// </remarks>
 public record SliceModel(
     string Namespace,
     string Name,
@@ -24,7 +29,7 @@ public record SliceModel(
     IEnumerable<CommandModel> Commands,
     IEnumerable<EventModel> Events,
     IEnumerable<QueryModel> Queries,
-    ProjectionModel? Projection,
+    IEnumerable<ProjectionModel> Projections,
     IEnumerable<ReactorModel> Reactors,
     IEnumerable<ConstraintModel> Constraints)
 {
@@ -55,5 +60,5 @@ public record SliceModel(
     /// <param name="kind">The Event Modeling kind of the slice.</param>
     /// <returns>The empty <see cref="SliceModel"/>.</returns>
     public static SliceModel Empty(string @namespace, string name, SliceKind kind) =>
-        new(@namespace, name, kind, null, [], [], [], null, [], []);
+        new(@namespace, name, kind, null, [], [], [], [], [], []);
 }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -90,11 +90,10 @@ public static class ScreenplayDiagnosticCodes
     /// A projection declares something the projection definition language has no counterpart for.
     /// </summary>
     /// <remarks>
-    /// Most of what this reports is a construct the language has no word for. One case is not: a slice holding a
-    /// second projection has that projection turned away because a slice declares at most one, which drops a read
-    /// model the application really builds (Cratis/Screenplay#30). Reporting it stays the right thing to do until a
-    /// slice can hold more than one - the projection is left out either way, and a reader counting read models
-    /// against the application otherwise has no way of seeing which one went missing.
+    /// Everything this reports is a construct within a projection that the language has no word for. A slice holding
+    /// a second projection was once reported here too, because a slice used to declare at most one and the rest were
+    /// turned away (Cratis/Screenplay#30); a slice now holds as many as its behavior needs, so they are all carried
+    /// and there is nothing left to say about them.
     /// </remarks>
     public const string UnmappableProjectionConstruct = "SP0015";
 
@@ -127,13 +126,13 @@ public static class ScreenplayDiagnosticCodes
     public const string UnmappableQuery = "SP0019";
 
     /// <summary>
-    /// A reducer folds events into a read model, which Screenplay has no counterpart for.
+    /// A reducer folds events into a read model with code that cannot be stated.
     /// </summary>
     /// <remarks>
     /// A projection says what each event does to the read model it builds. A reducer says the same thing as code,
     /// and the language has no construct to fold one value into another (Cratis/Screenplay#39). The events it
-    /// observes are read from its signatures and are real, so the document states which events reach the read model
-    /// while leaving unsaid what they do to it.
+    /// observes are read from its signatures and are real, so the read model is carried as a projection over those
+    /// events while what the fold works out is left unsaid.
     /// </remarks>
     public const string ReducerWithoutCounterpart = "SP0020";
 


### PR DESCRIPTION
## Changed

- A generated slice now carries every projection it declares, instead of the first one and a diagnostic for the rest. An application whose slice builds several read models - the one a screen binds to and the one a command reads to decide - now gets all of them
- A reducer's read model now stands beside the slice's projections instead of competing with them, so a slice mixing projections and reducers no longer loses most of its read side
- `SP0015` no longer reports a second projection in a slice; it is left for the constructs within a projection that the language genuinely has no word for
- `SP0020` now says what is actually lost - the read model is carried as a projection over the events the reducer observes, and only the fold itself goes unstated
