### PR TITLE
State that a query keeps answering

### DIFF
--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_that_keeps_answering.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_query_that_keeps_answering.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+using Cratis.Arc.Screenplay.Model;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Handing back a subject is the whole of how a query says it is a live read - there is no attribute saying so, and
+/// the caller subscribes rather than asks. Every other wrapper really is only how a result arrives, so peeling them
+/// all away alike took a fact about the application with them: a document said the same thing of a query answering
+/// once and a query that keeps answering, and said nothing about the difference.
+/// </summary>
+public class a_query_that_keeps_answering : Specification
+{
+    const string Reactive = """
+        namespace System.Reactive.Subjects
+        {
+            public interface ISubject<T>
+            {
+            }
+        }
+        """;
+
+    const string Source = """
+        using System.Collections.Generic;
+        using System.Reactive.Subjects;
+        using Cratis.Arc.Queries.ModelBound;
+
+        namespace Library.Authors.Listing;
+
+        [ReadModel]
+        public record Author(string Id, string Name)
+        {
+            public static ISubject<IEnumerable<Author>> AllAuthors() => null!;
+
+            public static IEnumerable<Author> AuthorsOnce() => [];
+        }
+        """;
+
+    static readonly (string Path, string Text)[] _sources =
+    [
+        ("Library/Feature/Slice/Slice.cs", Source),
+        ("Library/Reactive.cs", Reactive)
+    ];
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(_sources);
+
+    QueryModel Query(string name) => _analysis.Slice().Queries.First(_ => _.Name == name);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn(_sources).ShouldBeEmpty();
+    [Fact] void should_state_that_it_keeps_answering() => Query("AllAuthors").IsObservable.ShouldBeTrue();
+    [Fact] void should_still_say_what_it_answers_with() => Query("AllAuthors").ReturnType.ShouldEqual(new TypeReferenceModel("Author", true, false));
+    [Fact] void should_not_say_it_of_a_query_answering_once() => Query("AuthorsOnce").IsObservable.ShouldBeFalse();
+    [Fact] void should_report_nothing() => _analysis.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReader.cs
@@ -80,7 +80,8 @@ public class QueryReader(TypeRegistry types, ScreenplayDiagnostics diagnostics)
             returnType,
             required is null ? null : ToParameter(required),
             [.. parameters.Where(_ => !SymbolEqualityComparer.Default.Equals(_, required)).Select(ToParameter)],
-            AuthorizationReader.Read(method, declaring));
+            AuthorizationReader.Read(method, declaring),
+            QueryReturnTypes.IsObservable(method.ReturnType));
     }
 
     /// <summary>

--- a/Source/DotNET/Screenplay/Analysis/Queries/QueryReturnTypes.cs
+++ b/Source/DotNET/Screenplay/Analysis/Queries/QueryReturnTypes.cs
@@ -36,6 +36,11 @@ public static class QueryReturnTypes
         "System.Linq.IQueryable`1"
     ];
 
+    static readonly string[] _observables =
+    [
+        "System.Reactive.Subjects.ISubject`1"
+    ];
+
     /// <summary>
     /// Determines whether the host pages and sorts a query's result on the caller's behalf.
     /// </summary>
@@ -53,6 +58,34 @@ public static class QueryReturnTypes
         while (current is INamedTypeSymbol named && named.TypeArguments.Length == 1)
         {
             if (Matches(named, _queryables))
+            {
+                return true;
+            }
+
+            current = named.TypeArguments[0];
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a query keeps answering as the read model changes rather than answering once.
+    /// </summary>
+    /// <param name="type">The return type to check.</param>
+    /// <returns>True when the query hands back a subject.</returns>
+    /// <remarks>
+    /// Handing back a subject rather than a value is the whole of how a query says it is a live read - there is no
+    /// attribute and no parameter saying so, and the caller subscribes rather than asks. Every other wrapper really is
+    /// only how the result arrives, but this one is a fact about the query that the language holds a word for, so it
+    /// is read before the wrappers are peeled and stated rather than lost with them.
+    /// </remarks>
+    public static bool IsObservable(ITypeSymbol type)
+    {
+        var current = type;
+
+        while (current is INamedTypeSymbol named && named.TypeArguments.Length == 1)
+        {
+            if (Matches(named, _observables))
             {
                 return true;
             }

--- a/Source/DotNET/Screenplay/Emission/Queries/QuerySyntaxBuilder.cs
+++ b/Source/DotNET/Screenplay/Emission/Queries/QuerySyntaxBuilder.cs
@@ -33,7 +33,8 @@ public class QuerySyntaxBuilder(
             query.By is null ? null : ToParameter(query.By),
             [.. query.Filters.Select(ToParameter)],
             authorize.Build(query.Authorization),
-            SourceLocation.Start);
+            SourceLocation.Start,
+            IsObservable: query.IsObservable);
 
     /// <summary>
     /// Converts a parameter of the query.

--- a/Source/DotNET/Screenplay/Model/QueryModel.cs
+++ b/Source/DotNET/Screenplay/Model/QueryModel.cs
@@ -11,9 +11,11 @@ namespace Cratis.Arc.Screenplay.Model;
 /// <param name="By">The parameter identifying a single instance, if the query takes one.</param>
 /// <param name="Filters">The parameters narrowing the result.</param>
 /// <param name="Authorization">What the query requires of the caller, if anything.</param>
+/// <param name="IsObservable">Whether the query keeps answering as the read model changes rather than answering once.</param>
 public record QueryModel(
     string Name,
     TypeReferenceModel ReturnType,
     PropertyModel? By,
     IEnumerable<PropertyModel> Filters,
-    AuthorizationModel? Authorization);
+    AuthorizationModel? Authorization,
+    bool IsObservable = false);


### PR DESCRIPTION
## Added

- A query returning `ISubject<T>` is now marked `observable` in the generated document, so a live read that keeps pushing as the read model changes is no longer written as though it answers once
