### PR TITLE
Name the application after the project that was asked for

### DIFF
--- a/Source/DotNET/Screenplay.EndToEnd/LoadedApplication.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/LoadedApplication.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Arc.Screenplay.EndToEnd;
+
+/// <summary>
+/// Represents what reading a project or a solution yielded.
+/// </summary>
+/// <param name="Compilations">The compilations to generate from, empty when nothing yielded one.</param>
+/// <param name="Name">The name of the project that was asked for, or <see langword="null"/> when a solution was.</param>
+/// <remarks>
+/// An application read as several projects is named by none of them, so the generator offers no name and the caller
+/// supplies one. Naming a single project is the caller already having said which one the application is, and losing
+/// that on the way in would put the neutral default where the application's own name belongs.
+/// </remarks>
+public record LoadedApplication(IReadOnlyList<Compilation> Compilations, string? Name);

--- a/Source/DotNET/Screenplay.EndToEnd/Program.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/Program.cs
@@ -19,7 +19,8 @@ var output = Path.GetFullPath(args[1]);
 Console.WriteLine($"Generating the Screenplay document of '{project}'");
 
 var failures = new List<string>();
-var compilations = await ProjectCompilation.Of(project, failures);
+var loaded = await ProjectCompilation.Of(project, failures);
+var compilations = loaded.Compilations;
 
 foreach (var failure in failures)
 {
@@ -33,12 +34,12 @@ if (compilations.Count == 0)
     return 1;
 }
 
-foreach (var loaded in compilations)
+foreach (var compilation in compilations)
 {
-    Console.WriteLine($"  project: {loaded.AssemblyName}");
+    Console.WriteLine($"  project: {compilation.AssemblyName}");
 }
 
-var generated = new ScreenplayGenerator().Generate(compilations, new ScreenplayOptions());
+var generated = new ScreenplayGenerator().Generate(compilations, new ScreenplayOptions { Domain = loaded.Name });
 
 Directory.CreateDirectory(Path.GetDirectoryName(output)!);
 await File.WriteAllTextAsync(output, generated.Source);

--- a/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/ProjectCompilation.cs
@@ -46,20 +46,26 @@ public static class ProjectCompilation
     /// </summary>
     /// <param name="path">The full path of the project or solution file.</param>
     /// <param name="failures">Everything the workspace reported while loading, in the order it reported them.</param>
-    /// <returns>The compilations, empty when nothing yielded one.</returns>
+    /// <returns>The compilations, and the name of the project that was asked for when one was.</returns>
     /// <remarks>
     /// Registering the SDK has to happen before any MSBuild type is touched, which is why the members touching one
     /// are marked as not inlinable - the JIT would otherwise resolve those types while registration is still running.
+    /// <para>
+    /// Naming a project hands over that project and everything it references, so the application is read as several
+    /// projects and none of them names it on its own. The one that was asked for does name it, though - it is what
+    /// the caller pointed at - so it is handed back for the caller to say so. A solution names nothing this way,
+    /// because pointing at a solution points at all of it equally.
+    /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static async Task<IReadOnlyList<Compilation>> Of(string path, ICollection<string> failures)
+    public static async Task<LoadedApplication> Of(string path, ICollection<string> failures)
     {
         if (!MSBuildLocator.IsRegistered)
         {
             MSBuildLocator.RegisterDefaults();
         }
 
-        return IsSolution(path) ? await LoadSolution(path, failures) : await LoadProject(path, failures);
+        return IsSolution(path) ? new(await LoadSolution(path, failures), null) : await LoadProject(path, failures);
     }
 
     /// <summary>
@@ -84,7 +90,7 @@ public static class ProjectCompilation
     /// that has none. What the workspace already built is handed over instead.
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static async Task<IReadOnlyList<Compilation>> LoadProject(string path, ICollection<string> failures)
+    static async Task<LoadedApplication> LoadProject(string path, ICollection<string> failures)
     {
         var reported = new Lock();
         using var workspace = MSBuildWorkspace.Create();
@@ -92,7 +98,7 @@ public static class ProjectCompilation
 
         var project = await workspace.OpenProjectAsync(path);
 
-        return await CompilationsOf(project.Solution);
+        return new(await CompilationsOf(project.Solution), project.AssemblyName);
     }
 
     /// <summary>


### PR DESCRIPTION
## Fixed

- Generating from a single project again names the document after that project, instead of falling back to the neutral default. Handing over the projects it references made the application several projects, and several projects are named by none of them (#2521)
