### PR TITLE
Generate from an application written as several projects

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -237,6 +237,7 @@ jobs:
         run: |
           dotnet restore TestApps/AspNetCore/AspNetCore.csproj
           dotnet restore TestApps/Chronicle/Chronicle.csproj
+          dotnet restore TestApps/Layered/Layered.csproj
 
       - name: Generate and read back the document of a real application
         run: |
@@ -252,6 +253,19 @@ jobs:
           dotnet Source/DotNET/Screenplay.EndToEnd/bin/Release/net10.0/Cratis.Arc.Screenplay.EndToEnd.dll \
             TestApps/Chronicle/Chronicle.csproj \
             "${RUNNER_TEMP}/Chronicle.play"
+
+      # The two applications above are each one project, and a whole class of defect only exists between projects: a
+      # referenced project arrives as the compilation the workspace built rather than as an assembly on disk, so its
+      # declarations have real source belonging to a compilation that is not the one reading them. Two defects
+      # shipped through that gap and neither was reachable from here until this application existed. It is held to
+      # what its document says as well as to reading back clean, because a generator that quietly declines to read
+      # something writes a smaller document that compiles just as well.
+      - name: Generate and read back the document of a real application written as several projects
+        run: |
+          dotnet Source/DotNET/Screenplay.EndToEnd/bin/Release/net10.0/Cratis.Arc.Screenplay.EndToEnd.dll \
+            TestApps/Layered/Layered.csproj \
+            "${RUNNER_TEMP}/Layered.play" \
+            TestApps/Layered/Layered.expected
 
   proxy-specs:
     needs: [dotnet-build]

--- a/Arc.slnx
+++ b/Arc.slnx
@@ -45,6 +45,8 @@
         <Project Path="TestApps\ArcCore\ArcCore.csproj" />
         <Project Path="TestApps\Core\Core.csproj" />
         <Project Path="TestApps\Chronicle\Chronicle.csproj" />
+        <Project Path="TestApps\Layered\Layered.csproj" />
+        <Project Path="TestApps\Layered.Contracts\Layered.Contracts.csproj" />
         <Project Path="TestApps\Shared\Shared.csproj" />
     </Folder>
 </Solution>

--- a/Source/DotNET/Screenplay.EndToEnd/Expectation.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/Expectation.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.EndToEnd;
+
+/// <summary>
+/// Represents one thing a generated document, or what was reported while generating it, has to hold.
+/// </summary>
+/// <param name="Kind">What is being held to.</param>
+/// <param name="Subject">The line of the document, or the code of the diagnostic.</param>
+/// <param name="Count">How many times it has to occur, or <see langword="null"/> for at least once.</param>
+public record Expectation(ExpectationKind Kind, string Subject, int? Count)
+{
+    /// <summary>
+    /// Reads an expectation from the line declaring it.
+    /// </summary>
+    /// <param name="line">The line to read.</param>
+    /// <returns>The <see cref="Expectation"/>, or <see langword="null"/> when the line declares none.</returns>
+    /// <exception cref="UnreadableExpectation">Thrown when the line names no directive, or a count that is not one.</exception>
+    /// <remarks>
+    /// A line that cannot be read is an error rather than an expectation quietly skipped. A check whose expectations
+    /// file has a typo in it passes everything, which is the one outcome worse than failing.
+    /// </remarks>
+    public static Expectation? Read(string line)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+        {
+            return null;
+        }
+
+        var separator = trimmed.IndexOf(' ', StringComparison.Ordinal);
+        var directive = separator < 0 ? trimmed : trimmed[..separator];
+        var rest = separator < 0 ? string.Empty : trimmed[(separator + 1)..].Trim();
+
+        return directive switch
+        {
+            "says" => new(ExpectationKind.Says, Stated(rest, line), null),
+            "once" => new(ExpectationKind.Says, Stated(rest, line), 1),
+            "never" => new(ExpectationKind.Says, Stated(rest, line), 0),
+            "reports" => Reported(rest, line),
+            _ => throw new UnreadableExpectation(line)
+        };
+    }
+
+    /// <summary>
+    /// Reads the expectation a <c>reports</c> line declares.
+    /// </summary>
+    /// <param name="rest">What follows the directive.</param>
+    /// <param name="line">The whole line, for use in the error.</param>
+    /// <returns>The <see cref="Expectation"/>.</returns>
+    /// <exception cref="UnreadableExpectation">Thrown when the line names no code and count.</exception>
+    static Expectation Reported(string rest, string line)
+    {
+        var parts = rest.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return parts.Length == 2 && int.TryParse(parts[1], out var count) && count >= 0
+            ? new(ExpectationKind.Reports, parts[0], count)
+            : throw new UnreadableExpectation(line);
+    }
+
+    /// <summary>
+    /// Gets what a directive states, refusing an empty one.
+    /// </summary>
+    /// <param name="rest">What follows the directive.</param>
+    /// <param name="line">The whole line, for use in the error.</param>
+    /// <returns>What was stated.</returns>
+    /// <exception cref="UnreadableExpectation">Thrown when the directive states nothing.</exception>
+    static string Stated(string rest, string line) =>
+        rest.Length > 0 ? rest : throw new UnreadableExpectation(line);
+}

--- a/Source/DotNET/Screenplay.EndToEnd/ExpectationKind.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/ExpectationKind.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.EndToEnd;
+
+/// <summary>
+/// Represents what an <see cref="Expectation"/> is about.
+/// </summary>
+public enum ExpectationKind
+{
+    /// <summary>
+    /// A line the document has to carry, matched on the line with its indentation trimmed.
+    /// </summary>
+    Says = 0,
+
+    /// <summary>
+    /// A diagnostic code the generator has to report, and how many times.
+    /// </summary>
+    Reports = 1
+}

--- a/Source/DotNET/Screenplay.EndToEnd/Expectations.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/Expectations.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.EndToEnd;
+
+/// <summary>
+/// Holds what a generated document, and what was reported while generating it, have to say.
+/// </summary>
+/// <param name="expectations">The expectations to hold a generation to.</param>
+/// <remarks>
+/// Reading a document back through the compiler proves it is valid, which is not the same as proving it is true. A
+/// generator that quietly declined to read something produces a document that is smaller and still compiles, so the
+/// check that catches it has to be about what the document says rather than about whether it came back clean.
+/// <para>
+/// Diagnostics are held to alongside the document because the two halves of that are not both visible in the text. A
+/// value the generator recovered and a value it gave up on are both absent from the document - the first because
+/// there was nothing left to say and the second because nothing could be said - and only the report tells them apart.
+/// </para>
+/// </remarks>
+public class Expectations(IReadOnlyList<Expectation> expectations)
+{
+    /// <summary>
+    /// Reads the expectations declared in a file.
+    /// </summary>
+    /// <param name="path">The full path of the file.</param>
+    /// <returns>The <see cref="Expectations"/>.</returns>
+    public static async Task<Expectations> In(string path) =>
+        new([.. (await File.ReadAllLinesAsync(path)).Select(Expectation.Read).OfType<Expectation>()]);
+
+    /// <summary>
+    /// Gets everything a generation failed to hold to.
+    /// </summary>
+    /// <param name="document">The generated document.</param>
+    /// <param name="diagnostics">What was reported while generating it.</param>
+    /// <returns>The failures, empty when the generation held to all of them.</returns>
+    public IEnumerable<string> NotMetBy(string document, IEnumerable<ScreenplayDiagnostic> diagnostics)
+    {
+        var lines = document.Split('\n').Select(_ => _.Trim()).ToList();
+        var codes = diagnostics.Select(_ => _.Code).ToList();
+
+        return [.. expectations.Select(_ => NotMetBy(_, lines, codes)).OfType<string>()];
+    }
+
+    /// <summary>
+    /// Gets how one expectation was not held to.
+    /// </summary>
+    /// <param name="expectation">The expectation to check.</param>
+    /// <param name="lines">The lines of the document, trimmed.</param>
+    /// <param name="codes">The code of everything reported.</param>
+    /// <returns>The failure, or <see langword="null"/> when it was held to.</returns>
+    static string? NotMetBy(Expectation expectation, IReadOnlyList<string> lines, IReadOnlyList<string> codes)
+    {
+        var found = expectation.Kind == ExpectationKind.Says
+            ? lines.Count(_ => string.Equals(_, expectation.Subject, StringComparison.Ordinal))
+            : codes.Count(_ => string.Equals(_, expectation.Subject, StringComparison.Ordinal));
+
+        if (expectation.Count is { } expected)
+        {
+            return found == expected
+                ? null
+                : Describe(expectation, $"{expected} time(s)", found);
+        }
+
+        return found > 0 ? null : Describe(expectation, "at least once", found);
+    }
+
+    /// <summary>
+    /// Describes an expectation that was not held to.
+    /// </summary>
+    /// <param name="expectation">The expectation.</param>
+    /// <param name="expected">How often it was expected.</param>
+    /// <param name="found">How often it occurred.</param>
+    /// <returns>The description.</returns>
+    static string Describe(Expectation expectation, string expected, int found) =>
+        expectation.Kind == ExpectationKind.Says
+            ? $"the document was to say '{expectation.Subject}' {expected}, and says it {found} time(s)"
+            : $"'{expectation.Subject}' was to be reported {expected}, and was reported {found} time(s)";
+}

--- a/Source/DotNET/Screenplay.EndToEnd/Program.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/Program.cs
@@ -8,13 +8,14 @@ using Cratis.Screenplay;
 if (args.Length < 2)
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  Cratis.Arc.Screenplay.EndToEnd <project-or-solution> <output-file>");
+    Console.WriteLine("  Cratis.Arc.Screenplay.EndToEnd <project-or-solution> <output-file> [expectations-file]");
 
     return 2;
 }
 
 var project = Path.GetFullPath(args[0]);
 var output = Path.GetFullPath(args[1]);
+var expected = args.Length > 2 ? Path.GetFullPath(args[2]) : null;
 
 Console.WriteLine($"Generating the Screenplay document of '{project}'");
 
@@ -82,5 +83,29 @@ if (errors.Count > 0)
 }
 
 Console.WriteLine("The generated document reads back clean");
+
+// Reading back clean proves the document is valid, not that it is true. A generator that quietly declined to read
+// something writes a smaller document that compiles just as well, so an application whose expectations are declared
+// beside it is held to what the document actually says - and to what was reported, because a value recovered and a
+// value given up on are both absent from the text and only the report tells them apart.
+if (expected is null)
+{
+    return 0;
+}
+
+var unmet = (await Expectations.In(expected)).NotMetBy(generated.Source, generated.Diagnostics).ToList();
+foreach (var failure in unmet)
+{
+    Console.WriteLine($"  expectation: {failure}");
+}
+
+if (unmet.Count > 0)
+{
+    Console.WriteLine($"The generated document did not hold to '{expected}' - {unmet.Count} expectation(s)");
+
+    return 1;
+}
+
+Console.WriteLine($"The generated document holds to every expectation in '{expected}'");
 
 return 0;

--- a/Source/DotNET/Screenplay.EndToEnd/UnreadableExpectation.cs
+++ b/Source/DotNET/Screenplay.EndToEnd/UnreadableExpectation.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Screenplay.EndToEnd;
+
+/// <summary>
+/// The exception that is thrown when a line of an expectations file declares nothing this can check.
+/// </summary>
+/// <param name="line">The line that could not be read.</param>
+public class UnreadableExpectation(string line)
+    : Exception($"'{line}' is not an expectation - write 'says <line>', 'once <line>', 'never <line>' or 'reports <code> <count>'");

--- a/TestApps/Layered.Contracts/Layered.Contracts.csproj
+++ b/TestApps/Layered.Contracts/Layered.Contracts.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <!-- Set as the plural so that the multi targeting the repository defaults to in Release is really replaced
+             rather than only overridden for the inner build. This is a fixture read through MSBuild, not something
+             shipped, so one framework is all it needs. -->
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <!-- A vertical slice keeps every backend artifact in one file, which is what the rules about one type per
+             file and a file named after its type are turned off for here. -->
+        <NoWarn>$(NoWarn);SA0001;SA1600;SA1649;SA1402;MA0048</NoWarn>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../Source/DotNET/Cratis/Cratis.csproj" />
+        <ProjectReference Include="../../Source/DotNET/Chronicle/Chronicle.csproj" />
+    </ItemGroup>
+</Project>

--- a/TestApps/Layered.Contracts/Ordering/Placing/Placing.cs
+++ b/TestApps/Layered.Contracts/Ordering/Placing/Placing.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Layered.Ordering.Placing;
+
+/// <summary>
+/// Represents the identity of a customer.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record CustomerId(Guid Value) : EventSourceId<Guid>(Value)
+{
+    /// <summary>
+    /// The customer nobody is.
+    /// </summary>
+    public static readonly CustomerId NotSet = new(Guid.Empty);
+
+    /// <summary>
+    /// Converts an underlying value to an identity.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    public static implicit operator CustomerId(Guid value) => new(value);
+
+    /// <summary>
+    /// Creates a new identity.
+    /// </summary>
+    /// <returns>The <see cref="CustomerId"/>.</returns>
+    public static CustomerId New() => new(Guid.NewGuid());
+}
+
+/// <summary>
+/// Holds the customers the application knows by name rather than by lookup.
+/// </summary>
+/// <remarks>
+/// This is what the check exists for. A scenario in the project above states one of these as the customer it is
+/// about, so reading that scenario means following a member declared here - in a project the workspace hands over as
+/// the compilation it built rather than as an assembly on disk. The declaration therefore belongs to a compilation
+/// that is not the one reading it, which is a crash rather than a wrong answer unless every body is read through the
+/// models of the whole application.
+/// </remarks>
+public static class KnownCustomers
+{
+    /// <summary>
+    /// The customer the shop itself orders as.
+    /// </summary>
+    public static readonly CustomerId House = CustomerId.New();
+}
+
+/// <summary>
+/// The event that occurs when an order has been placed.
+/// </summary>
+/// <param name="Sku">What was ordered.</param>
+[EventType]
+public record OrderPlaced(string Sku);

--- a/TestApps/Layered/Layered.csproj
+++ b/TestApps/Layered/Layered.csproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <!-- Set as the plural so that the multi targeting the repository defaults to in Release is really replaced
+             rather than only overridden for the inner build, which would restore this for frameworks the testing
+             packages it references do not support. -->
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <!-- A vertical slice keeps every backend artifact in one file, which is what the rules about one type per
+             file and a file named after its type are turned off for here. -->
+        <NoWarn>$(NoWarn);SA0001;SA1600;SA1649;SA1402;MA0048</NoWarn>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- The contracts of the application, referenced the way one project of an application references another. -->
+        <ProjectReference Include="../Layered.Contracts/Layered.Contracts.csproj" />
+        <ProjectReference Include="../../Source/DotNET/Arc/Arc.csproj" />
+        <ProjectReference Include="../../Source/DotNET/Cratis/Cratis.csproj" />
+        <ProjectReference Include="../../Source/DotNET/Chronicle/Chronicle.csproj" />
+        <!-- A slice is specified where it lives, so the scenarios sit in this project rather than beside it. -->
+        <ProjectReference Include="../../Source/DotNET/Chronicle.Testing/Chronicle.Testing.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <!-- Only the attribute marking a method as an assertion is needed; nothing here is discovered or run as a
+             test, so no runner and no test SDK come with it. -->
+        <PackageReference Include="xunit" />
+    </ItemGroup>
+</Project>

--- a/TestApps/Layered/Layered.expected
+++ b/TestApps/Layered/Layered.expected
@@ -1,0 +1,72 @@
+# What the document generated from this application has to say, and what generating it has to report.
+#
+#   says <line>            the document carries the line, at least once, indentation ignored
+#   once <line>            exactly once
+#   never <line>           not at all
+#   reports <code> <n>     the generator reports the code exactly n times, 0 for never
+#
+# Everything here is about one of the two shapes this fixture exists for. Anything the framework projects it
+# references happen to contribute is deliberately not held to, because that is Arc's own source rather than the
+# application's, and holding this file to it would make it churn with every unrelated change.
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# A scenario naming a value the project below it declares.
+#
+# The scenario states its customer as KnownCustomers.House, a static readonly identity declared in
+# Layered.Contracts. The workspace hands that project over as the compilation it built rather than as an assembly on
+# disk, so the declaration belongs to a compilation other than the one reading the scenario. Reading it through the
+# wrong one threw and took the whole document with it.
+# ---------------------------------------------------------------------------------------------------------------
+
+# The scenario survived at all - it was the crash site.
+once specification WhenPlacingAnOrderAndTheCustomerOrderedBefore
+
+# What it starts from, what it does and what follows, with the values it could read.
+says given OrderPlaced
+says sku = "COFFEE-250G"
+says when PlaceOrder
+says sku = "COFFEE-1KG"
+says then OrderPlaced
+
+# This is the assertion that is not about crashing. The identity is made on the spot, so a document leaving it out
+# says exactly what the source says and there is nothing to report. A reader that stopped at the project boundary
+# rather than following the member into the project that declares it would leave it out too - and would report it as
+# a value nothing was recovered from. Both write the same document; only this tells them apart.
+reports SP0040 0
+
+# No scenario was dropped on the way, for that reason or any other.
+reports SP0039 0
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# Two slices building one read model.
+#
+# The placing slice builds Order with a model-bound projection and the reporting slice builds it again with a fluent
+# one. Screenplay holds one builder per read model however many slices declare one, and a document naming two does
+# not compile at all - so the second is turned away and said out loud rather than emitted.
+# ---------------------------------------------------------------------------------------------------------------
+
+# Exactly one builder reaches the document, and it is the one the first slice in namespace order declares.
+once projection Order => Order
+
+# The one that did not is reported rather than dropped in silence.
+reports SP0015 1
+
+# The reporting slice declared nothing else, so it is left out and that is said too.
+reports SP0002 1
+
+
+# ---------------------------------------------------------------------------------------------------------------
+# What the application declares across the two projects.
+# ---------------------------------------------------------------------------------------------------------------
+
+# The concept and the event are declared by the contracts project and reached through the project above it, so a
+# document holding them is a document generated from more than the project that was named.
+says concept CustomerId : Uuid
+once event OrderPlaced
+once command PlaceOrder
+says customerId CustomerId
+
+# The application is named after the project that was asked for, not the neutral default.
+once domain Layered

--- a/TestApps/Layered/Ordering/Placing/Placing.cs
+++ b/TestApps/Layered/Ordering/Placing/Placing.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Arc.Queries.ModelBound;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Layered.Ordering.Placing;
+
+/// <summary>
+/// Represents a command placing an order.
+/// </summary>
+/// <param name="CustomerId">Who is ordering.</param>
+/// <param name="Sku">What is being ordered.</param>
+[Command]
+public record PlaceOrder(CustomerId CustomerId, string Sku)
+{
+    /// <summary>
+    /// Handles the command by stating that the order was placed.
+    /// </summary>
+    /// <returns>The <see cref="OrderPlaced"/> event.</returns>
+    public OrderPlaced Handle() => new(Sku);
+}
+
+/// <summary>
+/// Represents what was ordered.
+/// </summary>
+/// <remarks>
+/// The slice below this one builds the same read model a second way, which is the other shape this fixture exists
+/// for. Screenplay holds one builder for each read model however many slices declare one, so a document naming two
+/// does not compile at all - and only an application really written that way reaches the rule.
+/// </remarks>
+[ReadModel]
+[FromEvent<OrderPlaced>]
+public record Order
+{
+    /// <summary>
+    /// Gets what was ordered.
+    /// </summary>
+    [SetFrom<OrderPlaced>(nameof(OrderPlaced.Sku))]
+    public string Sku { get; init; } = string.Empty;
+}

--- a/TestApps/Layered/Ordering/Placing/when_placing_an_order/and_the_customer_ordered_before.cs
+++ b/TestApps/Layered/Ordering/Placing/when_placing_an_order/and_the_customer_ordered_before.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Chronicle.Testing.Commands;
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Xunit;
+
+namespace Layered.Ordering.Placing.when_placing_an_order;
+
+/// <summary>
+/// A scenario stating the customer it is about as a well known one the contracts project declares.
+/// </summary>
+/// <remarks>
+/// Naming <see cref="KnownCustomers.House"/> is what makes this fixture worth having. Reading the scenario means
+/// following that member back to where it was made, and where it was made is another project - so the declaration
+/// belongs to a compilation other than the one reading the scenario. Following it through the wrong compilation is
+/// not a wrong answer but a crash.
+/// <para>
+/// Not crashing is the smaller half. The identity is made on the spot, so a document leaving it out says exactly what
+/// the source says and nothing is reported. A reader that merely declined to look across the project boundary would
+/// also leave it out - and would report the value as one nothing was recovered from, which is what the expectations
+/// beside this fixture hold it to.
+/// </para>
+/// </remarks>
+public class and_the_customer_ordered_before
+{
+    readonly CommandScenario<PlaceOrder> _scenario = new();
+    CommandResult _result = null!;
+
+    void Establish() =>
+        _scenario.Given.ForEventSource(KnownCustomers.House).Events(new OrderPlaced("COFFEE-250G"));
+
+    async Task Because() => _result = await _scenario.Execute(new PlaceOrder(KnownCustomers.House, "COFFEE-1KG"));
+
+    [Fact] void should_be_successful() => _result.ShouldBeSuccessful();
+    [Fact] async Task should_have_placed_the_order() => await _scenario.ShouldHaveAppendedEvent<PlaceOrder, OrderPlaced>(KnownCustomers.House);
+}

--- a/TestApps/Layered/Ordering/Reporting/Reporting.cs
+++ b/TestApps/Layered/Ordering/Reporting/Reporting.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections;
+using Layered.Ordering.Placing;
+
+namespace Layered.Ordering.Reporting;
+
+/// <summary>
+/// Builds the same read model the placing slice builds, from the same event.
+/// </summary>
+/// <remarks>
+/// An application really does grow a second builder for one read model - a reporting slice written beside the slice
+/// that owns the model, or a reducer folding what a projection already projects. Screenplay holds one builder for
+/// each read model whichever slices declare them, and a document naming two does not compile at all, so the second
+/// one has to be turned away and reported rather than emitted.
+/// <para>
+/// A single project could never show this while a slice kept only its first projection, because the two builders are
+/// in different slices and each slice kept its own. That is why it took an application written as several projects
+/// to find it.
+/// </para>
+/// </remarks>
+public class OrderReports : IProjectionFor<Order>
+{
+    /// <inheritdoc/>
+    public void Define(IProjectionBuilderFor<Order> builder) => builder
+        .From<OrderPlaced>(_ => _.Set(m => m.Sku).To(e => e.Sku));
+}


### PR DESCRIPTION
# Summary

Internal end-to-end check and test applications only — no user-facing change.
