### PR TITLE
Resolve discovered command and query extension points from the request scope

### DIFF
--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_the_command_carries_its_own_scope.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandFilters/when_executing_filters/and_the_command_carries_its_own_scope.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandFilters.when_executing_filters;
+
+/// <summary>
+/// A filter is resolved from the scope the command runs in, not from the provider that constructed this singleton,
+/// so a filter depending on a scoped service is created in the scope rather than in the root — where the container
+/// refuses to create it once scope validation is on.
+/// </summary>
+public class and_the_command_carries_its_own_scope : Specification
+{
+    CommandFilters _commandFilters;
+    ICommandFilter _filterFromTheScope;
+    ICommandFilter _filterFromTheRoot;
+    CommandContext _context;
+    System.Diagnostics.ActivitySource _activitySource;
+
+    void Establish()
+    {
+        _filterFromTheScope = Substitute.For<ICommandFilter>();
+        _filterFromTheRoot = Substitute.For<ICommandFilter>();
+
+        var scope = Substitute.For<IServiceProvider>();
+        scope.GetService(typeof(IInstancesOf<ICommandFilter>))
+            .Returns(new KnownInstancesOf<ICommandFilter>([_filterFromTheScope]));
+
+        _context = new CommandContext(CorrelationId.New(), typeof(object), new object(), [], new(), ServiceProvider: scope);
+
+        var activitySource = Substitute.For<IActivitySource<CommandFilters>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        activitySource.ActualSource.Returns(_activitySource);
+        _commandFilters = new(new KnownInstancesOf<ICommandFilter>([_filterFromTheRoot]), activitySource);
+    }
+
+    void Destroy() => _activitySource.Dispose();
+
+    async Task Because() => await _commandFilters.OnExecution(_context);
+
+    [Fact] void should_run_the_filter_from_the_scope() => _filterFromTheScope.Received(1).OnExecution(_context);
+    [Fact] void should_not_run_the_filter_from_the_root() => _filterFromTheRoot.DidNotReceive().OnExecution(Arg.Any<CommandContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_the_command_carries_its_own_scope.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandPipeline/when_executing/and_the_command_carries_its_own_scope.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Traces;
+
+namespace Cratis.Arc.Commands.for_CommandPipeline.when_executing;
+
+/// <summary>
+/// An execution scope is resolved from the scope the command runs in, not from the provider that constructed this
+/// singleton, so a scope depending on a scoped service is created in the command's scope rather than in the root.
+/// </summary>
+public class and_the_command_carries_its_own_scope : given.a_command_pipeline_and_a_handler_for_command
+{
+    ICommandExecutionScope _scopeFromTheScope;
+    ICommandExecutionScope _scopeFromTheRoot;
+    CommandPipeline _pipeline;
+
+    void Establish()
+    {
+        _scopeFromTheScope = Substitute.For<ICommandExecutionScope>();
+        _scopeFromTheRoot = Substitute.For<ICommandExecutionScope>();
+
+        _serviceProvider.GetService(typeof(IInstancesOf<ICommandExecutionScope>))
+            .Returns(new KnownInstancesOf<ICommandExecutionScope>([_scopeFromTheScope]));
+
+        var activitySource = Substitute.For<IActivitySource<CommandPipeline>>();
+        _activitySource = new System.Diagnostics.ActivitySource("Cratis.Arc.Test");
+        activitySource.ActualSource.Returns(_activitySource);
+        _pipeline = new(
+            _correlationIdAccessor,
+            _commandFilters,
+            _commandHandlerProviders,
+            _commandResponseValueHandlers,
+            _commandContextModifier,
+            _commandContextValuesBuilder,
+            _commandHandlerArgumentResolver,
+            new KnownInstancesOf<ICommandExecutionScope>([_scopeFromTheRoot]),
+            _serviceScopeFactory,
+            activitySource);
+    }
+
+    async Task Because() => await _pipeline.Execute(_command, _serviceProvider);
+
+    [Fact] void should_begin_the_execution_scope_from_the_scope() => _scopeFromTheScope.Received(1).Begin(Arg.Any<CommandContext>());
+    [Fact] void should_complete_the_execution_scope_from_the_scope() => _scopeFromTheScope.Received(1).Complete(Arg.Any<CommandContext>(), Arg.Any<CommandResult>());
+    [Fact] void should_not_begin_the_execution_scope_from_the_root() => _scopeFromTheRoot.DidNotReceive().Begin(Arg.Any<CommandContext>());
+}

--- a/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResponseValueHandlers/when_the_command_carries_its_own_scope/and_the_scope_offers_handlers.cs
+++ b/Source/DotNET/Arc.Core.Specs/Commands/for_CommandResponseValueHandlers/when_the_command_carries_its_own_scope/and_the_scope_offers_handlers.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Execution;
+
+namespace Cratis.Arc.Commands.for_CommandResponseValueHandlers.when_the_command_carries_its_own_scope;
+
+/// <summary>
+/// A handler is resolved from the scope the command runs in, not from the provider that constructed this singleton.
+/// Resolving from the latter means resolving from the root, where a handler depending on a scoped service — as every
+/// Chronicle response value handler does through <c>IEventLog</c> — cannot be created at all.
+/// </summary>
+public class and_the_scope_offers_handlers : Specification
+{
+    CommandResponseValueHandlers _handlers;
+    ICommandResponseValueHandler _handlerFromTheScope;
+    ICommandResponseValueHandler _handlerFromTheRoot;
+    CommandContext _context;
+    string _value;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _handlerFromTheScope = Substitute.For<ICommandResponseValueHandler>();
+        _handlerFromTheScope.CanHandle(Arg.Any<CommandContext>(), Arg.Any<object>()).Returns(true);
+        _handlerFromTheScope.Handle(Arg.Any<CommandContext>(), Arg.Any<object>()).Returns(CommandResult.Success(CorrelationId.New()));
+
+        _handlerFromTheRoot = Substitute.For<ICommandResponseValueHandler>();
+        _handlerFromTheRoot.CanHandle(Arg.Any<CommandContext>(), Arg.Any<object>()).Returns(true);
+        _handlerFromTheRoot.Handle(Arg.Any<CommandContext>(), Arg.Any<object>()).Returns(CommandResult.Success(CorrelationId.New()));
+
+        var scope = Substitute.For<IServiceProvider>();
+        scope.GetService(typeof(IInstancesOf<ICommandResponseValueHandler>))
+            .Returns(new KnownInstancesOf<ICommandResponseValueHandler>([_handlerFromTheScope]));
+
+        _handlers = new(new KnownInstancesOf<ICommandResponseValueHandler>([_handlerFromTheRoot]));
+        _context = new(CorrelationId.New(), typeof(string), "Something", [], new(), ServiceProvider: scope);
+        _value = "Forty two";
+    }
+
+    async Task Because() => _result = await _handlers.Handle(_context, _value);
+
+    [Fact] void should_handle_with_the_handler_from_the_scope() => _handlerFromTheScope.Received().Handle(_context, _value);
+    [Fact] void should_not_handle_with_the_handler_from_the_root() => _handlerFromTheRoot.DidNotReceive().Handle(_context, _value);
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+}

--- a/Source/DotNET/Arc.Core.Specs/Queries/for_QueryFilters/when_performing/and_the_query_carries_its_own_scope.cs
+++ b/Source/DotNET/Arc.Core.Specs/Queries/for_QueryFilters/when_performing/and_the_query_carries_its_own_scope.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Arc.Queries.for_QueryFilters.when_performing;
+
+/// <summary>
+/// A filter is resolved from the scope the query runs in, not from the provider that constructed this singleton,
+/// so a filter depending on a scoped service is created in the scope rather than in the root — the same lifetime
+/// seam the command pipeline has.
+/// </summary>
+public class and_the_query_carries_its_own_scope : given.a_query_filters
+{
+    IQueryFilter _filterFromTheScope;
+    IQueryFilter _filterFromTheRoot;
+    QueryContext _context;
+
+    void Establish()
+    {
+        _filterFromTheScope = Substitute.For<IQueryFilter>();
+        _filterFromTheRoot = Substitute.For<IQueryFilter>();
+
+        var scope = Substitute.For<IServiceProvider>();
+        scope.GetService(typeof(IInstancesOf<IQueryFilter>))
+            .Returns(new KnownInstancesOf<IQueryFilter>([_filterFromTheScope]));
+
+        _context = new("Test Query", _correlationId, Paging.NotPaged, Sorting.None, ServiceProvider: scope);
+        _queryFilters = new(new KnownInstancesOf<IQueryFilter>([_filterFromTheRoot]), _activitySource);
+    }
+
+    async Task Because() => await _queryFilters.OnPerform(_context);
+
+    [Fact] void should_run_the_filter_from_the_scope() => _filterFromTheScope.Received(1).OnPerform(_context);
+    [Fact] void should_not_run_the_filter_from_the_root() => _filterFromTheRoot.DidNotReceive().OnPerform(Arg.Any<QueryContext>());
+}

--- a/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandFilters.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.DependencyInjection;
 using Cratis.DependencyInjection;
 using Cratis.Traces;
 using Cratis.Types;
@@ -21,11 +22,15 @@ public class CommandFilters(IInstancesOf<ICommandFilter> filters, IActivitySourc
         var result = CommandResult.Success(context.CorrelationId);
         using var span = activitySource.OnExecution(context.Type.FullName ?? context.Type.Name);
 
+        // Filters are resolved from the command's own scope rather than the provider that constructed this singleton,
+        // so a filter depending on a scoped service is created in the scope the command runs in instead of the root.
+        var discoveredFilters = DiscoveredInstances.ResolvedFrom(context.ServiceProvider, filters);
+
         // Evaluate authorization filters before ordinary filters, independent of the order IInstancesOf yields them.
         // Without this the short-circuit below could return on a validation failure before the authorization filter
         // runs, leaving the authorization verdict at its default (authorized) and reporting a forbidden caller as
         // authorized. OrderBy is a stable sort, so filters within the same group keep their discovery order.
-        foreach (var filter in filters.OrderBy(filter => filter is IAuthorizationCommandFilter ? 0 : 1))
+        foreach (var filter in discoveredFilters.OrderBy(filter => filter is IAuthorizationCommandFilter ? 0 : 1))
         {
             try
             {

--- a/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandPipeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using Cratis.Arc.DependencyInjection;
 using Cratis.Arc.Validation;
 using Cratis.DependencyInjection;
 using Cratis.Execution;
@@ -112,8 +113,10 @@ public class CommandPipeline(
                 CancellationToken: cancellationToken);
             contextModifier.SetCurrent(commandContext);
 
-            // Materialized once so Begin and Complete are guaranteed to act on the same scope instances.
-            scopes = [.. executionScopes];
+            // Materialized once so Begin and Complete are guaranteed to act on the same scope instances, and resolved
+            // from the command's own scope rather than the provider that constructed this singleton, so an execution
+            // scope depending on a scoped service is created in the scope the command runs in instead of the root.
+            scopes = [.. DiscoveredInstances.ResolvedFrom(serviceProvider, executionScopes)];
             foreach (var executionScope in scopes)
             {
                 executionScope.Begin(commandContext);

--- a/Source/DotNET/Arc.Core/Commands/CommandResponseValueHandlers.cs
+++ b/Source/DotNET/Arc.Core/Commands/CommandResponseValueHandlers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.DependencyInjection;
 using Cratis.DependencyInjection;
 using Cratis.Types;
 
@@ -16,7 +17,7 @@ public class CommandResponseValueHandlers(IInstancesOf<ICommandResponseValueHand
     /// <inheritdoc/>
     public void UpdateContext(CommandContext context, object value)
     {
-        foreach (var handler in handlers.OfType<ICommandResponseValueContextUpdater>().Where(_ => _.CanHandle(context, value)))
+        foreach (var handler in HandlersFor(context).OfType<ICommandResponseValueContextUpdater>().Where(_ => _.CanHandle(context, value)))
         {
             handler.UpdateContext(context, value);
         }
@@ -24,12 +25,12 @@ public class CommandResponseValueHandlers(IInstancesOf<ICommandResponseValueHand
 
     /// <inheritdoc/>
     public bool CanHandle(CommandContext context, object value) =>
-        handlers.Any(handler => handler.CanHandle(context, value));
+        HandlersFor(context).Any(handler => handler.CanHandle(context, value));
 
     /// <inheritdoc/>
     public async Task<CommandResult> Handle(CommandContext context, object value)
     {
-        var handlersThatCanHandle = handlers.Where(handler => handler.CanHandle(context, value)).ToArray();
+        var handlersThatCanHandle = HandlersFor(context).Where(handler => handler.CanHandle(context, value)).ToArray();
         var commandResult = CommandResult.Success(context.CorrelationId);
         if (handlersThatCanHandle.Length != 0)
         {
@@ -42,4 +43,14 @@ public class CommandResponseValueHandlers(IInstancesOf<ICommandResponseValueHand
 
         return commandResult;
     }
+
+    /// <summary>
+    /// Gets the handlers to use for a command, resolved from the command's own scope rather than the provider that
+    /// constructed this singleton, so a handler depending on a scoped service — as every Chronicle handler does
+    /// through <c>IEventLog</c> — is created in the scope the command runs in instead of the root.
+    /// </summary>
+    /// <param name="context">The <see cref="CommandContext"/> for the command being handled.</param>
+    /// <returns>The available <see cref="ICommandResponseValueHandler"/>.</returns>
+    IEnumerable<ICommandResponseValueHandler> HandlersFor(CommandContext context) =>
+        DiscoveredInstances.ResolvedFrom(context.ServiceProvider, handlers);
 }

--- a/Source/DotNET/Arc.Core/DependencyInjection/DiscoveredInstances.cs
+++ b/Source/DotNET/Arc.Core/DependencyInjection/DiscoveredInstances.cs
@@ -23,7 +23,7 @@ namespace Cratis.Arc.DependencyInjection;
 /// provider Arc already threads through <c>CommandContext</c> and <c>QueryContext</c> for exactly this purpose.
 /// </para>
 /// </remarks>
-public static class DiscoveredInstances
+static class DiscoveredInstances
 {
     /// <summary>
     /// Gets the discovered implementations of <typeparamref name="T"/>, resolved from the given <see cref="IServiceProvider"/>.

--- a/Source/DotNET/Arc.Core/DependencyInjection/DiscoveredInstances.cs
+++ b/Source/DotNET/Arc.Core/DependencyInjection/DiscoveredInstances.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Arc.DependencyInjection;
+
+/// <summary>
+/// Resolves discovered implementations of an extension point from the service provider that owns the work being done.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IInstancesOf{T}"/> resolves each implementation lazily, but from the <see cref="IServiceProvider"/> that
+/// constructed it. A singleton holding one therefore resolves every implementation from the root provider, and an
+/// implementation that depends on a scoped service cannot be created there — the container rejects it outright once
+/// scope validation is on, which is what the host enables in Development.
+/// </para>
+/// <para>
+/// The systems that hold these collections are legitimately singletons: they are held in turn by the command and query
+/// pipelines, which are singletons themselves because they create the scope a command runs in. So rather than moving
+/// the collections into the scope, they resolve their implementations from the scope at the point of use — the same
+/// provider Arc already threads through <c>CommandContext</c> and <c>QueryContext</c> for exactly this purpose.
+/// </para>
+/// </remarks>
+public static class DiscoveredInstances
+{
+    /// <summary>
+    /// Gets the discovered implementations of <typeparamref name="T"/>, resolved from the given <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of the extension point to get implementations of.</typeparam>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/> scoped to the work being done, if there is one.</param>
+    /// <param name="fallback">The <see cref="IInstancesOf{T}"/> to use when there is no service provider to resolve from.</param>
+    /// <returns>The discovered implementations of <typeparamref name="T"/>.</returns>
+    /// <remarks>
+    /// Falls back to <paramref name="fallback"/> when there is no service provider — a command executed without one
+    /// has no scope for an implementation to be resolved from, and the injected collection is the only set available.
+    /// </remarks>
+    public static IEnumerable<T> ResolvedFrom<T>(IServiceProvider? serviceProvider, IInstancesOf<T> fallback)
+        where T : class =>
+        serviceProvider?.GetService<IInstancesOf<T>>() ?? fallback;
+}

--- a/Source/DotNET/Arc.Core/Queries/QueryFilters.cs
+++ b/Source/DotNET/Arc.Core/Queries/QueryFilters.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Arc.DependencyInjection;
 using Cratis.DependencyInjection;
 using Cratis.Traces;
 using Cratis.Types;
@@ -21,11 +22,15 @@ public class QueryFilters(IInstancesOf<IQueryFilter> filters, IActivitySource<Qu
         var result = QueryResult.Success(context.CorrelationId);
         using var span = activitySource.OnPerform(context.Name.Value);
 
+        // Filters are resolved from the query's own scope rather than the provider that constructed this singleton,
+        // so a filter depending on a scoped service is created in the scope the query runs in instead of the root.
+        var discoveredFilters = DiscoveredInstances.ResolvedFrom(context.ServiceProvider, filters);
+
         // Evaluate authorization filters before ordinary filters, independent of the order IInstancesOf yields them.
         // Without this the short-circuit below could return on a validation failure before the authorization filter
         // runs — turning what should be a 403 for a forbidden caller into a 400 depending on undefined discovery order.
         // OrderBy is a stable sort, so filters within the same group keep their discovery order.
-        foreach (var filter in filters.OrderBy(filter => filter is IAuthorizationQueryFilter ? 0 : 1))
+        foreach (var filter in discoveredFilters.OrderBy(filter => filter is IAuthorizationQueryFilter ? 0 : 1))
         {
             try
             {

--- a/Source/DotNET/Arc.Specs/for_HostBuilderExtensions/when_adding_cratis_arc/and_a_command_response_value_handler_needs_a_scoped_service.cs
+++ b/Source/DotNET/Arc.Specs/for_HostBuilderExtensions/when_adding_cratis_arc/and_a_command_response_value_handler_needs_a_scoped_service.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Identity;
+using Cratis.Execution;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Hosting.for_HostBuilderExtensions.when_adding_cratis_arc;
+
+public class and_a_command_response_value_handler_needs_a_scoped_service : Specification
+{
+    IHost? _host;
+    Exception? _error;
+
+    void Because()
+    {
+        var builder = new HostBuilder()
+            .ConfigureDefaults([])
+            .UseEnvironment(Environments.Development)
+            .AddCratisArc(options => options.IdentityDetailsProvider = typeof(DefaultIdentityDetailsProvider));
+
+        builder.ConfigureServices(services =>
+        {
+            services.AddScoped<ScopedCollaborator>();
+            services.AddTransient<HandlerNeedingAScopedCollaborator>();
+        });
+
+        _host = builder.Build();
+        _error = Catch.Exception(AskTheHandlersWhetherTheyCanHandleAValue);
+    }
+
+    void AskTheHandlersWhetherTheyCanHandleAValue()
+    {
+        using var scope = _host!.Services.CreateScope();
+        var handlers = _host.Services.GetRequiredService<ICommandResponseValueHandlers>();
+        var context = new CommandContext(
+            CorrelationId.New(),
+            typeof(object),
+            new object(),
+            [],
+            new(),
+            ServiceProvider: scope.ServiceProvider);
+
+        handlers.CanHandle(context, "a value");
+    }
+
+    void Destroy() => _host?.Dispose();
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+
+    public class ScopedCollaborator;
+
+    public class HandlerNeedingAScopedCollaborator(ScopedCollaborator collaborator) : ICommandResponseValueHandler
+    {
+        public bool CanHandle(CommandContext commandContext, object value) => collaborator is not null && value is int;
+
+        public Task<CommandResult> Handle(CommandContext commandContext, object value) =>
+            Task.FromResult(CommandResult.Success(commandContext.CorrelationId));
+    }
+}


### PR DESCRIPTION
## Fixed

- Start a Development application that uses a Chronicle command response value. Arc's discovered extension points were resolved from the root service provider, so a handler depending on the scoped `IEventLog` could not be created once the host turned scope validation on, and every such command threw. (#2505)
- Resolve command filters, command execution scopes and query filters from the scope the work runs in, so an implementation of any of these that depends on a scoped service works instead of throwing in Development. (#2505)
