### PR TITLE
Report a property whose type is a contract the document cannot declare

### DIFF
--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_abstract_class.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_abstract_class.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An abstract class leaves the same gap an interface does and for the same reason - what a value of it holds is
+/// settled by whatever derives from it - so it is reported the same way. It is worth saying separately because it is
+/// the shape that reaches real documents: an application describing a screen carries a base element far more often
+/// than it carries a bare interface.
+/// </summary>
+public class a_property_carrying_an_abstract_class : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        public abstract class UIElement
+        {
+            public string Kind { get; init; } = string.Empty;
+        }
+
+        [EventType]
+        public record AuthorRegistered(string Name, UIElement Element);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_report_a_name_the_document_never_declares() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableTypeReference);
+    [Fact] void should_name_the_contract_it_could_not_declare() => _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).Message.ShouldContain("UIElement");
+    [Fact] void should_say_nothing_about_the_property_it_could_express() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).ShouldEqual(1);
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_abstract_record.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_abstract_record.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// Being abstract is not on its own what leaves a name undeclared. A record is declared whether or not it is abstract,
+/// so a property carrying one names a shape the document does introduce, and reporting it would say a reference is
+/// dangling that resolves. This is the line between the two - what is reported is a type no declaration is written
+/// for, not a type something can derive from.
+/// </summary>
+public class a_property_carrying_an_abstract_record : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        public abstract record Outline(string Kind);
+
+        [EventType]
+        public record AuthorRegistered(string Name, Outline Shape);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_declare_the_shape_the_property_names() => _analysis.Model.Types.Any(_ => _.Name == "Outline").ShouldBeTrue();
+    [Fact] void should_report_nothing_the_document_declares() => _analysis.Diagnostics.Any(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).ShouldBeFalse();
+}

--- a/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_interface.cs
+++ b/Source/DotNET/Screenplay.Specs/for_ApplicationModelAnalyzer/when_analyzing/a_property_carrying_an_interface.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Screenplay.Analysis;
+
+namespace Cratis.Arc.Screenplay.for_ApplicationModelAnalyzer.when_analyzing;
+
+/// <summary>
+/// An interface survives being written as the single identifier the grammar allows, so nothing is lost in the writing.
+/// What cannot be written is the declaration: a <c>type</c> says what a value holds, and what an implementation holds
+/// is exactly what a contract leaves open. The property names something the document never introduces, which is the
+/// same dangling reference a constructed generic leaves, so it is said rather than passed off as an answer.
+/// </summary>
+public class a_property_carrying_an_interface : Specification
+{
+    const string Source = """
+        using Cratis.Chronicle.Events;
+
+        namespace Library.Authors.Registration;
+
+        public interface IRule;
+
+        [EventType]
+        public record AuthorRegistered(string Name, IRule Rule);
+        """;
+
+    ApplicationModelAnalysis _analysis;
+
+    void Establish() => _analysis = Analyzed.Source(Source);
+
+    [Fact] void should_compile_the_source_it_analyzed() => Analyzed.ErrorsIn((Analyzed.SlicePath, Source)).ShouldBeEmpty();
+    [Fact] void should_report_a_name_the_document_never_declares() => _analysis.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnmappableTypeReference);
+    [Fact] void should_name_the_contract_it_could_not_declare() => _analysis.Diagnostics.Single(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).Message.ShouldContain("IRule");
+    [Fact] void should_say_nothing_about_the_property_it_could_express() => _analysis.Diagnostics.Count(_ => _.Code == ScreenplayDiagnosticCodes.UnmappableTypeReference).ShouldEqual(1);
+}

--- a/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
+++ b/Source/DotNET/Screenplay/Analysis/Types/TypeRegistry.cs
@@ -107,6 +107,15 @@ public class TypeRegistry
         _concepts.AddValidations(conceptName, rules);
 
     /// <summary>
+    /// Determines whether a type says what implements it rather than what it holds.
+    /// </summary>
+    /// <param name="type">The type being named.</param>
+    /// <returns>True when no type declaration can be written for it.</returns>
+    static bool IsAContract(ITypeSymbol type) =>
+        type.TypeKind == TypeKind.Interface ||
+        type is INamedTypeSymbol { IsAbstract: true, TypeKind: TypeKind.Class, IsRecord: false };
+
+    /// <summary>
     /// Resolves the name a type is referenced by, registering it as a concept when it is one.
     /// </summary>
     /// <param name="type">The type to name.</param>
@@ -148,7 +157,7 @@ public class TypeRegistry
     }
 
     /// <summary>
-    /// Records a type whose simple name says less than the type does.
+    /// Records a type the document refers to by a name it never declares.
     /// </summary>
     /// <param name="type">The type being named.</param>
     /// <remarks>
@@ -156,10 +165,18 @@ public class TypeRegistry
     /// writing <c>IDictionary&lt;string, string&gt;</c> as the single identifier the grammar allows leaves the word
     /// <c>KeyValuePair</c> behind, which says nothing and which the document never declares. Same for a type
     /// parameter, whose name is a placeholder rather than a type.
+    /// <para>
+    /// A contract is the same failure arrived at from the other side. An interface or an abstract class survives being
+    /// written as a single identifier intact - the name is not what is lost - but a <c>type</c> declaration says what a
+    /// value holds, and what an implementation holds is exactly what a contract leaves open. Only a record is declared
+    /// (see <see cref="CarriedTypes.IsRecord"/>), so the property names something the document never introduces, which
+    /// is the same dangling reference a constructed generic leaves and is reported the same way. An abstract record is
+    /// not among these: it is declared like any other record, so it names something the document does introduce.
+    /// </para>
     /// </remarks>
     void ReportWhatTheNameLoses(ITypeSymbol type)
     {
-        if (type is INamedTypeSymbol { TypeArguments.Length: > 0 } or { TypeKind: TypeKind.TypeParameter })
+        if (type is INamedTypeSymbol { TypeArguments.Length: > 0 } or { TypeKind: TypeKind.TypeParameter } || IsAContract(type))
         {
             _unmappable.Add(type.ToDisplayString());
         }

--- a/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/DotNET/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -234,12 +234,18 @@ public static class ScreenplayDiagnosticCodes
     // be declared with it.
 
     /// <summary>
-    /// A type is referred to by a name that does not say what it is, because Screenplay cannot express it.
+    /// A type is referred to by a name the document never declares, because Screenplay cannot express it.
     /// </summary>
     /// <remarks>
     /// A Screenplay type reference is a single identifier. A constructed generic loses its arguments the moment it is
     /// written as one - a map of names to values becomes the word <c>KeyValuePair</c> - and the document then refers
     /// to a type it never declares. Nothing better can be written, so what was lost is said instead.
+    /// <para>
+    /// An interface or an abstract class ends in the same place by the opposite route. Its name survives being written
+    /// as a single identifier, so nothing is lost in the writing; what cannot be written is the declaration, because a
+    /// <c>type</c> says what a value holds and a contract leaves that to whatever implements it. Either way the
+    /// property names something the document never introduces, which is the one thing worth saying about both.
+    /// </para>
     /// </remarks>
     public const string UnmappableTypeReference = "SP0030";
 


### PR DESCRIPTION
## Fixed

- Report `SP0030` for a property whose type is an interface or an abstract class. The document names such a type without ever declaring it, and until now nothing said so — only a constructed generic or a type parameter was recognised, and a contract matched neither. (#2527)
