### PR TITLE
Name the constraint that rejected a command

### DIFF
--- a/Documentation/backend/testing/command-scenario.md
+++ b/Documentation/backend/testing/command-scenario.md
@@ -103,10 +103,21 @@ The `CommandResultShouldExtensions` class provides fluent BDD-style assertions f
 | `ShouldBeValid()` | `IsValid` is `true`; lists all validation errors on failure |
 | `ShouldHaveValidationErrors()` | `IsValid` is `false` |
 | `ShouldHaveValidationErrorFor(message)` | At least one validation error contains the given text |
+| `ShouldHaveValidationErrorBecauseOf(reason)` | At least one validation error carries the given `ValidationResultReason` |
+| `ShouldHaveConstraintViolationFor(constraintName)` | At least one validation error is a constraint violation for the named constraint |
 | `ShouldBeAuthorized()` | `IsAuthorized` is `true` |
 | `ShouldNotBeAuthorized()` | `IsAuthorized` is `false` |
 | `ShouldNotHaveExceptions()` | `HasExceptions` is `false` |
 | `ShouldHaveExceptions()` | `HasExceptions` is `true` |
+
+### Assert the constraint name, not the message
+
+`ShouldHaveValidationErrorFor(message)` matches against text a human wrote, so the spec stops asserting anything the day someone rewords it — and it cannot tell one constraint from another when two produce similar copy. When a command was rejected by a Chronicle constraint, name the constraint instead. It is the same assertion Chronicle offers on an append result, so a spec says the same thing whether the events reach the store through a command or a raw append.
+
+```csharp
+[Fact] void should_be_rejected_by_the_uniqueness_constraint() =>
+    _result.ShouldHaveConstraintViolationFor(AuthorConstraintNames.UniqueName);
+```
 
 ### Example: Validation spec
 

--- a/Documentation/frontend/core/commands/command-result.md
+++ b/Documentation/frontend/core/commands/command-result.md
@@ -183,6 +183,7 @@ Each `ValidationResult` contains:
 - `members`: Array of property names that failed validation
 - `state`: Additional context, set by whoever authored the rule (FluentValidation's `WithState`)
 - `reason`: What composed the result — see below
+- `reasonDetail`: Which specific thing within `reason` produced the result — the name of the violated constraint for `constraintViolation`. `undefined` when the reason carries no finer identity
 
 ### Telling one kind of rejection from another
 
@@ -206,6 +207,24 @@ if (result.validationResults.some(_ => _.reason === ValidationResultReason.Concu
     return retry();
 }
 ```
+
+### Telling one constraint from another
+
+`reason` says a constraint on the event store rejected the append; `reasonDetail` says **which** one. Two uniqueness constraints on the same command produce the same `reason`, so branching on it alone cannot pick the copy that belongs to each — and the message is developer text you should not be matching on either. Branch on the constraint name:
+
+```typescript
+const result = await command.execute();
+
+const rejectedBy = (constraint: string) =>
+    result.validationResults.some(_ =>
+        _.reason === ValidationResultReason.ConstraintViolation && _.reasonDetail === constraint);
+
+if (rejectedBy('UniqueOrganizationNumber')) {
+    return setFieldError('organizationNumber', 'That organization number is already registered.');
+}
+```
+
+The value is the constraint's own name as Chronicle reports it on the violation — the same name a backend spec asserts with `ShouldHaveConstraintViolationFor`.
 
 :::note
 `reason` is an open set, not an enum — Arc, Chronicle and your own code can all mint values. Treat an unrecognized value the way you treat `rule`, and never `switch` over it exhaustively.

--- a/Source/DotNET/Arc.Core/Validation/ValidationResult.cs
+++ b/Source/DotNET/Arc.Core/Validation/ValidationResult.cs
@@ -13,7 +13,7 @@ namespace Cratis.Arc.Validation;
 /// <remarks>
 /// <see cref="State"/> belongs to whoever authored the rule - it carries FluentValidation's <c>WithState</c> value
 /// straight through - so it is not where the framework says what kind of rejection this is. That is
-/// <see cref="Reason"/>.
+/// <see cref="Reason"/>, and which specific thing within that category is <see cref="ReasonDetail"/>.
 /// </remarks>
 public record ValidationResult(ValidationResultSeverity Severity, string Message, IEnumerable<string> Members, object State)
 {
@@ -24,15 +24,29 @@ public record ValidationResult(ValidationResultSeverity Severity, string Message
     public ValidationResultReason Reason { get; init; } = ValidationResultReason.Rule;
 
     /// <summary>
+    /// Gets the identity of the specific thing that produced this result within its <see cref="Reason"/> category,
+    /// or <see langword="null"/> when the reason carries no finer identity. <see cref="Reason"/> says a constraint rejected
+    /// the command; this says <em>which</em> constraint - so a client can branch on identity instead of parsing
+    /// <see cref="Message"/>, which is prose written for a human and free to change.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a <see cref="string"/> and deliberately not named after any one reason: this type is Arc's
+    /// general validation result, it does not depend on Chronicle, and every category is free to fill this in with
+    /// whatever names its own rejections - a constraint name today, something else tomorrow.
+    /// </remarks>
+    public string? ReasonDetail { get; init; }
+
+    /// <summary>
     /// Creates a new <see cref="ValidationResult"/> representing information.
     /// </summary>
     /// <param name="message">Message of the information.</param>
     /// <param name="members">Collection of member names that are related to the information.</param>
     /// <param name="state">State associated with the validation result.</param>
     /// <param name="reason">What composed the result. Defaults to <see cref="ValidationResultReason.Rule"/>.</param>
+    /// <param name="reasonDetail">The identity of the specific thing within <paramref name="reason"/> that produced the result.</param>
     /// <returns>A <see cref="ValidationResult"/>.</returns>
-    public static ValidationResult Information(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default)
-        => new(ValidationResultSeverity.Information, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule };
+    public static ValidationResult Information(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default, string? reasonDetail = default)
+        => new(ValidationResultSeverity.Information, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule, ReasonDetail = reasonDetail };
 
     /// <summary>
     /// Creates a new <see cref="ValidationResult"/> representing a warning.
@@ -41,9 +55,10 @@ public record ValidationResult(ValidationResultSeverity Severity, string Message
     /// <param name="members">Collection of member names that caused the warning.</param>
     /// <param name="state">State associated with the validation result.</param>
     /// <param name="reason">What composed the result. Defaults to <see cref="ValidationResultReason.Rule"/>.</param>
+    /// <param name="reasonDetail">The identity of the specific thing within <paramref name="reason"/> that produced the result.</param>
     /// <returns>A <see cref="ValidationResult"/>.</returns>
-    public static ValidationResult Warning(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default)
-        => new(ValidationResultSeverity.Warning, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule };
+    public static ValidationResult Warning(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default, string? reasonDetail = default)
+        => new(ValidationResultSeverity.Warning, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule, ReasonDetail = reasonDetail };
 
     /// <summary>
     /// Creates a new <see cref="ValidationResult"/> representing an error.
@@ -52,7 +67,8 @@ public record ValidationResult(ValidationResultSeverity Severity, string Message
     /// <param name="members">Collection of member names that caused the error.</param>
     /// <param name="state">State associated with the validation result.</param>
     /// <param name="reason">What composed the result. Defaults to <see cref="ValidationResultReason.Rule"/>.</param>
+    /// <param name="reasonDetail">The identity of the specific thing within <paramref name="reason"/> that produced the result.</param>
     /// <returns>A <see cref="ValidationResult"/>.</returns>
-    public static ValidationResult Error(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default)
-        => new(ValidationResultSeverity.Error, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule };
+    public static ValidationResult Error(string message, IEnumerable<string>? members = default, object? state = default, ValidationResultReason? reason = default, string? reasonDetail = default)
+        => new(ValidationResultSeverity.Error, message, members ?? [], state!) { Reason = reason ?? ValidationResultReason.Rule, ReasonDetail = reasonDetail };
 }

--- a/Source/DotNET/Chronicle.Specs/Commands/for_AppendResultExtensions/when_converting_append_result/with_constraint_violations.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_AppendResultExtensions/when_converting_append_result/with_constraint_violations.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
@@ -36,4 +37,11 @@ public class with_constraint_violations : given.all_dependencies
     [Fact] void should_include_constraint_violation_message() => _result.ValidationResults.First().Message.ShouldEqual("Test violation message");
     [Fact] void should_attribute_the_violation_to_the_camel_cased_member() => _result.ValidationResults.First().Members.ShouldContain("organizationNumber");
     [Fact] void should_say_the_rejection_is_a_constraint_violation() => _result.ValidationResults.First().Reason.ShouldEqual(Validation.ValidationResultReason.ConstraintViolation);
+    [Fact] void should_name_the_constraint_that_rejected_the_command() => _result.ValidationResults.First().ReasonDetail.ShouldEqual("TestConstraint");
+
+    /// <summary>
+    /// The parity the name exists for: the assertion a spec writes against a raw append holds unchanged once the
+    /// same events go through a command, and the <see cref="ConstraintName"/> concept is what it is written with.
+    /// </summary>
+    [Fact] void should_satisfy_the_same_assertion_a_raw_append_would() => _result.ShouldHaveConstraintViolationFor(new ConstraintName("TestConstraint"));
 }

--- a/Source/DotNET/Chronicle.Specs/Commands/for_ConstraintViolationExtensions/when_converting/with_the_property_name_in_details.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_ConstraintViolationExtensions/when_converting/with_the_property_name_in_details.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Arc.Chronicle.Commands.for_ConstraintViolationExtensions.when_converting;
+
+/// <summary>
+/// The full conversion: the violation arrives knowing which constraint rejected it, and every part of that has to
+/// survive the crossing into Arc's validation vocabulary - the message, the member it belongs to, the category of
+/// rejection, and the identity of the constraint itself.
+/// </summary>
+public class with_the_property_name_in_details : Specification
+{
+    ConstraintViolation _violation;
+    ValidationResult _result;
+
+    void Establish() => _violation = new ConstraintViolation(
+        EventTypeId.Unknown,
+        EventSequenceNumber.Unavailable,
+        ConstraintType.Unique,
+        new ConstraintName("UniqueOrganizationNumber"),
+        new ConstraintViolationMessage("The organization number is already in use"),
+        new ConstraintViolationDetails { [WellKnownConstraintDetailKeys.PropertyName] = "OrganizationNumber" });
+
+    void Because() => _result = _violation.ToValidationResult();
+
+    [Fact] void should_name_the_constraint_that_rejected_it() => _result.ReasonDetail.ShouldEqual("UniqueOrganizationNumber");
+    [Fact] void should_say_the_rejection_is_a_constraint_violation() => _result.Reason.ShouldEqual(ValidationResultReason.ConstraintViolation);
+    [Fact] void should_carry_the_violation_message() => _result.Message.ShouldEqual("The organization number is already in use");
+    [Fact] void should_attribute_it_to_the_camel_cased_member() => _result.Members.ShouldContainOnly("organizationNumber");
+    [Fact] void should_be_an_error() => _result.Severity.ShouldEqual(ValidationResultSeverity.Error);
+}

--- a/Source/DotNET/Chronicle.Specs/Commands/for_ConstraintViolationExtensions/when_converting/without_the_property_name_in_details.cs
+++ b/Source/DotNET/Chronicle.Specs/Commands/for_ConstraintViolationExtensions/when_converting/without_the_property_name_in_details.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Validation;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Arc.Chronicle.Commands.for_ConstraintViolationExtensions.when_converting;
+
+/// <summary>
+/// A constraint that names no property - one declared over the whole event rather than a single value - still names
+/// itself. The identity of the constraint does not ride along on the details a violation happens to carry, so a
+/// client can branch on it for every constraint, not only the ones that resolve to a field.
+/// </summary>
+public class without_the_property_name_in_details : Specification
+{
+    ConstraintViolation _violation;
+    ValidationResult _result;
+
+    void Establish() => _violation = new ConstraintViolation(
+        EventTypeId.Unknown,
+        EventSequenceNumber.Unavailable,
+        ConstraintType.Unique,
+        new ConstraintName("OneOnboardingPerAccount"),
+        new ConstraintViolationMessage("The account has already been onboarded"),
+        new ConstraintViolationDetails());
+
+    void Because() => _result = _violation.ToValidationResult();
+
+    [Fact] void should_name_the_constraint_that_rejected_it() => _result.ReasonDetail.ShouldEqual("OneOnboardingPerAccount");
+    [Fact] void should_not_attribute_it_to_any_member() => _result.Members.ShouldBeEmpty();
+}

--- a/Source/DotNET/Chronicle/Commands/ConstraintViolationExtensions.cs
+++ b/Source/DotNET/Chronicle/Commands/ConstraintViolationExtensions.cs
@@ -23,7 +23,9 @@ public static class ConstraintViolationExtensions
     /// <remarks>
     /// The result carries <see cref="ValidationResultReason.ConstraintViolation"/>: the message is the constraint's,
     /// not an authored rule's, and a client that treats the two the same cannot tell a store-level rejection from
-    /// one its own domain rules produced.
+    /// one its own domain rules produced. It also carries the violated <see cref="ConstraintName"/> as
+    /// <see cref="ValidationResult.ReasonDetail"/>, so telling <em>which</em> constraint rejected the command does
+    /// not come down to matching against the message - prose written for a human, and free to change.
     /// </remarks>
     public static ValidationResult ToValidationResult(this ConstraintViolation violation)
     {
@@ -31,6 +33,10 @@ public static class ConstraintViolationExtensions
             ? [propertyName.ToCamelCase()]
             : [];
 
-        return ValidationResult.Error(violation.Message.Value, members, reason: ValidationResultReason.ConstraintViolation);
+        return ValidationResult.Error(
+            violation.Message.Value,
+            members,
+            reason: ValidationResultReason.ConstraintViolation,
+            reasonDetail: violation.ConstraintName.Value);
     }
 }

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_an_authored_rule_carries_the_same_name.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_an_authored_rule_carries_the_same_name.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Testing.for_CommandResultShouldExtensions.when_asserting_a_constraint;
+
+/// <summary>
+/// The detail is a general field, open to every reason, so a name on its own proves nothing. A rule the application
+/// authored may label its rejection with anything at all - including a string that happens to read like a constraint
+/// name - and that is not the store rejecting the append, which is what the spec claims when it names a constraint.
+/// </summary>
+[Collection(AssertionPolicyCollection.Name)]
+public class and_an_authored_rule_carries_the_same_name : Specification
+{
+    CommandResult _rejected;
+    Exception _error;
+
+    void Establish()
+    {
+        given.a_recording_policy.Reset();
+        _rejected = new CommandResult
+        {
+            ValidationResults = [ValidationResult.Error("The organization number is already in use", reasonDetail: "UniqueOrganizationNumber")]
+        };
+    }
+
+    void Because() => _error = Catch.Exception(() => _rejected.ShouldHaveConstraintViolationFor("UniqueOrganizationNumber"));
+
+    [Fact] void should_not_accept_a_rule_wearing_a_constraint_name() => _error.ShouldBeOfExactType<CommandResultAssertionException>();
+    [Fact] void should_say_the_rejection_came_from_a_rule() => _error.Message.ShouldContain("rule");
+    [Fact] void should_not_consult_the_policy() => given.a_recording_policy.Consulted.ShouldBeEmpty();
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_nothing_rejected_the_command.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_nothing_rejected_the_command.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+
+namespace Cratis.Arc.Testing.for_CommandResultShouldExtensions.when_asserting_a_constraint;
+
+/// <summary>
+/// A command that succeeded fails the assertion, and says so in the terms the reader needs. Listing the rejections
+/// that did happen is useless when there were none, so the diagnostic states the absence instead of trailing off
+/// after "Actual:" and leaving the reader to guess whether the constraint fired under another name.
+/// </summary>
+[Collection(AssertionPolicyCollection.Name)]
+public class and_nothing_rejected_the_command : Specification
+{
+    CommandResult _successful;
+    Exception _error;
+
+    void Establish()
+    {
+        given.a_recording_policy.Reset();
+        _successful = new CommandResult();
+    }
+
+    void Because() => _error = Catch.Exception(() => _successful.ShouldHaveConstraintViolationFor("UniqueOrganizationNumber"));
+
+    [Fact] void should_fail_the_assertion() => _error.ShouldBeOfExactType<CommandResultAssertionException>();
+    [Fact] void should_say_there_were_no_validation_errors_at_all() => _error.Message.ShouldContain("no validation errors at all");
+    [Fact] void should_not_consult_the_policy() => given.a_recording_policy.Consulted.ShouldBeEmpty();
+}

--- a/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_the_result_names_it.cs
+++ b/Source/DotNET/Testing.Specs/Commands/for_CommandResultShouldExtensions/when_asserting_a_constraint/and_the_result_names_it.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+using Cratis.Arc.Testing.Commands;
+using Cratis.Arc.Validation;
+
+namespace Cratis.Arc.Testing.for_CommandResultShouldExtensions.when_asserting_a_constraint;
+
+/// <summary>
+/// The assertion Chronicle already ships for an append result, now available where the same events reach the store
+/// through a command. It separates one constraint from another, which is what the reason assertion cannot do - every
+/// constraint in the system satisfies that one equally.
+/// </summary>
+[Collection(AssertionPolicyCollection.Name)]
+public class and_the_result_names_it : Specification
+{
+    CommandResult _rejected;
+    Exception _rightConstraint;
+    Exception _wrongConstraint;
+
+    void Establish()
+    {
+        given.a_recording_policy.Reset();
+        _rejected = new CommandResult
+        {
+            ValidationResults =
+            [
+                ValidationResult.Error(
+                    "The organization number is already in use",
+                    reason: ValidationResultReason.ConstraintViolation,
+                    reasonDetail: "UniqueOrganizationNumber")
+            ]
+        };
+    }
+
+    void Because()
+    {
+        _rightConstraint = Catch.Exception(() => _rejected.ShouldHaveConstraintViolationFor("UniqueOrganizationNumber"));
+        _wrongConstraint = Catch.Exception(() => _rejected.ShouldHaveConstraintViolationFor("UniqueEmailAddress"));
+    }
+
+    [Fact] void should_pass_for_the_constraint_the_result_names() => _rightConstraint.ShouldBeNull();
+    [Fact] void should_fail_for_a_constraint_it_does_not() => _wrongConstraint.ShouldBeOfExactType<CommandResultAssertionException>();
+    [Fact] void should_say_which_constraint_was_actually_violated() => _wrongConstraint.Message.ShouldContain("UniqueOrganizationNumber");
+    [Fact] void should_consult_the_policy_for_the_assertion_that_passed() => given.a_recording_policy.Consulted.ShouldContainOnly(nameof(CommandResultShouldExtensions.ShouldHaveConstraintViolationFor));
+
+    /// <summary>
+    /// The reason assertion passes on the very same result no matter which constraint the spec meant, so it cannot
+    /// tell a spec named after one uniqueness rule from a rejection produced by an entirely different one.
+    /// </summary>
+    [Fact] void should_be_a_result_the_reason_assertion_cannot_tell_apart() =>
+        Catch.Exception(() => _rejected.ShouldHaveValidationErrorBecauseOf(ValidationResultReason.ConstraintViolation)).ShouldBeNull();
+}

--- a/Source/DotNET/Testing/Commands/CommandResultShouldExtensions.cs
+++ b/Source/DotNET/Testing/Commands/CommandResultShouldExtensions.cs
@@ -135,6 +135,36 @@ public static class CommandResultShouldExtensions
     }
 
     /// <summary>
+    /// Asserts that the <see cref="CommandResult"/> was rejected by a specific named constraint.
+    /// </summary>
+    /// <param name="result">The <see cref="CommandResult"/> to assert.</param>
+    /// <param name="constraintName">The name of the constraint expected to have rejected the command.</param>
+    /// <exception cref="CommandResultAssertionException">
+    /// Thrown when no validation error is a constraint violation carrying that constraint name.
+    /// </exception>
+    /// <remarks>
+    /// The command-side counterpart to Chronicle's assertion of the same name on an append result, so the constraint
+    /// a spec names does not change depending on whether the events reach the store through a command or a raw
+    /// append. It asserts the constraint's identity rather than its message: the message is prose written for a
+    /// human and free to be reworded, while a spec that matches on it silently stops asserting anything the day it
+    /// is. Naming the constraint also separates this rejection from every other one — a domain rule, a race, or an
+    /// unrelated constraint all satisfy <see cref="ShouldHaveValidationErrors"/>, and every constraint whatsoever
+    /// satisfies <see cref="ShouldHaveValidationErrorBecauseOf"/> with
+    /// <see cref="ValidationResultReason.ConstraintViolation"/>.
+    /// </remarks>
+    public static void ShouldHaveConstraintViolationFor(this CommandResult result, string constraintName)
+    {
+        if (!result.ValidationResults.Any(_ => _.Reason == ValidationResultReason.ConstraintViolation && _.ReasonDetail == constraintName))
+        {
+            var actual = string.Join(", ", result.ValidationResults.Select(_ => $"{_.Reason}/{_.ReasonDetail ?? "<no detail>"} ('{_.Message}')"));
+            throw new CommandResultAssertionException(
+                $"Expected command to have a constraint violation for '{constraintName}', but none did. Actual: {(actual.Length > 0 ? actual : "no validation errors at all")}");
+        }
+
+        CommandResultAssertionPolicies.Apply(result);
+    }
+
+    /// <summary>
     /// Asserts that the <see cref="CommandResult"/> is authorized.
     /// </summary>
     /// <param name="result">The <see cref="CommandResult"/> to assert.</param>

--- a/Source/JavaScript/Arc/commands/CommandResult.ts
+++ b/Source/JavaScript/Arc/commands/CommandResult.ts
@@ -43,6 +43,7 @@ type ServerCommandResult = {
         members: string[];
         state: object;
         reason?: string;
+        reasonDetail?: string;
     }[];
     exceptionMessages: string[];
     exceptionStackTrace: string;
@@ -97,7 +98,9 @@ export class CommandResult<TResponse = object> implements ICommandResult<TRespon
                 severity: _.severity,
                 message: _.message,
                 members: _.members,
-                state: _.state
+                state: _.state,
+                reason: _.reason,
+                reasonDetail: _.reasonDetail
             })),
             exceptionMessages: [],
             exceptionStackTrace: '',
@@ -148,7 +151,7 @@ export class CommandResult<TResponse = object> implements ICommandResult<TRespon
         this.isAuthorized = result.isAuthorized;
         this.isValid = result.isValid;
         this.hasExceptions = result.hasExceptions;
-        this.validationResults = result.validationResults.map(_ => new ValidationResult(_.severity, _.message, _.members, _.state, _.reason));
+        this.validationResults = result.validationResults.map(_ => new ValidationResult(_.severity, _.message, _.members, _.state, _.reason, _.reasonDetail));
         this.exceptionMessages = result.exceptionMessages;
         this.exceptionStackTrace = result.exceptionStackTrace;
         this.authorizationFailureReason = result.authorizationFailureReason;

--- a/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
+++ b/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
@@ -43,6 +43,6 @@ describe('when constructing from a server result with a constraint violation', (
 
     it('should let a client tell one constraint from another without reading the message', () =>
         result.validationResults
-            .filter(_ => _.reason === ValidationResultReason.ConstraintViolation && _.reasonDetail === 'UniqueEmailAddress')
-            .length.should.equal(0));
+            .filter(_ => _.reason === ValidationResultReason.ConstraintViolation && _.reasonDetail === 'UniqueOrganizationNumber')
+            .length.should.equal(1));
 });

--- a/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
+++ b/Source/JavaScript/Arc/commands/for_CommandResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationResultReason } from '../../validation/ValidationResultReason';
+import { ValidationResultSeverity } from '../../validation/ValidationResultSeverity';
+import { CommandResult } from '../CommandResult';
+
+describe('when constructing from a server result with a constraint violation', () => {
+    const result = new CommandResult({
+        correlationId: '0c0ee8c8-b5a6-4999-b030-6e6a0c931b91',
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [
+            {
+                severity: ValidationResultSeverity.Error,
+                message: 'The organization number is already in use',
+                members: ['organizationNumber'],
+                state: {},
+                reason: ValidationResultReason.ConstraintViolation,
+                reasonDetail: 'UniqueOrganizationNumber'
+            },
+            {
+                severity: ValidationResultSeverity.Error,
+                message: 'Name is required',
+                members: ['name'],
+                state: {}
+            }
+        ],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        authorizationFailureReason: '',
+        response: null
+    }, String, false);
+
+    it('should carry the name of the violated constraint across the wire', () =>
+        result.validationResults[0].reasonDetail!.should.equal('UniqueOrganizationNumber'));
+
+    // A reason with no finer identity - and a server that predates this - both send nothing.
+    it('should leave the detail undefined when the server sends none', () =>
+        (result.validationResults[1].reasonDetail === undefined).should.be.true);
+
+    it('should let a client tell one constraint from another without reading the message', () =>
+        result.validationResults
+            .filter(_ => _.reason === ValidationResultReason.ConstraintViolation && _.reasonDetail === 'UniqueEmailAddress')
+            .length.should.equal(0));
+});

--- a/Source/JavaScript/Arc/commands/for_CommandResult/when_creating_a_validation_failed_result.ts
+++ b/Source/JavaScript/Arc/commands/for_CommandResult/when_creating_a_validation_failed_result.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationResult } from '../../validation/ValidationResult';
+import { ValidationResultReason } from '../../validation/ValidationResultReason';
+import { ValidationResultSeverity } from '../../validation/ValidationResultSeverity';
+import { CommandResult } from '../CommandResult';
+
+describe('when creating a validation failed result', () => {
+    const result = CommandResult.validationFailed([
+        new ValidationResult(
+            ValidationResultSeverity.Error,
+            'The organization number is already in use',
+            ['organizationNumber'],
+            {},
+            ValidationResultReason.ConstraintViolation,
+            'UniqueOrganizationNumber')
+    ]);
+
+    it('should keep the reason the caller gave it', () =>
+        result.validationResults[0].reason.should.equal(ValidationResultReason.ConstraintViolation));
+
+    it('should keep the name of the violated constraint', () =>
+        result.validationResults[0].reasonDetail!.should.equal('UniqueOrganizationNumber'));
+});

--- a/Source/JavaScript/Arc/queries/QueryResult.ts
+++ b/Source/JavaScript/Arc/queries/QueryResult.ts
@@ -95,7 +95,9 @@ export class QueryResult<TDataType = object> implements IQueryResult<TDataType> 
                 severity: _.severity,
                 message: _.message,
                 members: _.members,
-                state: _.state
+                state: _.state,
+                reason: _.reason,
+                reasonDetail: _.reasonDetail
             })),
             exceptionMessages: [],
             exceptionStackTrace: '',

--- a/Source/JavaScript/Arc/queries/QueryResult.ts
+++ b/Source/JavaScript/Arc/queries/QueryResult.ts
@@ -38,6 +38,7 @@ type ServerValidationResult = {
     members: string[];
     state: object;
     reason?: string;
+    reasonDetail?: string;
 }
 
 type ServerPagingInfo = {
@@ -154,7 +155,7 @@ export class QueryResult<TDataType = object> implements IQueryResult<TDataType> 
         this.isAuthorized = result.isAuthorized;
         this.isValid = result.isValid;
         this.hasExceptions = result.hasExceptions;
-        this.validationResults = result.validationResults.map(_ => new ValidationResult(_.severity, _.message, _.members, _.state, _.reason));
+        this.validationResults = result.validationResults.map(_ => new ValidationResult(_.severity, _.message, _.members, _.state, _.reason, _.reasonDetail));
         this.exceptionMessages = result.exceptionMessages;
         this.exceptionStackTrace = result.exceptionStackTrace;
         this.paging = new PagingInfo();

--- a/Source/JavaScript/Arc/queries/for_QueryResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResult/when_constructing_from_a_server_result_with_a_constraint_violation.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationResultReason } from '../../validation/ValidationResultReason';
+import { ValidationResultSeverity } from '../../validation/ValidationResultSeverity';
+import { QueryResult } from '../QueryResult';
+
+describe('when constructing from a server result with a constraint violation', () => {
+    const result = new QueryResult({
+        data: {},
+        isSuccess: false,
+        isAuthorized: true,
+        isValid: false,
+        hasExceptions: false,
+        validationResults: [
+            {
+                severity: ValidationResultSeverity.Error,
+                message: 'The organization number is already in use',
+                members: ['organizationNumber'],
+                state: {},
+                reason: ValidationResultReason.ConstraintViolation,
+                reasonDetail: 'UniqueOrganizationNumber'
+            }
+        ],
+        exceptionMessages: [],
+        exceptionStackTrace: '',
+        paging: { page: 0, size: 0, totalItems: 0, totalPages: 0 }
+    }, Object, false);
+
+    it('should carry what kind of thing rejected the query', () =>
+        result.validationResults[0].reason.should.equal(ValidationResultReason.ConstraintViolation));
+
+    it('should carry the name of the violated constraint', () =>
+        result.validationResults[0].reasonDetail!.should.equal('UniqueOrganizationNumber'));
+});

--- a/Source/JavaScript/Arc/queries/for_QueryResult/when_creating_a_validation_failed_result.ts
+++ b/Source/JavaScript/Arc/queries/for_QueryResult/when_creating_a_validation_failed_result.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { ValidationResult } from '../../validation/ValidationResult';
+import { ValidationResultReason } from '../../validation/ValidationResultReason';
+import { ValidationResultSeverity } from '../../validation/ValidationResultSeverity';
+import { QueryResult } from '../QueryResult';
+
+// The query side is meant to read the same way the command side does, which only holds if it carries
+// the same fields through - so this is the mirror of the CommandResult spec of the same name.
+describe('when creating a validation failed result', () => {
+    const result = QueryResult.validationFailed([
+        new ValidationResult(
+            ValidationResultSeverity.Error,
+            'The organization number is already in use',
+            ['organizationNumber'],
+            {},
+            ValidationResultReason.ConstraintViolation,
+            'UniqueOrganizationNumber')
+    ], { defaultValue: {}, modelType: Object, enumerable: false });
+
+    it('should keep the reason the caller gave it', () =>
+        result.validationResults[0].reason.should.equal(ValidationResultReason.ConstraintViolation));
+
+    it('should keep the name of the violated constraint', () =>
+        result.validationResults[0].reasonDetail!.should.equal('UniqueOrganizationNumber'));
+});

--- a/Source/JavaScript/Arc/validation/ValidationResult.ts
+++ b/Source/JavaScript/Arc/validation/ValidationResult.ts
@@ -17,12 +17,16 @@ export class ValidationResult {
      * @param members The members the result is attributed to.
      * @param state State associated with the result - the rule author's, carried straight through.
      * @param reason What composed the result. Defaults to `rule`, meaning an authored rule rejected the input.
+     * @param reasonDetail Which specific thing within {@link reason} produced the result - the name of the violated
+     * constraint for `constraintViolation`, for instance. Undefined when the reason carries no finer identity.
+     * Branch on this rather than matching {@link message}, which is prose and free to change.
      */
     constructor(
         readonly severity: ValidationResultSeverity,
         readonly message: string,
         readonly members: string[],
         readonly state: any,
-        readonly reason: ValidationResultReason = ValidationResultReason.Rule) {
+        readonly reason: ValidationResultReason = ValidationResultReason.Rule,
+        readonly reasonDetail?: string) {
     }
 }


### PR DESCRIPTION
## Added

- The name of the violated constraint on a validation result, so a client can tell one constraint rejection from another without matching on the message text (#2487)
- `ShouldHaveConstraintViolationFor` for asserting a command result names a given constraint, matching the assertion already available against a raw append (#2487)

## Fixed

- A client-composed validation failure no longer loses its reason, which had reported every such result as an authored rule (#2487)
